### PR TITLE
Better checks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+jsonschema==2.6.0
+PyYAML==3.12

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -5,8 +5,8 @@ schema = json.load(io.open('schema.json', encoding='utf-8'))
 seen_ids = set()
 
 for file in sys.argv[1:]:
-    source = json.load(io.open(file, encoding='utf-8'))
     try:
+        source = json.load(io.open(file, encoding='utf-8'))
         validate(source, schema)
         id = source['properties']['id']
         if id in seen_ids:


### PR DESCRIPTION
I broke the json schema in a new source file, and make check crashed on json.load. This changes the check script very slightly to print the file name even when the json can't be loaded.

I also added a requirements file while I was at it.