### PR TITLE
Luxembourg imagery names now fit iD editor pane.

### DIFF
--- a/imagery.geojson
+++ b/imagery.geojson
@@ -80580,7 +80580,7 @@
                 "id": "lu.geoportail.opendata.basemap",
                 "license_url": "https://data.public.lu/en/datasets/carte-de-base-webservices-wms-et-wmts/",
                 "max_zoom": 20,
-                "name": "Luxembourg Geoportail Basemap",
+                "name": "Basemap geoportail.lu",
                 "start_date": "2013-07-19",
                 "type": "tms",
                 "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/basemap/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.png"
@@ -81510,7 +81510,7 @@
                 "id": "lu.geoportail.opendata.cadastre",
                 "license_url": "https://data.public.lu/en/datasets/plan-cadastral-numerise-pcn-webservices-wms-et-wmts/",
                 "max_zoom": 20,
-                "name": "Luxembourg Geoportail Cadastre",
+                "name": "Cadastre geoportail.lu",
                 "type": "tms",
                 "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/cadastre/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.png"
             },
@@ -82440,7 +82440,7 @@
                 "id": "lu.geoportail.opendata.ortho2010",
                 "license_url": "https://data.public.lu/en/datasets/bd-l-ortho-webservices-wms-et-wmts",
                 "max_zoom": 20,
-                "name": "Luxembourg Geoportail Ortho 2010",
+                "name": "Ortho 2010 geoportail.lu",
                 "start_date": "2010-06-24",
                 "type": "tms",
                 "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/ortho_2010/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.jpeg"
@@ -83371,7 +83371,7 @@
                 "id": "lu.geoportail.opendata.ortho2013",
                 "license_url": "https://data.public.lu/en/datasets/bd-l-ortho-webservices-wms-et-wmts",
                 "max_zoom": 20,
-                "name": "Luxembourg Geoportail Ortho 2013",
+                "name": "Ortho 2013 geoportail.lu",
                 "start_date": "2013-07-19",
                 "type": "tms",
                 "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/ortho_2013/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.jpeg"
@@ -84303,7 +84303,7 @@
                 "id": "lu.geoportail.opendata.ortho2016",
                 "license_url": "https://data.public.lu/en/datasets/bd-l-ortho-webservices-wms-et-wmts",
                 "max_zoom": 20,
-                "name": "Luxembourg Geoportail Ortho 2016",
+                "name": "Ortho 2016 geoportail.lu",
                 "start_date": "2013-08-30",
                 "type": "tms",
                 "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/ortho_2016/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.jpeg"
@@ -85234,7 +85234,7 @@
                 "id": "lu.geoportail.opendata.topo",
                 "license_url": "https://data.public.lu/en/datasets/cartes-topographiques-services-wms-et-wmts/",
                 "max_zoom": 20,
-                "name": "Luxembourg Geoportail Topographical Map",
+                "name": "Topographical Map geoportail.lu",
                 "start_date": "2013-07-19",
                 "type": "tms",
                 "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/topo/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.png"
@@ -112364,7 +112364,7 @@
                 "attribution": {
                     "required": true,
                     "text": "\u00a9 Michael Spreng, CC by-SA 3.0, map data OpenStreetMap contributors, ODbL 1.0",
-                    "url": "http://slopemap.waymarkedtrails.org/en/help/legal"
+                    "url": "http://slopes.waymarkedtrails.org/en/help/legal"
                 },
                 "icon": "http://static.waymarkedtrails.org/img/map_slopes.png",
                 "id": "Waymarked_Trails-Winter_Sports",
@@ -112372,7 +112372,7 @@
                 "name": "Waymarked Trails: Winter Sports",
                 "overlay": true,
                 "type": "tms",
-                "url": "http://tile.waymarkedtrails.org/slopemap/{zoom}/{x}/{y}.png"
+                "url": "http://tile.waymarkedtrails.org/slopes/{zoom}/{x}/{y}.png"
             },
             "type": "Feature"
         }

--- a/imagery.json
+++ b/imagery.json
@@ -79659,7 +79659,7 @@
         "icon": "https://www.geoportail.lu/static/img/lion.png",
         "id": "lu.geoportail.opendata.basemap",
         "license_url": "https://data.public.lu/en/datasets/carte-de-base-webservices-wms-et-wmts/",
-        "name": "Luxembourg Geoportail Basemap",
+        "name": "Basemap geoportail.lu",
         "start_date": "2013-07-19",
         "type": "tms",
         "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/basemap/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.png"
@@ -80585,7 +80585,7 @@
         "icon": "https://www.geoportail.lu/static/img/lion.png",
         "id": "lu.geoportail.opendata.cadastre",
         "license_url": "https://data.public.lu/en/datasets/plan-cadastral-numerise-pcn-webservices-wms-et-wmts/",
