### PR TITLE
Add new images for Berlin 2018, change source for 2015 and add exact dates

### DIFF
--- a/sources/europe/de/Berlinaerialphotograph2015.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2015.geojson
@@ -3,17 +3,11 @@
   "properties": {
     "id": "Berlin-2015",
     "name": "Berlin aerial photography 2015",
-    "type": "wms",
-    "url": "https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_luftbild2015_rgb?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=0&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
-    "start_date": "2015",
-    "end_date": "2015",
+    "type": "tms",
+    "url": "https://tiles.codefor.de/berlin-2017/{zoom}/{x}/{y}.png",
+    "start_date": "2015-08-02",
+    "end_date": "2015-08-03",
     "country_code": "DE",
-    "available_projections": [
-      "EPSG:25833",
-      "EPSG:4326",
-      "EPSG:3068",
-      "EPSG:4258"
-    ],
     "attribution": {
       "text": "Geoportal Berlin/Digitale farbige Orthophotos 2015"
     },

--- a/sources/europe/de/Berlinaerialphotograph2016infrared.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2016infrared.geojson
@@ -5,8 +5,8 @@
     "name": "Berlin aerial photography 2016 (infrared)",
     "type": "tms",
     "url": "https://tiles.codefor.de/berlin-2016i/{zoom}/{x}/{y}.png",
-    "start_date": "2016",
-    "end_date": "2016",
+    "start_date": "2016-04-02",
+    "end_date": "2016-04-03",
     "country_code": "DE",
     "attribution": {
       "text": "Geoportal Berlin/Digitale Color-Infrarot-Orthophotos 2016"

--- a/sources/europe/de/Berlinaerialphotograph2017.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2017.geojson
@@ -5,8 +5,8 @@
     "name": "Berlin aerial photography 2017",
     "type": "tms",
     "url": "https://tiles.codefor.de/berlin-2017/{zoom}/{x}/{y}.png",
-    "start_date": "2017",
-    "end_date": "2017",
+    "start_date": "2017-03-27",
+    "end_date": "2017-03-28",
     "country_code": "DE",
     "best": true,
     "attribution": {

--- a/sources/europe/de/Berlinaerialphotograph2018.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2018.geojson
@@ -1,15 +1,16 @@
 {
   "type": "Feature",
   "properties": {
-    "id": "Berlin-2017",
-    "name": "Berlin aerial photography 2017",
+    "id": "Berlin-2018",
+    "name": "Berlin aerial photography 2018",
     "type": "tms",
-    "url": "https://tiles.codefor.de/berlin-2017/{zoom}/{x}/{y}.png",
-    "start_date": "2017-03-27",
-    "end_date": "2017-03-28",
+    "url": "https://tiles.codefor.de/berlin-2018/{zoom}/{x}/{y}.png",
+    "start_date": "2018-03-19",
+    "end_date": "2018-04-07",
     "country_code": "DE",
+    "best": true,
     "attribution": {
-      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2017"
+      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2018"
     },
     "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=367583#p367583"
   },


### PR DESCRIPTION
Thanks to https://github.com/jochenklar/fis-broker/issues/1#issuecomment-414062058 and the city of Berlin we have new data for 2018.

The licence for 2018 is the same as for the other years, so the terms that are linked in the json still apply.

As a side note: Most of the 2018 images are from 2018-04-07, the southern part of the data is from 2018-03-19. See image at https://github.com/jochenklar/fis-broker/issues/1#issuecomment-413660394

Also, the geojson is the same as for 2017, even though it does not fit perfectly with the available data as seen in the image in https://github.com/jochenklar/fis-broker/issues/1#issuecomment-414062539 http://fbarc.stadt-berlin.de/FIS_Broker_Atom/DOP/Blattschnitt2x2km.gif. However IMO this could be made public as is and maybe modified later.

**Merging:**

I made small commits do make documentation easier, but I guess squashing them into one would be a good idea.