### PR TITLE
Add public domain imagery for San Juan County WA

### DIFF
--- a/imagery.geojson
+++ b/imagery.geojson
@@ -86995,6 +86995,69 @@
             }, 
             "type": "Feature", 
             "properties": {
+                "url": "http://sjcgis.org/arcgis/rest/services/Basemaps/Aerials_2013_WM/MapServer/tile/{zoom}/{y}/{x}", 
+                "type": "tms", 
+                "name": "2013 aerial imagery for San Juan County WA"
+            }
+        }, 
+        {
+            "geometry": {
+                "type": "Polygon", 
+                "coordinates": [
+                    [
+                        [
+                            -123.274024, 
+                            48.692975
+                        ], 
+                        [
+                            -123.007726, 
+                            48.767256
+                        ], 
+                        [
+                            -123.007619, 
+                            48.831577
+                        ], 
+                        [
+                            -122.783495, 
+                            48.758416
+                        ], 
+                        [
+                            -122.693402, 
+                            48.658522
+                        ], 
+                        [
+                            -122.767451, 
+                            48.603606
+                        ], 
+                        [
+                            -122.744842, 
+                            48.387083
+                        ], 
+                        [
+                            -123.248221, 
+                            48.283531
+                        ], 
+                        [
+                            -123.114524, 
+                            48.422614
+                        ], 
+                        [
+                            -123.219035, 
+                            48.548575
+                        ], 
+                        [
+                            -123.274024, 
+                            48.692975
+                        ], 
+                        [
+                            -123.274024, 
+                            48.692975
+                        ]
+                    ]
+                ]
+            }, 
+            "type": "Feature", 
+            "properties": {
                 "url": "http://sjcgis.org/arcgis/rest/services/Basemaps/General_Basemap_WM/MapServer/tile/{zoom}/{y}/{x}", 
                 "type": "tms", 
                 "name": "Vector Streetmap for San Juan County WA"

--- a/imagery.json
+++ b/imagery.json
@@ -86245,6 +86245,75 @@
                 ]
             ]
         }, 