-        "name": "Luxembourg Geoportail Cadastre",
+        "name": "Cadastre geoportail.lu",
         "type": "tms",
         "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/cadastre/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.png"
     },
@@ -81511,7 +81511,7 @@
         "icon": "https://www.geoportail.lu/static/img/lion.png",
         "id": "lu.geoportail.opendata.ortho2010",
         "license_url": "https://data.public.lu/en/datasets/bd-l-ortho-webservices-wms-et-wmts",
-        "name": "Luxembourg Geoportail Ortho 2010",
+        "name": "Ortho 2010 geoportail.lu",
         "start_date": "2010-06-24",
         "type": "tms",
         "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/ortho_2010/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.jpeg"
@@ -82438,7 +82438,7 @@
         "icon": "https://www.geoportail.lu/static/img/lion.png",
         "id": "lu.geoportail.opendata.ortho2013",
         "license_url": "https://data.public.lu/en/datasets/bd-l-ortho-webservices-wms-et-wmts",
-        "name": "Luxembourg Geoportail Ortho 2013",
+        "name": "Ortho 2013 geoportail.lu",
         "start_date": "2013-07-19",
         "type": "tms",
         "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/ortho_2013/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.jpeg"
@@ -83366,7 +83366,7 @@
         "icon": "https://www.geoportail.lu/static/img/lion.png",
         "id": "lu.geoportail.opendata.ortho2016",
         "license_url": "https://data.public.lu/en/datasets/bd-l-ortho-webservices-wms-et-wmts",
-        "name": "Luxembourg Geoportail Ortho 2016",
+        "name": "Ortho 2016 geoportail.lu",
         "start_date": "2013-08-30",
         "type": "tms",
         "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/ortho_2016/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.jpeg"
@@ -84293,7 +84293,7 @@
         "icon": "https://www.geoportail.lu/static/img/lion.png",
         "id": "lu.geoportail.opendata.topo",
         "license_url": "https://data.public.lu/en/datasets/cartes-topographiques-services-wms-et-wmts/",
-        "name": "Luxembourg Geoportail Topographical Map",
+        "name": "Topographical Map geoportail.lu",
         "start_date": "2013-07-19",
         "type": "tms",
         "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/topo/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.png"
@@ -111073,7 +111073,7 @@
         "attribution": {
             "required": true,
             "text": "\u00a9 Michael Spreng, CC by-SA 3.0, map data OpenStreetMap contributors, ODbL 1.0",
-            "url": "http://slopemap.waymarkedtrails.org/en/help/legal"
+            "url": "http://slopes.waymarkedtrails.org/en/help/legal"
         },
         "extent": {
             "max_zoom": 17
@@ -111083,6 +111083,6 @@
         "name": "Waymarked Trails: Winter Sports",
         "overlay": true,
         "type": "tms",
-        "url": "http://tile.waymarkedtrails.org/slopemap/{zoom}/{x}/{y}.png"
+        "url": "http://tile.waymarkedtrails.org/slopes/{zoom}/{x}/{y}.png"
     }
 ]

--- a/imagery.xml
+++ b/imagery.xml
@@ -22191,7 +22191,7 @@
     </bounds>
   </entry>
   <entry>
-    <name>Luxembourg Geoportail Basemap</name>
+    <name>Basemap geoportail.lu</name>
     <id>lu.geoportail.opendata.basemap</id>
     <type>tms</type>
     <url>https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/basemap/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.png</url>
@@ -22432,7 +22432,7 @@
     </bounds>
   </entry>
   <entry>
-    <name>Luxembourg Geoportail Cadastre</name>
+    <name>Cadastre geoportail.lu</name>
     <id>lu.geoportail.opendata.cadastre</id>
     <type>tms</type>
     <url>https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/cadastre/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.png</url>
@@ -22673,7 +22673,7 @@
     </bounds>
   </entry>
   <entry>
-    <name>Luxembourg Geoportail Ortho 2010</name>
+    <name>Ortho 2010 geoportail.lu</name>
     <id>lu.geoportail.opendata.ortho2010</id>
     <type>tms</type>
     <url>https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/ortho_2010/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.jpeg</url>
@@ -22914,7 +22914,7 @@
     </bounds>
   </entry>
   <entry>
-    <name>Luxembourg Geoportail Ortho 2013</name>
+    <name>Ortho 2013 geoportail.lu</name>
     <id>lu.geoportail.opendata.ortho2013</id>
     <type>tms</type>
     <url>https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/ortho_2013/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.jpeg</url>
@@ -23155,7 +23155,7 @@
     </bounds>
   </entry>
   <entry>
-    <name>Luxembourg Geoportail Ortho 2016</name>
+    <name>Ortho 2016 geoportail.lu</name>
     <id>lu.geoportail.opendata.ortho2016</id>
     <type>tms</type>
     <url>https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/ortho_2016/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.jpeg</url>
