### PR TITLE
Added test layer opacity slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@ This is an <a href='https://github.com/osmlab/editor-layer-index'>open source pr
     improve.</a></p>
 
 <div id='map'></div>
+<input id="slide" type="range" min="0" max="1" step="0.01" value="1" onchange="updateOpacity(this.value)" oninput="updateOpacity(this.value)">
 <div id='table'>
     <div id='wrap'></div>
 </div>

--- a/site/site.js
+++ b/site/site.js
@@ -4,6 +4,14 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>'
 }).addTo(map);
 
+var testLayer;
+var testLayerOpacity = 1;
+
+function updateOpacity(value) {
+    testLayerOpacity = value;
+    testLayer.setOpacity(value);
+}
+
 d3.json("imagery.geojson", function(error, imagery) {
     imagery.features = imagery.features.sort(function(a,b) {
         // sort by country code, then alphabetically
@@ -39,7 +47,7 @@ d3.json("imagery.geojson", function(error, imagery) {
     })
     .addTo(map)
 
-    var testLayer = L.geoJson(/* dummy */).addTo(map)
+    testLayer = L.geoJson(/* dummy */).addTo(map)
 
     var divs = d3.select('#wrap')
         .selectAll('div')
@@ -93,6 +101,7 @@ d3.json("imagery.geojson", function(error, imagery) {
                 url = url.replace(/{switch:(.*?)}/, '{s}');
                 testLayer = L.tileLayer(url, {
                     subdomains: domains,
+                    opacity: testLayerOpacity,
                     attribution: d.properties.attribution ?
                         '&copy; ' + (d.properties.attribution.url ?
                             '<a href="'+d.properties.attribution.url+'">'+d.properties.attribution.text+'</a>' :
@@ -114,6 +123,7 @@ d3.json("imagery.geojson", function(error, imagery) {
                     format: format,
                     version: version,
                     transparent: transparent,
+                    opacity: testLayerOpacity,
                     uppercase: true,
                     attribution: d.properties.attribution ?
                         '&copy; ' + (d.properties.attribution.url ?

--- a/site/style.css
+++ b/site/style.css
@@ -61,3 +61,9 @@ span.type {
     margin-left:5px;
     font: normal 10px/20px 'Helvetica Neue', sans-serif;
 }
+
+#slide {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+}


### PR DESCRIPTION
So that it is easier to visually check alignments between the base OSM layer and the test overlay.

Example:
![image](https://user-images.githubusercontent.com/319826/39667229-68a2c35e-50b1-11e8-8050-7f0537d04f9d.png)
