### PR TITLE
change URL on osm-tools.org to current location

### DIFF
--- a/sources/asia/CambodiaLaosThailandVietnambilingual.geojson
+++ b/sources/asia/CambodiaLaosThailandVietnambilingual.geojson
@@ -2,13 +2,13 @@
     "type": "Feature",
     "properties": {
         "id": "osm-cambodia_laos_thailand_vietnam-bilingual",
-        "url": "http://{switch:a,b,c,d}.tile.osm-tools.org/osm_then/{zoom}/{x}/{y}.png",
+        "url": "http://{switch:a,b,c,d}.tile.osm-tools.org/osm/{zoom}/{x}/{y}.png",
         "attribution": {
             "url": "http://www.osm-tools.org/",
             "text": "© osm-tools.org & OpenStreetMap contributors, CC-BY-SA",
             "required": true
         },
-        "max_zoom": 19,
+        "max_zoom": 20,
         "type": "tms",
         "name": "Cambodia, Laos, Thailand, Vietnam, Myanmar bilingual"
     },


### PR DESCRIPTION
URL providing the bilingual map was changed. This updates the details to point to the current location. As zoom is provided up to 20 this is adjusted as well.

Fixes #369