### PR TITLE
Align HRI entry to JOSM one

### DIFF
--- a/sources/europe/fi/hri-orto.geojson
+++ b/sources/europe/fi/hri-orto.geojson
@@ -3,7 +3,7 @@
             "properties": {
                 "attribution": {
                     "required": true,
-                    "text": "\u00a9 Helsingin kaupunkiymp\u00e4rist\u00f6n toimiala",
+                    "text": "\u00a9 Espoon, Helsingin ja Vantaan kaupungit, Kirkkonummen ja Nurmij\u00e4rven kunnat sek\u00e4 HSL ja HSY",
                     "url": "https://www.hsy.fi/"
                 },
                 "available_projections": [
@@ -13,12 +13,12 @@
                 ],
                 "best": true,
                 "country_code": "FI",
-                "description": "Ortophotos from Helsinki Region Infoshare",
+                "description": "Ortophotos from the municipalities of Espoo, Helsinki, Vantaa, Kirkkonummi and Nurmijärvi + HSL and HSY",
                 "icon": "https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/fi/hri_logo.png",
                 "id": "hri-orto",
                 "license_url": "https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/fi/HRI_permission_07082018.pdf",
                 "max_zoom": 19,
-                "name": "HRI Orthophoto",
+                "name": "Helsinki region orthophoto",
                 "type": "wms",
                 "url": "https://kartta.hsy.fi/geoserver/ows?SERVICE=WMS&FORMAT=image/jpeg&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=taustakartat_ja_aluejaot:Ortoilmakuva_2017&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
             },


### PR DESCRIPTION
This aligns HRI entry (#339) to [modifications made](https://josm.openstreetmap.de/wiki/Maps/Finland?action=diff&version=30) by @NKAmapper on JOSM wiki.