### PR TITLE
add layer with vector data from IBGE to DF-Brazil

### DIFF
--- a/imagery.geojson
+++ b/imagery.geojson
@@ -10593,6 +10593,47 @@
         },
         {
             "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            7.492,
+                            47.4817
+                        ],
+                        [
+                            7.492,
+                            47.6342
+                        ],
+                        [
+                            7.784,
+                            47.6342
+                        ],
+                        [
+                            7.784,
+                            47.4817
+                        ],
+                        [
+                            7.492,
+                            47.4817
+                        ]
+                    ]
+                ]
+            },
+            "type": "Feature",
+            "properties": {
+                "url": "http://mapproxy.osm.ch:8080/tiles/KTBASELSTADT2015/EPSG900913/{z}/{x}/{y}.png?origin=nw",
+                "country-code": "CH",
+                "type": "tms",
+                "name": "Kanton Basel-Stadt 2015",
+                "attribution": {
+                    "url": null,
+                    "text": "Kanton Basel-Stadt OF 2015",
+                    "required": true
+                }
+            }
+        },
+        {
+            "geometry": {
                 "type": "MultiPolygon",
                 "coordinates": [
                     [
@@ -95266,6 +95307,48 @@
                 "type": "tms",
                 "name": "Vector Streetmap for San Juan County WA",
                 "best": true
+            }
+        },
+        {
+            "geometry": {
+                "type": "MultiPolygon",
+                "coordinates": [
+                    [
+                        [
+                            [
+                                -48.2444,
+                                -16.0508
+                            ],
+                            [
+                                -48.2444,
+                                -15.5005
+                            ],
+                            [
+                                -47.5695,
+                                -15.5005
+                            ],
+                            [
+                                -47.5695,
+                                -16.0508
+                            ],
+                            [
+                                -48.2444,
+                                -16.0508
+                            ],
+                            [
+                                -48.2444,
+                                -16.0508
+                            ]
+                        ]
+                    ]
+                ]
+            },
+            "type": "Feature",
+            "properties": {
+                "url": "https://api.mapbox.com/styles/v1/wille/cirnnxni1000jg8nfppc8g7pm/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1Ijoid2lsbGUiLCJhIjoicFNVWk5VWSJ9.hluCd0YGvYHNlFi_utWe2g",
+                "country-code": "BR",
+                "type": "tms",
+                "name": "IBGE Distrito Federal + Mapbox Satellite"
             }
         },
         {

--- a/imagery.geojson
+++ b/imagery.geojson
@@ -95348,7 +95348,7 @@
                 "url": "https://api.mapbox.com/styles/v1/wille/cirnnxni1000jg8nfppc8g7pm/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1Ijoid2lsbGUiLCJhIjoicFNVWk5VWSJ9.hluCd0YGvYHNlFi_utWe2g",
                 "country-code": "BR",
                 "type": "tms",
-                "name": "IBGE Distrito Federal + Mapbox Satellite"
+                "name": "IBGE Distrito Federal"
             }
         },
         {

--- a/imagery.json
+++ b/imagery.json
@@ -10172,6 +10172,27 @@
     },
     {
         "extent": {
+            "min_zoom": 8,
+            "max_zoom": 21,
+            "bbox": {
+                "min_lon": 7.492,
+                "max_lat": 47.6342,
+                "min_lat": 47.4817,
+                "max_lon": 7.784
+            }
+        },
+        "attribution": {
+            "text": "Kanton Basel-Stadt OF 2015",
+            "required": true
+        },
+        "name": "Kanton Basel-Stadt 2015",
+        "url": "http://mapproxy.osm.ch:8080/tiles/KTBASELSTADT2015/EPSG900913/{z}/{x}/{y}.png?origin=nw",
+        "country_code": "CH",
+        "type": "tms",
+        "best": false
+    },
+    {
+        "extent": {
             "min_zoom": 12,
             "max_zoom": 19,
             "bbox": {
@@ -93206,6 +93227,48 @@
         "type": "tms",
         "best": true,
         "name": "Vector Streetmap for San Juan County WA"
+    },
+    {
+        "extent": {
+            "min_zoom": 0,
+            "max_zoom": 19,
+            "bbox": {
+                "min_lon": -16.0508,
+                "max_lat": -47.5695,
+                "min_lat": -48.2444,
+                "max_lon": -15.5005
+            },
+            "polygon": [
+                [
+                    [
+                        -48.2444,
+                        -16.0508
+                    ],
+                    [
+                        -48.2444,
+                        -15.5005
+                    ],
+                    [
+                        -47.5695,
+                        -15.5005
+                    ],
+                    [
+                        -47.5695,
+                        -16.0508
+                    ],
+                    [
+                        -48.2444,
+                        -16.0508
+                    ]
+                ]
+            ]
+        },
+        "name": "IBGE Distrito Federal + Mapbox Satellite",
+        "url": "https://api.mapbox.com/styles/v1/wille/cirnnxni1000jg8nfppc8g7pm/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1Ijoid2lsbGUiLCJhIjoicFNVWk5VWSJ9.hluCd0YGvYHNlFi_utWe2g",
+        "license_url": "http://www.mapbox.com/about/maps/",
+        "country_code": "BR",
+        "type": "tms",
+        "description": "Addresses data from IBGE on top of Mapbox Satellite imagery"
     },
     {
         "name": "IBGE Mapa de Setores Rurais",

--- a/imagery.json
+++ b/imagery.json
@@ -93263,12 +93263,12 @@
                 ]
             ]
         },
-        "name": "IBGE Distrito Federal + Mapbox Satellite",
+        "name": "IBGE Distrito Federal",
+        "overlay": true,
         "url": "https://api.mapbox.com/styles/v1/wille/cirnnxni1000jg8nfppc8g7pm/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1Ijoid2lsbGUiLCJhIjoicFNVWk5VWSJ9.hluCd0YGvYHNlFi_utWe2g",
-        "license_url": "http://www.mapbox.com/about/maps/",
         "country_code": "BR",
         "type": "tms",
-        "description": "Addresses data from IBGE on top of Mapbox Satellite imagery"
+        "description": "Addresses data from IBGE"
     },
     {
         "name": "IBGE Mapa de Setores Rurais",

--- a/imagery.xml
+++ b/imagery.xml
@@ -2889,6 +2889,16 @@
     </bounds>
   </entry>
   <entry>
+    <name>Kanton Basel-Stadt 2015</name>
+    <type>tms</type>
+    <url>http://mapproxy.osm.ch:8080/tiles/KTBASELSTADT2015/EPSG900913/{z}/{x}/{y}.png?origin=nw</url>
+    <attribution-text mandatory="true">Kanton Basel-Stadt OF 2015</attribution-text>
+    <country-code>CH</country-code>
+    <min-zoom>8</min-zoom>
+    <max-zoom>21</max-zoom>
+    <bounds max-lat="47.6342" max-lon="7.784" min-lat="47.4817" min-lon="7.492" />
+  </entry>
+  <entry>
     <name>Kanton Solothurn 25cm (SOGIS 2014-2015)</name>
     <type>tms</type>
     <url>http://mapproxy.osm.ch:8080/tiles/sogis2014/EPSG900913/{z}/{x}/{y}.png?origin=nw</url>
@@ -25482,6 +25492,23 @@
         <point lat="48.422614" lon="-123.114524" />
         <point lat="48.548575" lon="-123.219035" />
         <point lat="48.692975" lon="-123.274024" />
+      </shape>
+    </bounds>
+  </entry>
+  <entry>
+    <name>IBGE Distrito Federal + Mapbox Satellite</name>
+    <type>tms</type>
+    <url>https://api.mapbox.com/styles/v1/wille/cirnnxni1000jg8nfppc8g7pm/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1Ijoid2lsbGUiLCJhIjoicFNVWk5VWSJ9.hluCd0YGvYHNlFi_utWe2g</url>
+    <country-code>BR</country-code>
+    <min-zoom>0</min-zoom>
+    <max-zoom>19</max-zoom>
+    <bounds max-lat="-47.5695" max-lon="-15.5005" min-lat="-48.2444" min-lon="-16.0508">
+      <shape>
+        <point lat="-16.0508" lon="-48.2444" />
+        <point lat="-15.5005" lon="-48.2444" />
+        <point lat="-15.5005" lon="-47.5695" />
+        <point lat="-16.0508" lon="-47.5695" />
+        <point lat="-16.0508" lon="-48.2444" />
       </shape>
     </bounds>
   </entry>

--- a/imagery.xml
+++ b/imagery.xml
@@ -25496,7 +25496,7 @@
     </bounds>
   </entry>
   <entry>
-    <name>IBGE Distrito Federal + Mapbox Satellite</name>
+    <name>IBGE Distrito Federal</name>
     <type>tms</type>
     <url>https://api.mapbox.com/styles/v1/wille/cirnnxni1000jg8nfppc8g7pm/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1Ijoid2lsbGUiLCJhIjoicFNVWk5VWSJ9.hluCd0YGvYHNlFi_utWe2g</url>
     <country-code>BR</country-code>

--- a/sources/south-america/br/IBGE_DF_Adresses.json
+++ b/sources/south-america/br/IBGE_DF_Adresses.json
@@ -1,10 +1,10 @@
 {
     "url": "https://api.mapbox.com/styles/v1/wille/cirnnxni1000jg8nfppc8g7pm/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1Ijoid2lsbGUiLCJhIjoicFNVWk5VWSJ9.hluCd0YGvYHNlFi_utWe2g",
-    "name": "IBGE Distrito Federal + Mapbox Satellite",
+    "name": "IBGE Distrito Federal",
     "type": "tms",
-    "description": "Addresses data from IBGE on top of Mapbox Satellite imagery",
+    "description": "Addresses data from IBGE",
     "country_code": "BR",
-    "license_url": "http://www.mapbox.com/about/maps/",
+    "overlay": true,
     "extent": {
         "min_zoom": 0,
         "max_zoom": 19,

--- a/sources/south-america/br/IBGE_DF_Mapbox_Satellite.json
+++ b/sources/south-america/br/IBGE_DF_Mapbox_Satellite.json
@@ -1,0 +1,42 @@
+{
+    "url": "https://api.mapbox.com/styles/v1/wille/cirnnxni1000jg8nfppc8g7pm/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1Ijoid2lsbGUiLCJhIjoicFNVWk5VWSJ9.hluCd0YGvYHNlFi_utWe2g",
+    "name": "IBGE Distrito Federal + Mapbox Satellite",
+    "type": "tms",
+    "description": "Addresses data from IBGE on top of Mapbox Satellite imagery",
+    "country_code": "BR",
+    "license_url": "http://www.mapbox.com/about/maps/",
+    "extent": {
+        "min_zoom": 0,
+        "max_zoom": 19,
+        "bbox": {
+            "min_lon": -16.0508,
+            "max_lon": -15.5005,
+            "min_lat": -48.2444,
+            "max_lat": -47.5695
+        },
+        "polygon": [
+          [
+            [
+              -48.2444,
+              -16.0508
+            ],
+            [
+              -48.2444,
+              -15.5005
+            ],
+            [
+              -47.5695,
+              -15.5005
+            ],
+            [
+              -47.5695,
+              -16.0508
+            ],
+            [
+              -48.2444,
+              -16.0508
+            ]
+          ]
+        ]
+    }
+}


### PR DESCRIPTION
I produced a layer using data from IBGE on top of Mapbox Satellite to help users to map addresses on Distrito Federal, Brazil. The data from IBGE is released in Public Domain. I published a blog post about it https://www.openstreetmap.org/user/wille/diary/39238 (Portuguese only, sorry).