### PR TITLE
new OSMIM layers from May 2018

### DIFF
--- a/sources/antarctica/osmim-imagicode-S2B_R005_S69_20180222T061749.geojson
+++ b/sources/antarctica/osmim-imagicode-S2B_R005_S69_20180222T061749.geojson
@@ -1,0 +1,27 @@
+{
+    "type": "Feature",
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "description": "Up-to-date late season image or an area poorly mapped in OSM at the moment - lots of sea ice, be careful with distinguishing sea ice from ice shelves and floating glacier tongues. (true color)",
+        "end_date": "2018-02-22",
+        "url": "http://imagico.de/map/osmim_tiles.php?layer=S2B_R005_S69_20180222T061749&z={zoom}&x={x}&y={-y}",
+        "license_url": "http://imagico.de/map/osmim_tiles.php",
+        "max_zoom": 13,
+        "start_date": "2018-02-22",
+        "country_code": "AQ",
+        "icon": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAADWElEQVQ4y13TS2gcdQDH8e/szGQ372Tz2irGpoS0KSapoqjRQ4knD0WweLRCCXiQXuJFMR6EYMVC0IsPyKVFsJpWbQ0KQmL14KPWirGmZjdmk+w7mX1kZ2d2dv7/mfFUsX5Pv8Pv+lH4X6/NvTPc239gOlXyp7ZzlaEg8EGYyVaZWY7dc+/CuTde+fu/f+XOeP3iLT2bTMxN9NVm1PZhbfKBGC/OXsDzHJr1EEf6ilSMLZFrxObHJk/OfvDqCQmgArz3TUJfXZm/3K53nZ4YPRw69czjXPrqR+LJHJ4rUFXA3qG33Va3cpknU2vxY1pz9yWzlPZVgL6xobNGXp7u6T9Geq/O+U+usHRtE6du0aJncSyXtnCOcqVC0ZTIhnM44itNhpFeVs5+kRxe//OP22VDar4ncRwHz85TKtY40H2D4n6KwNMRgUPIC9ES0mj2NNwK4rfE2qhWyBnT1YrUQkqA3hwmpIYw63law4JcaR/hR9GVAh2tOmEUHunpwKkJVm10VdOntbptP+VJiaIoKIDv7zPQbVDxJIPRPkRkh8CN0KFrjHdGiXW3kkuXSRYEakid0qQrDkrhEgQ+tZpNtVTmoQdNrGgB6XjUpEJzSxvCgnhOZ+RQFKtcZV8IpO8NhXxfIoWLY9tUS0XePxXHMNrY3BxkOx+lXVX54dc+VjdaiHabXPg6RcMSWFULT3poEGxJ0eit1Wq06w4FMURPl8NObo9MvgnTaOGF402M399DrDNEPJHnl99rZIoWvudvaeGwtux53sOPjffy9pn7CHdKnn5WJ/5XnudnrjF2tJ/F61mGBiIc7fe4mXT5ds0lu1tE8f1lbSDWu5DZyb98fMLVwp0dgINv5Bjpcfj50yloUsAo8Ob8T/iVBociLrtlC9+tCwgW1O8++7A09dxLbUvfrzzRpV7nSCyK0qRDOEwjlUYr7iH2DPx6hXevpLi5YXNjfRsCcQ4aiwrAlxuB/tHCx5fTyaUTg/1pJke6eHR0GF9AKZtnv1BlYSWFWYBEepdyuXwV5EmQ8l9Mn9929asXF+c21xMz5b1NreHewvNcHAc0qRGpQyqfFZZZnQc5C1LepfFOZ946P5xJbkybRmbKzm8f3C3b2GZlyzYLy9WqteD5jbs4/wOHuM2qT5aWEQAAAABJRU5ErkJggg==",
+        "type": "tms",
+        "id": "osmim-imagicode-S2B_R005_S69_20180222T061749",
+        "name": "imagico.de: Lützow-Holm Bay"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ 35.124, -70.3693 ], [ 35.1241, -69.2795 ], [ 36.3864, -68.4765 ], [ 42.2208, -68.4762 ], [ 42.2208, -70.3651 ], [ 35.124, -70.3693 ] ]
+        ]
+    }
+}

