### PR TITLE
Change tile server for berlin images

### DIFF
--- a/sources/europe/de/Berlinaerialphotograph2011.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2011.geojson
@@ -2,7 +2,7 @@
   "type": "Feature",
   "properties": {
     "id": "Berlin-2011",
-    "name": "Berlin aerial photograph 2011",
+    "name": "Berlin aerial photography 2011",
     "type": "wms",
     "url": "https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_luftbild2011_20?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=0&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
     "start_date": "2011",

--- a/sources/europe/de/Berlinaerialphotograph2014.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2014.geojson
@@ -2,9 +2,9 @@
   "type": "Feature",
   "properties": {
     "id": "Berlin-2014",
-    "name": "Berlin aerial photograph 2014",
-    "type": "wms",
-    "url": "https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_luftbild2014?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=0&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+    "name": "Berlin aerial photography 2014",
+    "type": "tms",
+    "url": "https://tiles.codefor.de/berlin-2014/{z}/{x}/{y}.png",
     "start_date": "2014",
     "end_date": "2014",
     "country_code": "DE",

--- a/sources/europe/de/Berlinaerialphotograph2015.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2015.geojson
@@ -2,9 +2,9 @@
   "type": "Feature",
   "properties": {
     "id": "Berlin-2015",
-    "name": "Berlin aerial photograph 2015",
-    "type": "wms",
-    "url": "https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_luftbild2015_rgb?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=0&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+    "name": "Berlin aerial photography 2015",
+    "type": "tms",
+    "url": "https://tiles.codefor.de/berlin-2015/{z}/{x}/{y}.png",
     "start_date": "2015",
     "end_date": "2015",
     "country_code": "DE",

--- a/sources/europe/de/Berlinaerialphotograph2016.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2016.geojson
@@ -2,9 +2,9 @@
   "type": "Feature",
   "properties": {
     "id": "Berlin-2016",
-    "name": "Berlin aerial photograph 2016",
-    "type": "wms",
-    "url": "https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_luftbild2016_rgb?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=0&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+    "name": "Berlin aerial photography 2016",
+    "type": "tms",
+    "url": "https://tiles.codefor.de/berlin-2016/{z}/{x}/{y}.png",
     "start_date": "2016",
     "end_date": "2016",
     "country_code": "DE",

--- a/sources/europe/de/Berlinaerialphotograph2017.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2017.geojson
@@ -2,9 +2,9 @@
   "type": "Feature",
   "properties": {
     "id": "Berlin-2017",
-    "name": "Berlin aerial photograph 2017",
-    "type": "wms",
-    "url": "https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_luftbild2017_rgb?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=0&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+    "name": "Berlin aerial photography 2017",
+    "type": "tms",
+    "url": "https://tiles.codefor.de/berlin-2017/{z}/{x}/{y}.png",
     "start_date": "2017",
     "end_date": "2017",
     "country_code": "DE",


### PR DESCRIPTION
This is a follow up to https://github.com/osmlab/editor-layer-index/issues/480.

It is awesome to have the Berlin aerial photography right in iD now.
However, the image server by the city seems to be a bit slow.

# Speed comparison

| City | OKFN |
|---|---|
| <img width="998" alt="bildschirmfoto 2018-06-28 um 19 21 06" src="https://user-images.githubusercontent.com/111561/42051307-060f96a6-7b0c-11e8-8d37-d7022677412c.png"> ~6s waiting, [URL](https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_luftbild2017_rgb?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=0&STYLES=&SRS=EPSG:4326&WIDTH=256&HEIGHT=256&BBOX=13.469238281250004,52.46793278868702,13.469581604003897,52.46814194225074)  |  <img width="998" alt="bildschirmfoto 2018-06-28 um 19 21 16" src="https://user-images.githubusercontent.com/111561/42051322-1333210e-7b0c-11e8-9854-22edfb380543.png"> ~37ms waiting, [URL](https://tiles.codefor.de/berlin-2017/18/140800/85992.png)  |

The OKFN source is based on https://tiles.codefor.de/ / https://codefor.de/projekte/2018-04-09-fis-broker.html

Note: The 2011 data are not available with tiles.codefor, so I left them be.

# Todos

- [ ] Can someone validate that this changes will work?
- [ ] I wonder if we need the ` "required": true` attribute for the `attribution` part, [other datasets have it](https://github.com/osmlab/editor-layer-index/search?l=JSON&q=required); what does it do?

