### PR TITLE
Revert Berlin aerial photograph 2015 back to wms

### DIFF
--- a/sources/europe/de/Berlinaerialphotograph2015.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2015.geojson
@@ -3,11 +3,17 @@
   "properties": {
     "id": "Berlin-2015",
     "name": "Berlin aerial photography 2015",
-    "type": "tms",
-    "url": "https://tiles.codefor.de/berlin-2015/{zoom}/{x}/{y}.png",
+    "type": "wms",
+    "url": "https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_luftbild2015_rgb?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=0&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
     "start_date": "2015",
     "end_date": "2015",
     "country_code": "DE",
+    "available_projections": [
+      "EPSG:25833",
+      "EPSG:4326",
+      "EPSG:3068",
+      "EPSG:4258"
+    ],
     "attribution": {
       "text": "Geoportal Berlin/Digitale farbige Orthophotos 2015"
     },


### PR DESCRIPTION
Revert the 2015 files back to WMS.

The 2015 map is not available at https://tiles.codefor.de/. I don't know why or why I proposed the change :-/.

The wms-URL uses the cities own server directly. In https://github.com/osmlab/editor-layer-index/pull/515 I proposed removing the cities server since it was to slow.

- Option 1 would be to remove the 2015 layer completely.
- Option 2 would be to use the city server and hope that since its just one layer, this server will to be too slow.

I think option 2 is fine for now; we can still delete it later.

About the change: 

- This manually revert one part of https://github.com/osmlab/editor-layer-index/commit/8ba28d711d70c070e0c02ab2124756c83dab6b0e#diff-cdc85c6ec45d176ea9a981e330f434f6L11
- And also https://github.com/osmlab/editor-layer-index/commit/8fdc15687c3532aa0d309cc0771435d8cd47a9f5#diff-cdc85c6ec45d176ea9a981e330f434f6L5