@@ -23397,7 +23397,7 @@
     </bounds>
   </entry>
   <entry>
-    <name>Luxembourg Geoportail Topographical Map</name>
+    <name>Topographical Map geoportail.lu</name>
     <id>lu.geoportail.opendata.topo</id>
     <type>tms</type>
     <url>https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/topo/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.png</url>
@@ -31336,9 +31336,9 @@
     <name>Waymarked Trails: Winter Sports</name>
     <id>Waymarked_Trails-Winter_Sports</id>
     <type>tms</type>
-    <url>http://tile.waymarkedtrails.org/slopemap/{zoom}/{x}/{y}.png</url>
+    <url>http://tile.waymarkedtrails.org/slopes/{zoom}/{x}/{y}.png</url>
     <attribution-text mandatory="true">© Michael Spreng, CC by-SA 3.0, map data OpenStreetMap contributors, ODbL 1.0</attribution-text>
-    <attribution-url>http://slopemap.waymarkedtrails.org/en/help/legal</attribution-url>
+    <attribution-url>http://slopes.waymarkedtrails.org/en/help/legal</attribution-url>
     <icon>http://static.waymarkedtrails.org/img/map_slopes.png</icon>
     <max-zoom>17</max-zoom>
   </entry>

--- a/sources/europe/lu/Luxembourg-GeoportailBasemap.geojson
+++ b/sources/europe/lu/Luxembourg-GeoportailBasemap.geojson
@@ -6,7 +6,7 @@
             "text": "Administration du Cadastre et de la Topographie",
             "required": false
         },
-        "name": "Luxembourg Geoportail Basemap",
+        "name": "Basemap geoportail.lu",
         "end_date": "2010-07-20",
         "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/basemap/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.png",
         "max_zoom": 20,

--- a/sources/europe/lu/Luxembourg-GeoportailCadastre.geojson
+++ b/sources/europe/lu/Luxembourg-GeoportailCadastre.geojson
@@ -6,7 +6,7 @@
             "text": "Administration du Cadastre et de la Topographie",
             "required": false
         },
-        "name": "Luxembourg Geoportail Cadastre",
+        "name": "Cadastre geoportail.lu",
         "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/cadastre/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.png",
         "max_zoom": 20,
         "license_url": "https://data.public.lu/en/datasets/plan-cadastral-numerise-pcn-webservices-wms-et-wmts/",

--- a/sources/europe/lu/Luxembourg-GeoportailOrtho2010.geojson
+++ b/sources/europe/lu/Luxembourg-GeoportailOrtho2010.geojson
@@ -6,7 +6,7 @@
             "text": "Administration du Cadastre et de la Topographie",
             "required": false
         },
-        "name": "Luxembourg Geoportail Ortho 2010",
+        "name": "Ortho 2010 geoportail.lu",
         "end_date": "2010-07-02",
         "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/ortho_2010/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.jpeg",
         "max_zoom": 20,

--- a/sources/europe/lu/Luxembourg-GeoportailOrtho2013.geojson
+++ b/sources/europe/lu/Luxembourg-GeoportailOrtho2013.geojson
@@ -6,7 +6,7 @@
             "text": "Administration du Cadastre et de la Topographie",
             "required": false
         },
-        "name": "Luxembourg Geoportail Ortho 2013",
+        "name": "Ortho 2013 geoportail.lu",
         "end_date": "2013-07-20",
         "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/ortho_2013/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.jpeg",
         "max_zoom": 20,

--- a/sources/europe/lu/Luxembourg-GeoportailOrtho2016.geojson
+++ b/sources/europe/lu/Luxembourg-GeoportailOrtho2016.geojson
@@ -6,7 +6,7 @@
             "text": "Administration du Cadastre et de la Topographie",
             "required": false
         },
-        "name": "Luxembourg Geoportail Ortho 2016",
+        "name": "Ortho 2016 geoportail.lu",
         "end_date": "2016-08-16",
         "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/ortho_2016/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.jpeg",
         "max_zoom": 20,

--- a/sources/europe/lu/Luxembourg-GeoportailTopo.geojson
+++ b/sources/europe/lu/Luxembourg-GeoportailTopo.geojson
@@ -6,7 +6,7 @@
             "text": "Administration du Cadastre et de la Topographie",
             "required": false
         },
-        "name": "Luxembourg Geoportail Topographical Map",
+        "name": "Topographical Map geoportail.lu",
         "end_date": "2010-07-20",
         "url": "https://{switch:wmts3,wmts4}.geoportail.lu/opendata/wmts/topo/GLOBAL_WEBMERCATOR_4_V3/{zoom}/{x}/{y}.png",
         "max_zoom": 20,


### PR DESCRIPTION
Names shorter, and significant part now first.