### PR TITLE
Display GPS trace direction graphically

### DIFF
--- a/sources/world/OpenStreetMap-GPS.json
+++ b/sources/world/OpenStreetMap-GPS.json
@@ -10,7 +10,7 @@
     "attribution": {
         "url": "http://www.openstreetmap.org/copyright",
         "text": "© OpenStreetMap contributors",
-        "html": "© <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>. North: <span style='display: inline-block; width: 10px; height: 10px; background-color: #7fed11;'></span> South: <span style='display: inline-block; width: 10px; height: 10px; background-color: #7f11ed;'></span> East: <span style='display: inline-block; width: 10px; height: 10px; background-color: #ff3f3f;'></span> West: <span style='display: inline-block; width: 10px; height: 10px; background-color: #00bfbf;'></span>",
+        "html": "<span style='color: #eee'>GPS Direction:</span> <span style='font-size: 16px; padding: 0 0 2px 2px; font-weight: bold; background-color: rgba(0,0,0,0.5);'> <span style='color: #0f0;'>&uarr;</span> <span style='color: #f63;'>&rarr;</span> <span style='color: #c0f;'>&darr;</span> <span style='color: #0ff;'>&larr;</span> </span> © <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>.",
         "required": true
     },
     "overlay": true

--- a/sources/world/OpenStreetMap-GPS.json
+++ b/sources/world/OpenStreetMap-GPS.json
@@ -10,7 +10,7 @@
     "attribution": {
         "url": "http://www.openstreetmap.org/copyright",
         "text": "© OpenStreetMap contributors",
-        "html": "<span style='color: #eee'>GPS Direction:</span> <span style='font-size: 16px; padding: 0 0 2px 2px; font-weight: bold; background-color: rgba(0,0,0,0.5);'> <span style='color: #0f0;'>&uarr;</span> <span style='color: #f63;'>&rarr;</span> <span style='color: #c0f;'>&darr;</span> <span style='color: #0ff;'>&larr;</span> </span> © <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>.",
+        "html": "<span style='display: inline-block; padding: 0 8px; background-color: rgba(0,0,0,0.5);'><span style='color: #eee;'>GPS Direction:</span> <span style='font-size: 15px; padding-left: 2px; font-weight: bold;'> <span style='color: #0ee;'>&larr;</span> <span style='color: #96f;'>&darr;</span> <span style='color: #6e0;'>&uarr;</span> <span style='color: #f63;'>&rarr;</span> </span></span> © <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>.",
         "required": true
     },
     "overlay": true


### PR DESCRIPTION
I received a request today from an iD user to show the GPS direction graphically with arrows.. Here's what I made:

thoughts?
<img width="670" alt="screenshot 2016-07-18 11 35 06" src="https://cloud.githubusercontent.com/assets/38784/16920958/a542e2e6-4cdd-11e6-905a-d7b0f157fff4.png">


For comparison, here's what this legend looks like today:
<img width="659" alt="screenshot 2016-07-18 11 50 56" src="https://cloud.githubusercontent.com/assets/38784/16921039/eeb96d82-4cdd-11e6-967e-7c9289926bfa.png">

