### PR TITLE
update hike bike map

### DIFF
--- a/sources/world/HikeBike.geojson
+++ b/sources/world/HikeBike.geojson
@@ -1,10 +1,10 @@
 {
     "type": "Feature",
     "properties": {
-        "url": "http://toolserver.org/tiles/hikebike/{zoom}/{x}/{y}.png",
+        "url": "http://{switch:a,b,c}.tiles.wmflabs.org/hikebike/{zoom}/{x}/{y}.png",
         "attribution": {
-            "url": "http://openstreetmap.org/",
-            "text": "© OpenStreetMap contributors, CC-BY-SA",
+            "url": "https://www.openstreetmap.org/copyright",
+            "text": "© OpenStreetMap contributors",
             "required": true
         },
         "max_zoom": 18,


### PR DESCRIPTION
wmflabs url is newer. hikebikemap.org also uses this. see also https://wiki.openstreetmap.org/wiki/Hike_%26_Bike_Map

updated also attribution

synchronized with josm