### PR TITLE
Fix attribution in MQ layer.

### DIFF
--- a/sources/world/MapQuestOSM.json
+++ b/sources/world/MapQuestOSM.json
@@ -1,7 +1,6 @@
 {
     "attribution": {
-        "url": "http://openstreetmap.org/", 
-        "text": "\u00a9 OpenStreetMap contributors, CC-BY-SA", 
+        "html": "Tiles Courtesy of <a href=\"http://www.mapquest.com/\" target=\"_blank\">MapQuest</a> <img src=\"http://developer.mapquest.com/content/osm/mq_logo.png\">, Map data \u00a9 <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap contributors</a>", 
         "required": true
     }, 
     "name": "MapQuest OSM", 


### PR DESCRIPTION
Changed attribution text to what is requested in the [MapQuest Open Terms of Use](http://developer.mapquest.com/web/products/open/map#aui-3-2-0PR1-1111).
