### PR TITLE
Add two WMS overlays for Norway

### DIFF
--- a/sources/europe/no/Kartverket-friluft.geojson
+++ b/sources/europe/no/Kartverket-friluft.geojson
@@ -8,7 +8,7 @@
         "description": "Hiking trails from the Norwegian database `Tur- og Friluftsruter´, including DNT routes.", 
         "url": "https://wms.geonorge.no/skwms1/wms.friluftsruter2?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=Fotrute&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}", 
         "icon": "https://www.kartverket.no/Content/Images/logo-graphic-512.png", 
-        "min_zoom": 3, 
+        "min_zoom": 6, 
         "max_zoom": 24,
         "attribution": {
             "required": true, 

--- a/sources/europe/no/Kartverket-friluft.geojson
+++ b/sources/europe/no/Kartverket-friluft.geojson
@@ -1,0 +1,37 @@
+{
+    "type": "Feature",
+    "properties": {
+        "type": "wms", 
+        "name": "Kartverket Hiking Trails",
+        "id": "kartverket-friluft", 
+        "country_code": "NO", 
+        "description": "Hiking trails from the Norwegian database `Tur- og Friluftsruter´, including DNT routes.", 
+        "url": "https://wms.geonorge.no/skwms1/wms.friluftsruter2?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=Fotrute&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}", 
+        "icon": "https://www.kartverket.no/Content/Images/logo-graphic-512.png", 
+        "min_zoom": 3, 
+        "max_zoom": 24,
+        "attribution": {
+            "required": true, 
+            "text": "\u00a9 Kartverket", 
+            "url": "https://kartverket.no/geodataarbeid/temadata/nasjonal-database-for-tur--og-friluftsruter/"
+        },
+        "overlay": true,
+        "available_projections": [
+            "EPSG:3857",
+            "EPSG:4326",
+            "EPSG:900913"
+         ]
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+            [31.904253,70.4368136],[28.4765186,71.3289643],[23.6865015,71.2514263],[16.8090601,70.0730823], 
+            [11.1620655,67.5253903],[9.975542,64.811576],[4.2187061,62.1449966],[4.3725367,59.1871966], 
+            [6.1743055,57.8915032],[7.932118,57.7393554],[10.777577,58.8649103],[11.7224012,58.762509], 
+            [12.722157,60.1141506],[13.0517469,61.3493518],[12.5243921,63.6169922],[14.2382593,63.9856094], 
+            [15.1171656,65.9016624],[18.6987085,68.3749083],[20.0610132,68.2612583],[21.0058375,68.7841518], 
+            [25.2465601,68.3506025],[26.9384546,69.8472011],[28.7621851,69.6112133],[28.5864039,68.8556004], 
+            [31.069314,69.5191547],[31.904253,70.4368136]  
+        ]]
+    }      
+}

--- a/sources/europe/no/Kartverket-vegnett.geojson
+++ b/sources/europe/no/Kartverket-vegnett.geojson
@@ -1,0 +1,37 @@
+{
+    "type": "Feature",
+    "properties": {
+        "type": "wms", 
+        "name": "Kartverket Road Network",
+        "id": "kartverket-vegnett", 
+        "country_code": "NO", 
+        "description": "Norwegian road network from the National Road database (NVDB). Colours represent national, county, municipal, private and forest roads + footways/cycleways.", 
+        "url": "http://openwms.statkart.no/skwms1/wms.vegnett?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=all&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}", 
+        "icon": "https://www.kartverket.no/Content/Images/logo-graphic-512.png", 
+        "min_zoom": 3, 
+        "max_zoom": 24,
+        "attribution": {
+            "required": true, 
+            "text": "\u00a9 Kartverket", 
+            "url": "https://www.kartverket.no/data/kartdata/vegdata/"
+        },
+        "overlay": true,
+        "available_projections": [
+            "EPSG:3857",
+            "EPSG:4326",
+            "EPSG:900913"
+         ]
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+            [31.904253,70.4368136],[28.4765186,71.3289643],[23.6865015,71.2514263],[16.8090601,70.0730823], 
+            [11.1620655,67.5253903],[9.975542,64.811576],[4.2187061,62.1449966],[4.3725367,59.1871966], 
+            [6.1743055,57.8915032],[7.932118,57.7393554],[10.777577,58.8649103],[11.7224012,58.762509], 
+            [12.722157,60.1141506],[13.0517469,61.3493518],[12.5243921,63.6169922],[14.2382593,63.9856094], 
+            [15.1171656,65.9016624],[18.6987085,68.3749083],[20.0610132,68.2612583],[21.0058375,68.7841518], 
+            [25.2465601,68.3506025],[26.9384546,69.8472011],[28.7621851,69.6112133],[28.5864039,68.8556004], 
+            [31.069314,69.5191547],[31.904253,70.4368136]  
+        ]]
+    }      
+}


### PR DESCRIPTION
Thank you for implementing WMS in iD - great feature!

Here are two very useful WMS overlays for Norway:
1) Marked hiking trails
2) Road network

Both services are provided by the Norwegian Mapping Authority (Kartverket).

[Explicit permission and discussion on the Norwegian mailing list.](https://lists.nuug.no/pipermail/kart/2014-August/004831.html)

[Overview of Norwegian import sources.](https://wiki.openstreetmap.org/wiki/Norwegian_import_sources)