### PR TITLE
Add support for HTTP header indicating invalid tiles

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -104,6 +104,14 @@
                     "type": "string",
                     "pattern": "^\\d\\d\\d\\d(-\\d\\d(-\\d\\d)?)?$"
                 },
+                "no_tile_header": {
+                    "description": "HTTP header to check for information if the tile is invalid",
+                    "type": "string"
+                },
+                "no_tile_value": {
+                    "description": "Value for the no tile header indicating that the tile is invalid",
+                    "type": "string"
+                },
                 "overlay": {
                     "description": "'true' if tiles are transparent and can be overlaid on another source",
                     "type": "boolean",

--- a/schema.json
+++ b/schema.json
@@ -106,14 +106,25 @@
                 },
                 "no_tile_header": {
                     "description": "HTTP header to check for information if the tile is invalid",
-                    "type": "string"
-                },
-                "no_tile_values": {
-                    "description": "Values for the no tile header indicating that the tile is invalid",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "object",
+                    "minProperties": 1,
+                    "maxProperties": 1,
+                    "patternProperties": {
+                        "^.*$": {
+                            "anyOf": [
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        }
+                    },
+                    "additionalProperties": false
                 },
                 "overlay": {
                     "description": "'true' if tiles are transparent and can be overlaid on another source",

--- a/schema.json
+++ b/schema.json
@@ -108,9 +108,12 @@
                     "description": "HTTP header to check for information if the tile is invalid",
                     "type": "string"
                 },
-                "no_tile_value": {
-                    "description": "Value for the no tile header indicating that the tile is invalid",
-                    "type": "string"
+                "no_tile_values": {
+                    "description": "Values for the no tile header indicating that the tile is invalid",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "overlay": {
                     "description": "'true' if tiles are transparent and can be overlaid on another source",

--- a/sources/world/Bing.geojson
+++ b/sources/world/Bing.geojson
@@ -9,7 +9,9 @@
         "license_url": "https://wiki.openstreetmap.org/wiki/Bing_Maps",
         "max_zoom": 22,
         "no_tile_header": "X-VE-Tile-Info",
-        "no_tile_value": "no-tile",
+        "no_tile_values": [
+            "no-tile"
+        ],
         "name": "Bing aerial imagery",
         "type": "bing",
         "url": "https://www.bing.com/maps"

--- a/sources/world/Bing.geojson
+++ b/sources/world/Bing.geojson
@@ -8,6 +8,8 @@
         "id": "Bing",
         "license_url": "https://wiki.openstreetmap.org/wiki/Bing_Maps",
         "max_zoom": 22,
+        "no_tile_header": "X-VE-Tile-Info",
+        "no_tile_value": "no-tile",
         "name": "Bing aerial imagery",
         "type": "bing",
         "url": "https://www.bing.com/maps"

--- a/sources/world/Bing.geojson
+++ b/sources/world/Bing.geojson
@@ -8,10 +8,11 @@
         "id": "Bing",
         "license_url": "https://wiki.openstreetmap.org/wiki/Bing_Maps",
         "max_zoom": 22,
-        "no_tile_header": "X-VE-Tile-Info",
-        "no_tile_values": [
-            "no-tile"
-        ],
+        "no_tile_header": {
+            "X-VE-Tile-Info": [
+                "no-tile"
+            ]
+        },
         "name": "Bing aerial imagery",
         "type": "bing",
         "url": "https://www.bing.com/maps"

--- a/sources/world/EsriImagery.geojson
+++ b/sources/world/EsriImagery.geojson
@@ -13,7 +13,7 @@
         "id": "EsriWorldImagery",
         "max_zoom": 22,
         "no_tile_header": "Etag",
-        "no_tile_value": "10i954m13i2",
+        "no_tile_values": ["10i954m13i2"],
         "name": "Esri World Imagery",
         "type": "tms",
         "url": "https://{switch:services,server}.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{zoom}/{y}/{x}"

--- a/sources/world/EsriImagery.geojson
+++ b/sources/world/EsriImagery.geojson
@@ -12,6 +12,8 @@
         "icon": "https://osmlab.github.io/editor-layer-index/sources/world/EsriImageryClarity.png",
         "id": "EsriWorldImagery",
         "max_zoom": 22,
+        "no_tile_header": "Etag",
+        "no_tile_value": "10i954m13i2",
         "name": "Esri World Imagery",
         "type": "tms",
         "url": "https://{switch:services,server}.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{zoom}/{y}/{x}"

--- a/sources/world/EsriImagery.geojson
+++ b/sources/world/EsriImagery.geojson
@@ -12,8 +12,11 @@
         "icon": "https://osmlab.github.io/editor-layer-index/sources/world/EsriImageryClarity.png",
         "id": "EsriWorldImagery",
         "max_zoom": 22,
-        "no_tile_header": "Etag",
-        "no_tile_values": ["10i954m13i2"],
+        "no_tile_header": {
+            "Etag": [
+                "10i954m13i2"
+            ]
+        },
         "name": "Esri World Imagery",
         "type": "tms",
         "url": "https://{switch:services,server}.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{zoom}/{y}/{x}"


### PR DESCRIPTION
This adds fields that allow specifying a HTTP header and associated value that indicates an invalid tile, this is mainly useful for layers that return error tiles instead of 404s. This mirrors a similar facility of JOSM.

Note, this could naturally be modelled as a JSON object or an array instead of two string fields, no particular preference on my behalf. 