### PR TITLE
Change AGRI (Australia) and Surrey Air Survey (UK) to also load over https

### DIFF
--- a/sources/australia/au/AGRIblack-and-white25m.geojson
+++ b/sources/australia/au/AGRIblack-and-white25m.geojson
@@ -2,7 +2,7 @@
     "type": "Feature",
     "properties": {
         "id": "AGRI-black_and_white-2.5m",
-        "url": "http://agri.openstreetmap.org/{zoom}/{x}/{y}.png",
+        "url": "https://agri.openstreetmap.org/{zoom}/{x}/{y}.png",
         "attribution": {
             "text": "AGRI",
             "required": false

--- a/sources/europe/gb/SurreyAirSurvey.geojson
+++ b/sources/europe/gb/SurreyAirSurvey.geojson
@@ -4,7 +4,7 @@
         "id": "Surrey-Air_Survey",
         "name": "Surrey Air Survey",
         "end_date": "2009",
-        "url": "http://gravitystorm.dev.openstreetmap.org/surrey/{zoom}/{x}/{y}.png",
+        "url": "https://gravitystorm.dev.openstreetmap.org/surrey/{zoom}/{x}/{y}.png",
         "max_zoom": 19,
         "min_zoom": 8,
         "country_code": "GB",


### PR DESCRIPTION
Both AGRI and SAS imagery also now redirect to https, and don't load into P2 on drag when defined as http.

As with https://github.com/osmlab/editor-layer-index/pull/380 , I've not tested the updated editor-imagery-index in an editor, but tiles from these layers do as expected load over https.  A number of other osm.org-hosted layers have not yet been changed to http because e.g. http://ooc.openstreetmap.org/npe/15/16303/10460.png does not yet redirect.  Also some layers don't seem to load at all (presumably they have been superceded).