### PR TITLE
Convert start_date and end_date back into JOSM XML

### DIFF
--- a/scripts/convert_xml.py
+++ b/scripts/convert_xml.py
@@ -52,6 +52,15 @@ def add_source(source):
         default = ET.SubElement(entry, "default")
         default.text = 'true'
 
+    if 'start_date' in props:
+        date = ET.SubElement(entry, "date")
+        if 'end_date' in props and props['start_date'] == props['end_date']:
+            date.text = props['start_date']
+        elif 'end_date' in props and props['start_date'] != props['end_date']:
+            date.text = ';'.join([props['start_date'], props['end_date']])
+        else:
+            date.text = ';'.join([props['start_date'], "-"])
+
     if 'icon' in props:
         icon = ET.SubElement(entry, "icon")
         icon.text = props['icon']


### PR DESCRIPTION
This PR converts `start_date` and `end_date` back into `<date></date>`.

There are four different cases:


| start_date    | end_date | date (generated) |
| ---| ---| --- |
| 2013         | 2013             |    2013 |
| 2013          | 2014          |   2013;2014 |
| 2013  |    _not present_    |   2013;- |
| _not present_  |    _not present_    |   _not present_   |

A prior PR (#461) handles the conversion from JOSM `<date></date>` to `start_date` and `end_date`.
Discussion: #462 and #286 