### PR TITLE
Add imagery for islands between Korea and Japan, claimed by both

### DIFF
--- a/imagery.geojson
+++ b/imagery.geojson
@@ -52373,6 +52373,41 @@
                 "coordinates": [
                     [
                         [
+                            131.8896884, 
+                            37.3233324
+                        ], 
+                        [
+                            131.8019383, 
+                            37.3048378
+                        ], 
+                        [
+                            131.857606, 
+                            37.135737
+                        ], 
+                        [
+                            131.9462171, 
+                            37.1554941
+                        ], 
+                        [
+                            131.8896884, 
+                            37.3233324
+                        ]
+                    ]
+                ]
+            }, 
+            "type": "Feature", 
+            "properties": {
+                "url": "http://pnorman.dev.openstreetmap.org/imagery/orb32536/{zoom}/{x}/{y}.png", 
+                "type": "tms", 
+                "name": "Orbview 32536 (Disputed Asian Islands)"
+            }
+        }, 
+        {
+            "geometry": {
+                "type": "Polygon", 
+                "coordinates": [
+                    [
+                        [
                             -88.08494, 
                             30.14173
                         ], 

--- a/imagery.json
+++ b/imagery.json
@@ -51828,6 +51828,39 @@
     }
 }
 {
+    "url": "http://pnorman.dev.openstreetmap.org/imagery/orb32536/{zoom}/{x}/{y}.png", 
+    "type": "tms", 
+    "name": "Orbview 32536 (Disputed Asian Islands)", 
+    "extent": {
+        "bbox": {
+            "min_lon": "131.8019383", 
+            "max_lon": "131.9462171", 
+            "min_lat": "37.1357370", 
+            "max_lat": "37.3233324"
+        }, 
+        "polygon": [
+            [
+                [
+                    131.8896884, 
+                    37.3233324
+                ], 
+                [
+                    131.8019383, 
+                    37.3048378
+                ], 
+                [
+                    131.857606, 
+                    37.135737
+                ], 
+                [
+                    131.9462171, 
+                    37.1554941
+                ]
+            ]
+        ]
+    }
+}
+{
     "url": "http://tiger-osm.mapquest.com/tiles/1.0.0/tiger/{zoom}/{x}/{y}.png", 
     "type": "tms", 
     "name": "OSM - Tiger Edited Map", 

--- a/imagery.xml
+++ b/imagery.xml
@@ -5817,6 +5817,20 @@
         <attribution-text>AGRI</attribution-text>
     </entry>
 
+    <!-- only for Asia -->
+
+    <entry>
+        <name>Orbview 32536 (Disputed Asian Islands)</name>
+        <type>tms</type>
+        <url>http://pnorman.dev.openstreetmap.org/imagery/orb32536/{zoom}/{x}/{y}.png</url>
+        <bounds min-lat='37.1357370' min-lon='131.8019383' max-lat='37.3233324' max-lon='131.9462171'>
+            <shape>
+                <point lat='37.3233324' lon='131.8896884'/><point lat='37.3048378' lon='131.8019383'/><point lat='37.1357370' lon='131.8576060'/>
+                <point lat='37.1554941' lon='131.9462171'/>
+            </shape>
+        </bounds>
+    </entry>
+
     <!-- copied from Potlatch2 -->
 
     <entry>


### PR DESCRIPTION
The ownership of the islands in question is disputed so I have not added a country code.

The imagery is 1m/px panchromatic orbview-3 imagery from the USGS (public domain)

It has been lanczos resampled to z17 web mercator (95.1 cm/px) and histogram streched and contrast adjusted. It is hosted on errol.

See pnorman/mapproxy-config@5a0b193c83f0245115ce93ae0c9b9df2896d08b8 .. pnorman/mapproxy-config@2151a591058aed6ab8a2e76a69a6487815d3ae74