--- a/sources/asia/kz/osmim-imagicode-caspian_2018.geojson
+++ b/sources/asia/kz/osmim-imagicode-caspian_2018.geojson
@@ -1,0 +1,27 @@
+{
+    "type": "Feature",
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "description": "Coastal contruction and Kashagan oil field in Kazakhstan in May 2018 (true color)",
+        "end_date": "2018-05-16",
+        "url": "http://imagico.de/map/osmim_tiles.php?layer=caspian_2018&z={zoom}&x={x}&y={-y}",
+        "license_url": "http://imagico.de/map/osmim_tiles.php",
+        "max_zoom": 14,
+        "start_date": "2018-05-16",
+        "country_code": "KZ",
+        "icon": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAADWElEQVQ4y13TS2gcdQDH8e/szGQ372Tz2irGpoS0KSapoqjRQ4knD0WweLRCCXiQXuJFMR6EYMVC0IsPyKVFsJpWbQ0KQmL14KPWirGmZjdmk+w7mX1kZ2d2dv7/mfFUsX5Pv8Pv+lH4X6/NvTPc239gOlXyp7ZzlaEg8EGYyVaZWY7dc+/CuTde+fu/f+XOeP3iLT2bTMxN9NVm1PZhbfKBGC/OXsDzHJr1EEf6ilSMLZFrxObHJk/OfvDqCQmgArz3TUJfXZm/3K53nZ4YPRw69czjXPrqR+LJHJ4rUFXA3qG33Va3cpknU2vxY1pz9yWzlPZVgL6xobNGXp7u6T9Geq/O+U+usHRtE6du0aJncSyXtnCOcqVC0ZTIhnM44itNhpFeVs5+kRxe//OP22VDar4ncRwHz85TKtY40H2D4n6KwNMRgUPIC9ES0mj2NNwK4rfE2qhWyBnT1YrUQkqA3hwmpIYw63law4JcaR/hR9GVAh2tOmEUHunpwKkJVm10VdOntbptP+VJiaIoKIDv7zPQbVDxJIPRPkRkh8CN0KFrjHdGiXW3kkuXSRYEakid0qQrDkrhEgQ+tZpNtVTmoQdNrGgB6XjUpEJzSxvCgnhOZ+RQFKtcZV8IpO8NhXxfIoWLY9tUS0XePxXHMNrY3BxkOx+lXVX54dc+VjdaiHabXPg6RcMSWFULT3poEGxJ0eit1Wq06w4FMURPl8NObo9MvgnTaOGF402M399DrDNEPJHnl99rZIoWvudvaeGwtux53sOPjffy9pn7CHdKnn5WJ/5XnudnrjF2tJ/F61mGBiIc7fe4mXT5ds0lu1tE8f1lbSDWu5DZyb98fMLVwp0dgINv5Bjpcfj50yloUsAo8Ob8T/iVBociLrtlC9+tCwgW1O8++7A09dxLbUvfrzzRpV7nSCyK0qRDOEwjlUYr7iH2DPx6hXevpLi5YXNjfRsCcQ4aiwrAlxuB/tHCx5fTyaUTg/1pJke6eHR0GF9AKZtnv1BlYSWFWYBEepdyuXwV5EmQ8l9Mn9929asXF+c21xMz5b1NreHewvNcHAc0qRGpQyqfFZZZnQc5C1LepfFOZ946P5xJbkybRmbKzm8f3C3b2GZlyzYLy9WqteD5jbs4/wOHuM2qT5aWEQAAAABJRU5ErkJggg==",
+        "type": "tms",
+        "id": "osmim-imagicode-caspian_2018",
+        "name": "imagico.de: Northeast Caspian Sea 2018"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ 51.0243, 45.0729 ], [ 51.0243, 46.569 ], [ 52.4259, 46.5687 ], [ 53.6471, 46.3177 ], [ 53.6474, 45.0729 ], [ 51.0243, 45.0729 ] ]
+        ]
+    }
+}

