### PR TITLE
Fix `end_date` for Brussels imagery

### DIFF
--- a/sources/europe/be/BE_OrthoPhoto2016_Brussels_WMS.geojson
+++ b/sources/europe/be/BE_OrthoPhoto2016_Brussels_WMS.geojson
@@ -10,7 +10,7 @@
         "available_projections": ["CRS:84", "EPSG:31370", "EPSG:4326", "EPSG:3857"],
         "best": false,
         "start_date": "2016",
-        "end_date": "2017",
+        "end_date": "2016",
         "attribution": {
             "text": "Realized by means of Brussels UrbIS®© - Distribution & Copyright CIRB",
             "required": true

--- a/sources/europe/be/BE_OrthoPhoto2017_Brussels_WMS.geojson
+++ b/sources/europe/be/BE_OrthoPhoto2017_Brussels_WMS.geojson
@@ -9,7 +9,7 @@
         "type": "tms",
         "best": true,
         "start_date": "2017",
-        "end_date": "2018",
+        "end_date": "2017",
         "attribution": {
             "text": "Realized by means of Brussels UrbIS®© - Distribution & Copyright CIRB",
             "required": true


### PR DESCRIPTION
Those are yearly release of aeriel imagery. I think I wrote it wrong on initial commit and that's why it's still 2016 aerial imagery that is displayed in iD (for instance).
This PR should fix that (unless, I'm wrong).