### PR TITLE
Added type=wms_endpoint to schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -36,7 +36,8 @@
                         "tms",
                         "wms",
                         "bing",
-                        "scanex"
+                        "scanex",
+                        "wms_endpoint"
                     ]
                 },
                 "url": {


### PR DESCRIPTION
None of the editors that use ELI currently use the wms catalogs that are still quite rare. This will allow ELI contributors to create them, encouraging editors to support them.