--- a/sources/europe/de/osmim-imagicode-northsea_s2_2018.geojson
+++ b/sources/europe/de/osmim-imagicode-northsea_s2_2018.geojson
@@ -1,0 +1,27 @@
+{
+    "type": "Feature",
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "description": "Up-to-date low tide imagery of the coast for updating mapping of tidalflats and shoals (true color)",
+        "end_date": "2018-05-08",
+        "url": "http://imagico.de/map/osmim_tiles.php?layer=northsea_s2_2018&z={zoom}&x={x}&y={-y}",
+        "license_url": "http://imagico.de/map/osmim_tiles.php",
+        "max_zoom": 13,
+        "start_date": "2018-05-08",
+        "country_code": "DE",
+        "icon": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAADWElEQVQ4y13TS2gcdQDH8e/szGQ372Tz2irGpoS0KSapoqjRQ4knD0WweLRCCXiQXuJFMR6EYMVC0IsPyKVFsJpWbQ0KQmL14KPWirGmZjdmk+w7mX1kZ2d2dv7/mfFUsX5Pv8Pv+lH4X6/NvTPc239gOlXyp7ZzlaEg8EGYyVaZWY7dc+/CuTde+fu/f+XOeP3iLT2bTMxN9NVm1PZhbfKBGC/OXsDzHJr1EEf6ilSMLZFrxObHJk/OfvDqCQmgArz3TUJfXZm/3K53nZ4YPRw69czjXPrqR+LJHJ4rUFXA3qG33Va3cpknU2vxY1pz9yWzlPZVgL6xobNGXp7u6T9Geq/O+U+usHRtE6du0aJncSyXtnCOcqVC0ZTIhnM44itNhpFeVs5+kRxe//OP22VDar4ncRwHz85TKtY40H2D4n6KwNMRgUPIC9ES0mj2NNwK4rfE2qhWyBnT1YrUQkqA3hwmpIYw63law4JcaR/hR9GVAh2tOmEUHunpwKkJVm10VdOntbptP+VJiaIoKIDv7zPQbVDxJIPRPkRkh8CN0KFrjHdGiXW3kkuXSRYEakid0qQrDkrhEgQ+tZpNtVTmoQdNrGgB6XjUpEJzSxvCgnhOZ+RQFKtcZV8IpO8NhXxfIoWLY9tUS0XePxXHMNrY3BxkOx+lXVX54dc+VjdaiHabXPg6RcMSWFULT3poEGxJ0eit1Wq06w4FMURPl8NObo9MvgnTaOGF402M399DrDNEPJHnl99rZIoWvudvaeGwtux53sOPjffy9pn7CHdKnn5WJ/5XnudnrjF2tJ/F61mGBiIc7fe4mXT5ds0lu1tE8f1lbSDWu5DZyb98fMLVwp0dgINv5Bjpcfj50yloUsAo8Ob8T/iVBociLrtlC9+tCwgW1O8++7A09dxLbUvfrzzRpV7nSCyK0qRDOEwjlUYr7iH2DPx6hXevpLi5YXNjfRsCcQ4aiwrAlxuB/tHCx5fTyaUTg/1pJke6eHR0GF9AKZtnv1BlYSWFWYBEepdyuXwV5EmQ8l9Mn9929asXF+c21xMz5b1NreHewvNcHAc0qRGpQyqfFZZZnQc5C1LepfFOZ946P5xJbkybRmbKzm8f3C3b2GZlyzYLy9WqteD5jbs4/wOHuM2qT5aWEQAAAABJRU5ErkJggg==",
+        "type": "tms",
+        "id": "osmim-imagicode-northsea_s2_2018",
+        "name": "imagico.de: North Sea Coast spring 2018"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ 5.3179, 53.0918 ], [ 5.322, 53.4418 ], [ 6.7023, 56.3572 ], [ 9.8813, 56.3578 ], [ 9.8813, 53.2819 ], [ 9.7758, 53.0921 ], [ 5.3179, 53.0918 ] ]
+        ]
+    }
+}