+        "description": "Public domain aerial imagery taken in May/June 2013 from San Juan County, WA. Resolution is 9 inch.", 
+        "end_date": "2013-06", 
+        "overlay": false, 
+        "url": "http://sjcgis.org/arcgis/rest/services/Basemaps/Aerials_2013_WM/MapServer/tile/{zoom}/{y}/{x}", 
+        "country_code": "US", 
+        "type": "tms", 
+        "start_date": "2013-05", 
+        "best": true, 
+        "name": "2013 aerial imagery for San Juan County WA"
+    }, 
+    {
+        "extent": {
+            "min_zoom": 0, 
+            "max_zoom": 19, 
+            "bbox": {
+                "min_lon": -124.0554571, 
+                "max_lat": 49.6102497, 
+                "min_lat": 47.2732239, 
+                "max_lon": -121.7184313
+            }, 
+            "polygon": [
+                [
+                    [
+                        -123.274024, 
+                        48.692975
+                    ], 
+                    [
+                        -123.007726, 
+                        48.767256
+                    ], 
+                    [
+                        -123.007619, 
+                        48.831577
+                    ], 
+                    [
+                        -122.783495, 
+                        48.758416
+                    ], 
+                    [
+                        -122.693402, 
+                        48.658522
+                    ], 
+                    [
+                        -122.767451, 
+                        48.603606
+                    ], 
+                    [
+                        -122.744842, 
+                        48.387083
+                    ], 
+                    [
+                        -123.248221, 
+                        48.283531
+                    ], 
+                    [
+                        -123.114524, 
+                        48.422614
+                    ], 
+                    [
+                        -123.219035, 
+                        48.548575
+                    ], 
+                    [
+                        -123.274024, 
+                        48.692975
+                    ]
+                ]
+            ]
+        }, 
         "description": "Public domain street and address data from the San Juan County, WA. Updated at least quarterly.", 
         "overlay": false, 
         "url": "http://sjcgis.org/arcgis/rest/services/Basemaps/General_Basemap_WM/MapServer/tile/{zoom}/{y}/{x}", 

--- a/imagery.xml
+++ b/imagery.xml
@@ -23555,6 +23555,29 @@
     </bounds>
   </entry>
   <entry>
+    <name>2013 aerial imagery for San Juan County WA</name>
+    <type>tms</type>
+    <url>http://sjcgis.org/arcgis/rest/services/Basemaps/Aerials_2013_WM/MapServer/tile/{zoom}/{y}/{x}</url>
+    <country-code>US</country-code>
+    <min-zoom>0</min-zoom>
+    <max-zoom>19</max-zoom>
+    <bounds max-lat="49.61025" max-lon="-121.718431" min-lat="47.273224" min-lon="-124.055457">
+      <shape>
+        <point lat="48.692975" lon="-123.274024" />
+        <point lat="48.767256" lon="-123.007726" />
+        <point lat="48.831577" lon="-123.007619" />
+        <point lat="48.758416" lon="-122.783495" />
+        <point lat="48.658522" lon="-122.693402" />
+        <point lat="48.603606" lon="-122.767451" />
+        <point lat="48.387083" lon="-122.744842" />
+        <point lat="48.283531" lon="-123.248221" />
+        <point lat="48.422614" lon="-123.114524" />
+        <point lat="48.548575" lon="-123.219035" />
+        <point lat="48.692975" lon="-123.274024" />
+      </shape>
+    </bounds>
+  </entry>
+  <entry>
     <name>Vector Streetmap for San Juan County WA</name>
     <type>tms</type>
     <url>http://sjcgis.org/arcgis/rest/services/Basemaps/General_Basemap_WM/MapServer/tile/{zoom}/{y}/{x}</url>

--- a/sources/north-america/us/wa/SanJuanCountyWA2013Imagery.json
+++ b/sources/north-america/us/wa/SanJuanCountyWA2013Imagery.json
@@ -1,0 +1,67 @@
+{
+    "url": "http://sjcgis.org/arcgis/rest/services/Basemaps/Aerials_2013_WM/MapServer/tile/{zoom}/{y}/{x}",
+    "type": "tms",
+    "name": "2013 aerial imagery for San Juan County WA",
+    "overlay": false,
+    "description": "Public domain aerial imagery taken in May/June 2013 from San Juan County, WA.",
+    "country_code": "US",
+    "best": true,
+    "extent": {
+        "min_zoom": 0,
+        "max_zoom": 19,
+        "bbox": {
+            "min_lon": -124.0554571,
+            "max_lon": -121.7184313,
+            "min_lat": 47.2732239,
+            "max_lat": 49.6102497
+        },
+        "polygon": [
+            [
+                [
+                        -123.274024,
+                    48.692975
+                ],
+                [
+                        -123.007726,
+                    48.767256
+                ],
+                [
+                        -123.007619,
+                    48.831577
+                ],
+                [
+                        -122.783495,
+                    48.758416
+                ],
+                [
+                        -122.693402,
+                    48.658522
+                ],
+                [
+                        -122.767451,
+                    48.603606
+                ],
+                [
+                        -122.744842,
+                    48.387083
+                ],
+                [
+                        -123.248221,
+                    48.283531
+                ],
+                [
+                        -123.114524,
+                    48.422614
+                ],
+                [
+                        -123.219035,
+                    48.548575
+                ],
+                [
+                        -123.274024,
+                    48.692975
+                ]
+            ]
+        ]
+    }
+}

--- a/sources/north-america/us/wa/SanJuanCountyWA2013Imagery.json
+++ b/sources/north-america/us/wa/SanJuanCountyWA2013Imagery.json
@@ -3,7 +3,7 @@
     "type": "tms",
     "name": "2013 aerial imagery for San Juan County WA",
     "overlay": false,
-    "description": "Public domain aerial imagery taken in May/June 2013 from San Juan County, WA.",
+    "description": "Public domain aerial imagery taken in May/June 2013 from San Juan County, WA. Resolution is 9 inch.",
     "country_code": "US",
     "best": true,
     "start_date": "2013-05",

--- a/sources/north-america/us/wa/SanJuanCountyWA2013Imagery.json
+++ b/sources/north-america/us/wa/SanJuanCountyWA2013Imagery.json
@@ -6,6 +6,8 @@
     "description": "Public domain aerial imagery taken in May/June 2013 from San Juan County, WA.",
     "country_code": "US",
     "best": true,
+    "start_date": "2013-05",
+    "end_date": "2013-06",
     "extent": {
         "min_zoom": 0,
         "max_zoom": 19,


### PR DESCRIPTION
Aerial imagery was flown in May/June 2013 and released to public
domain. Please note the service is from an Esri ArcGIS Server which
flips the x and y order in the URL. ¯\_(ツ)_/¯