### PR TITLE
Ignore null values for attribution-* in convert_individual.py

### DIFF
--- a/scripts/convert_individual.py
+++ b/scripts/convert_individual.py
@@ -65,7 +65,14 @@ for imagery in imageries:
         attr_url = attr_url_node[0].childNodes[0].nodeValue
 
     if any((attr_text, attr_required, attr_url)):
-        properties['attribution'] = dict(text=attr_text, url=attr_url, required=attr_required)
+        attribution_dict = dict()
+        if attr_text:
+            attribution_dict['text'] = attr_text
+        if attr_url:
+            attribution_dict['url'] = attr_url
+        if attr_required:
+            attribution_dict['required'] = attr_required
+        properties['attribution'] = attribution_dict
 
     default = None
 


### PR DESCRIPTION
Previously if one key was found, all of them would be written into the dict (even if they were null). Now only the keys that aren't null are written into the dict. Closes #468