--- a/sources/europe/ru/osmim-imagicode-S2A_R021_N44_20180429T082601.geojson
+++ b/sources/europe/ru/osmim-imagicode-S2A_R021_N44_20180429T082601.geojson
@@ -1,0 +1,27 @@
+{
+    "type": "Feature",
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "description": "Bridge and surrounding after completion in April 2018 (true color)",
+        "end_date": "2018-04-29",
+        "url": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R021_N44_20180429T082601&z={zoom}&x={x}&y={-y}",
+        "license_url": "http://imagico.de/map/osmim_tiles.php",
+        "max_zoom": 14,
+        "start_date": "2018-04-29",
+        "country_code": "RU",
+        "icon": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAADWElEQVQ4y13TS2gcdQDH8e/szGQ372Tz2irGpoS0KSapoqjRQ4knD0WweLRCCXiQXuJFMR6EYMVC0IsPyKVFsJpWbQ0KQmL14KPWirGmZjdmk+w7mX1kZ2d2dv7/mfFUsX5Pv8Pv+lH4X6/NvTPc239gOlXyp7ZzlaEg8EGYyVaZWY7dc+/CuTde+fu/f+XOeP3iLT2bTMxN9NVm1PZhbfKBGC/OXsDzHJr1EEf6ilSMLZFrxObHJk/OfvDqCQmgArz3TUJfXZm/3K53nZ4YPRw69czjXPrqR+LJHJ4rUFXA3qG33Va3cpknU2vxY1pz9yWzlPZVgL6xobNGXp7u6T9Geq/O+U+usHRtE6du0aJncSyXtnCOcqVC0ZTIhnM44itNhpFeVs5+kRxe//OP22VDar4ncRwHz85TKtY40H2D4n6KwNMRgUPIC9ES0mj2NNwK4rfE2qhWyBnT1YrUQkqA3hwmpIYw63law4JcaR/hR9GVAh2tOmEUHunpwKkJVm10VdOntbptP+VJiaIoKIDv7zPQbVDxJIPRPkRkh8CN0KFrjHdGiXW3kkuXSRYEakid0qQrDkrhEgQ+tZpNtVTmoQdNrGgB6XjUpEJzSxvCgnhOZ+RQFKtcZV8IpO8NhXxfIoWLY9tUS0XePxXHMNrY3BxkOx+lXVX54dc+VjdaiHabXPg6RcMSWFULT3poEGxJ0eit1Wq06w4FMURPl8NObo9MvgnTaOGF402M399DrDNEPJHnl99rZIoWvudvaeGwtux53sOPjffy9pn7CHdKnn5WJ/5XnudnrjF2tJ/F61mGBiIc7fe4mXT5ds0lu1tE8f1lbSDWu5DZyb98fMLVwp0dgINv5Bjpcfj50yloUsAo8Ob8T/iVBociLrtlC9+tCwgW1O8++7A09dxLbUvfrzzRpV7nSCyK0qRDOEwjlUYr7iH2DPx6hXevpLi5YXNjfRsCcQ4aiwrAlxuB/tHCx5fTyaUTg/1pJke6eHR0GF9AKZtnv1BlYSWFWYBEepdyuXwV5EmQ8l9Mn9929asXF+c21xMz5b1NreHewvNcHAc0qRGpQyqfFZZZnQc5C1LepfFOZ946P5xJbkybRmbKzm8f3C3b2GZlyzYLy9WqteD5jbs4/wOHuM2qT5aWEQAAAABJRU5ErkJggg==",
+        "type": "tms",
+        "id": "osmim-imagicode-S2A_R021_N44_20180429T082601",
+        "name": "imagico.de: Kerch Strait 2018"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ 35.8787, 45.0348 ], [ 35.8787, 45.6095 ], [ 36.9208, 45.6095 ], [ 36.9208, 45.0348 ], [ 35.8787, 45.0348 ] ]
+        ]
+    }
+}


### PR DESCRIPTION
New layers.

I also added a feature for self-description of the tile layers.  If you call

http://imagico.de/map/osmim_tiles.php?layer=

you get a list of layers available.  With

http://imagico.de/map/osmim_tiles.php?layer=northsea_s2_2018

you get an extended tilejson description of the layer and with 

http://imagico.de/map/osmim_tiles.php?layer=northsea_s2_2018&footprint

you get the layer footprint.

Pulling these in automatically is probably not a good idea since the main purpose of this repository is to provide a hand curated collection of layers but it might offer possibilities for more efficient updates in the future.  It might also make sense for other image layer providers to create similar descriptions.