### PR TITLE
Change "OS OpenData StreetView" to fetch via https

### DIFF
--- a/sources/europe/gb/OSOpenDataStreetView.geojson
+++ b/sources/europe/gb/OSOpenDataStreetView.geojson
@@ -3,7 +3,7 @@
     "properties": {
         "id": "OS-OpenData_StreetView",
         "name": "OS OpenData StreetView",
-        "url": "http://os.openstreetmap.org/sv/{zoom}/{x}/{y}.png",
+        "url": "https://os.openstreetmap.org/sv/{zoom}/{x}/{y}.png",
         "max_zoom": 18,
         "min_zoom": 1,
         "country_code": "GB",


### PR DESCRIPTION
Ref https://trac.openstreetmap.org/ticket/5484 .  

I've not tested the updated editor-imagery-index in an editor, but tiles such as https://os.openstreetmap.org/sv//15/16261/10666.png do as expected load over https.

There may of course be more changes in imagery definitions that have the same problem.


