### PR TITLE
Select Geodatastyrelsen as best for Denmark

### DIFF
--- a/sources/europe/dk/Geodatastyrelsen-Denmark.json
+++ b/sources/europe/dk/Geodatastyrelsen-Denmark.json
@@ -8,6 +8,7 @@
     "type": "tms",
     "name": "Geodatastyrelsen (Denmark)",
     "country_code": "DK",
++    "best": true,
     "extent": {
         "max_zoom": 21,
         "bbox": {

--- a/sources/europe/dk/Geodatastyrelsen-Denmark.json
+++ b/sources/europe/dk/Geodatastyrelsen-Denmark.json
@@ -8,7 +8,7 @@
     "type": "tms",
     "name": "Geodatastyrelsen (Denmark)",
     "country_code": "DK",
-+    "best": true,
+    "best": true,
     "extent": {
         "max_zoom": 21,
         "bbox": {


### PR DESCRIPTION
I spend a lot of time checking edits in Denmark and have many times suggested to new or foreign (to Denmark) mappers that they use Geodatastyrelsen imagery (currently from spring 2015 and from now on updated every year) instead of older Bing imagery. Would be very nice if Geodatastyrelsen was default imagery for Denmark.