### PR TITLE
Fix Berlin aerial photograph infrared

### DIFF
--- a/sources/europe/de/Berlinaerialphotograph2016infrared.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2016infrared.geojson
@@ -1,15 +1,15 @@
 {
   "type": "Feature",
   "properties": {
-    "id": "Berlin-2017-infrared",
-    "name": "Berlin aerial photography 2017 (infrared)",
+    "id": "Berlin-2016-infrared",
+    "name": "Berlin aerial photography 2016 (infrared)",
     "type": "tms",
-    "url": "https://tiles.codefor.de/berlin-2017i/{zoom}/{x}/{y}.png",
-    "start_date": "2017",
-    "end_date": "2017",
+    "url": "https://tiles.codefor.de/berlin-2016i/{zoom}/{x}/{y}.png",
+    "start_date": "2016",
+    "end_date": "2016",
     "country_code": "DE",
     "attribution": {
-      "text": "Geoportal Berlin/Digitale Color-Infrarot-Orthophotos 2017"
+      "text": "Geoportal Berlin/Digitale Color-Infrarot-Orthophotos 2016"
     },
     "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=367583#p367583"
   },


### PR DESCRIPTION
Actually, there is no 2017 infrared, just 2016.
I don't know why I proposed 2017 :-/.

Example: https://tiles.codefor.de/berlin-2016i/14/8803/5373.png
Via https://tiles.codefor.de/

---

Btw, the exact date is 
> Bildflug am 02. und 03. April 2016.

Source http://fbinter.stadt-berlin.de/fb/gisbroker.do;jsessionid=3DF88B3ECC7D1F04EF020D1066C19D28?cmd=map_metaInfoShow&layerID=k_luftbild2016_cir@senstadt&type=shortInfo&isThemeLayer=true
Or http://fbinter.stadt-berlin.de/fb/?loginkey=showMap&mapId=k_luftbild2016_cir@senstadt => Info (i) => "Kurzinfo"