### PR TITLE
Anchor date regexes

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -35,12 +35,12 @@
         "start_date": {
             "description": "The age of the oldest imagery or data in the source, as an RFC3339 date or leading portion of one",
             "type": "string",
-            "pattern": "\\d\\d\\d\\d(-\\d\\d(-\\d\\d)?)?"
+            "pattern": "^\\d\\d\\d\\d(-\\d\\d(-\\d\\d)?)?$"
         },
         "end_date": {
             "description": "The age of the newest imagery or data in the source, as an RFC3339 date or leading portion of one",
             "type": "string",
-            "pattern": "\\d\\d\\d\\d(-\\d\\d(-\\d\\d)?)?"
+            "pattern": "^\\d\\d\\d\\d(-\\d\\d(-\\d\\d)?)?$"
         },
         "overlay": {
             "description": "'true' if tiles are transparent and can be overlaid on another source",

--- a/sources/north-america/landsat_bc_047026.json
+++ b/sources/north-america/landsat_bc_047026.json
@@ -6,8 +6,8 @@
     "id": "landsat_047026",
     "default": false,
     "description": "Recent lower-resolution landwsat imagery for southwest British Columbia",
-    "start_date": "2013-9-12",
-    "end_date": "2013-9-12",
+    "start_date": "2013-09-12",
+    "end_date": "2013-09-12",
     "overlay": false,
     "extent": {
         "min_zoom": 5, 


### PR DESCRIPTION
json schema regular expressions are not implicitly anchored, so we need to
anchor them explicitly or foo1234bar is considered valid.
