### PR TITLE
Selected PNOA as the best imagery for Spain

### DIFF
--- a/sources/europe/es/PNOASpain.json
+++ b/sources/europe/es/PNOASpain.json
@@ -7,6 +7,7 @@
     "type": "wms",
     "name": "PNOA Spain",
     "country_code": "ES",
+    "best": true,
     "extent": {
         "bbox": {
             "min_lon": -18.1661033,


### PR DESCRIPTION
Hi!

I just selected PNOA (that stands for National Aerial Ortophotography Plan) as the best imagery source in Spain. It has updated images and they are correctly aligned with the terrain in order to prevent displaced mapping.

Example showing the displacement of Bing imagery in mountain territory: http://imgur.com/a/uunhD

Kind regards,
Alejandro
