### PR TITLE
Add information on licence and OSM usage permission

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -65,7 +65,7 @@
                     ]
                 },
                 "license": {
-                    "description": "The license for the imagery specified using a SPDX identifier",
+                    "description": "The license for the imagery specified using a SPDX identifier, or 'COMMERCIAL'",
                     "type": "string"
                 },
                 "license_url": {

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -75,7 +75,7 @@ for filename in arguments.path:
             raise ValidationError('{z} found instead of {zoom} in tile url')
         if 'license' in source['properties']:
             license = source['properties']['license']
-            if not spdx_lookup.by_id(license):
+            if not spdx_lookup.by_id(license) and license != 'COMMERCIAL':
                 raise ValidationError('Unknown license %s' % license)
         else:
             logger.debug("{} has no license property".format(filename))

--- a/sources/world/Bing.geojson
+++ b/sources/world/Bing.geojson
@@ -6,6 +6,8 @@
         "i18n": true,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/world/Bing.png",
         "id": "Bing",
+        "licence": "COMMERCIAL", 
+        "permission_osm": "explicit",
         "license_url": "https://wiki.openstreetmap.org/wiki/Bing_Maps",
         "max_zoom": 22,
         "name": "Bing aerial imagery",

--- a/sources/world/Bing.geojson
+++ b/sources/world/Bing.geojson
@@ -6,7 +6,7 @@
         "i18n": true,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/world/Bing.png",
         "id": "Bing",
-        "licence": "COMMERCIAL", 
+        "license": "COMMERCIAL", 
         "permission_osm": "explicit",
         "license_url": "https://wiki.openstreetmap.org/wiki/Bing_Maps",
         "max_zoom": 22,

--- a/sources/world/DigitalGlobePremiumImagery.geojson
+++ b/sources/world/DigitalGlobePremiumImagery.geojson
@@ -7,6 +7,8 @@
             "url": "https://wiki.openstreetmap.org/wiki/DigitalGlobe"
         },
         "default": true,
+        "licence": "COMMERCIAL", 
+        "permission_osm": "explicit",
         "description": "DigitalGlobe-Premium is a mosaic composed of DigitalGlobe basemap with select regions filled with +Vivid or custom area of interest imagery, 50cm resolution or better, and refreshed more frequently with ongoing updates.",
         "i18n": true,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/world/DigitalGlobePremiumImagery.png",

--- a/sources/world/DigitalGlobePremiumImagery.geojson
+++ b/sources/world/DigitalGlobePremiumImagery.geojson
@@ -7,7 +7,7 @@
             "url": "https://wiki.openstreetmap.org/wiki/DigitalGlobe"
         },
         "default": true,
-        "licence": "COMMERCIAL", 
+        "license": "COMMERCIAL", 
         "permission_osm": "explicit",
         "description": "DigitalGlobe-Premium is a mosaic composed of DigitalGlobe basemap with select regions filled with +Vivid or custom area of interest imagery, 50cm resolution or better, and refreshed more frequently with ongoing updates.",
         "i18n": true,

--- a/sources/world/DigitalGlobePremiumImagery_vintage_overlay.geojson
+++ b/sources/world/DigitalGlobePremiumImagery_vintage_overlay.geojson
@@ -6,6 +6,8 @@
             "text": "Terms & Feedback",
             "url": "https://wiki.openstreetmap.org/wiki/DigitalGlobe"
         },
+        "licence": "COMMERCIAL", 
+        "permission_osm": "explicit",
         "description": "Imagery boundaries and capture dates. Labels appear at zoom level 13 and higher.",
         "i18n": true,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/world/DigitalGlobePremiumImagery.png",

--- a/sources/world/DigitalGlobePremiumImagery_vintage_overlay.geojson
+++ b/sources/world/DigitalGlobePremiumImagery_vintage_overlay.geojson
@@ -6,7 +6,7 @@
             "text": "Terms & Feedback",
             "url": "https://wiki.openstreetmap.org/wiki/DigitalGlobe"
         },
-        "licence": "COMMERCIAL", 
+        "license": "COMMERCIAL", 
         "permission_osm": "explicit",
         "description": "Imagery boundaries and capture dates. Labels appear at zoom level 13 and higher.",
         "i18n": true,

--- a/sources/world/DigitalGlobeStandardImagery.geojson
+++ b/sources/world/DigitalGlobeStandardImagery.geojson
@@ -7,6 +7,8 @@
             "url": "https://wiki.openstreetmap.org/wiki/DigitalGlobe"
         },
         "default": true,
+        "licence": "COMMERCIAL", 
+        "permission_osm": "explicit",
         "description": "DigitalGlobe-Standard is a curated set of imagery covering 86% of the earth’s landmass, with 30-60cm resolution where available, backfilled by Landsat. Average age is 2.31 years, with some areas updated 2x per year.",
         "i18n": true,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/world/DigitalGlobePremiumImagery.png",

--- a/sources/world/DigitalGlobeStandardImagery.geojson
+++ b/sources/world/DigitalGlobeStandardImagery.geojson
@@ -7,7 +7,7 @@
             "url": "https://wiki.openstreetmap.org/wiki/DigitalGlobe"
         },
         "default": true,
-        "licence": "COMMERCIAL", 
+        "license": "COMMERCIAL", 
         "permission_osm": "explicit",
         "description": "DigitalGlobe-Standard is a curated set of imagery covering 86% of the earth’s landmass, with 30-60cm resolution where available, backfilled by Landsat. Average age is 2.31 years, with some areas updated 2x per year.",
         "i18n": true,

--- a/sources/world/DigitalGlobeStandardImagery_vintage_overlay.geojson
+++ b/sources/world/DigitalGlobeStandardImagery_vintage_overlay.geojson
@@ -7,6 +7,8 @@
             "url": "https://wiki.openstreetmap.org/wiki/DigitalGlobe"
         },
         "description": "Imagery boundaries and capture dates. Labels appear at zoom level 13 and higher.",
+        "licence": "COMMERCIAL", 
+        "permission_osm": "explicit",
         "i18n": true,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/world/DigitalGlobePremiumImagery.png",
         "id": "DigitalGlobe-Standard-vintage",

--- a/sources/world/DigitalGlobeStandardImagery_vintage_overlay.geojson
+++ b/sources/world/DigitalGlobeStandardImagery_vintage_overlay.geojson
@@ -7,7 +7,7 @@
             "url": "https://wiki.openstreetmap.org/wiki/DigitalGlobe"
         },
         "description": "Imagery boundaries and capture dates. Labels appear at zoom level 13 and higher.",
-        "licence": "COMMERCIAL", 
+        "license": "COMMERCIAL", 
         "permission_osm": "explicit",
         "i18n": true,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/world/DigitalGlobePremiumImagery.png",

--- a/sources/world/EsriImagery.geojson
+++ b/sources/world/EsriImagery.geojson
@@ -7,7 +7,7 @@
             "url": "https://wiki.openstreetmap.org/wiki/Esri"
         },
         "default": true,
-        "licence": "COMMERCIAL", 
+        "license": "COMMERCIAL", 
         "permission_osm": "explicit",
         "description": "Esri world imagery.",
         "i18n": true,

--- a/sources/world/EsriImagery.geojson
+++ b/sources/world/EsriImagery.geojson
@@ -7,6 +7,8 @@
             "url": "https://wiki.openstreetmap.org/wiki/Esri"
         },
         "default": true,
+        "licence": "COMMERCIAL", 
+        "permission_osm": "explicit",
         "description": "Esri world imagery.",
         "i18n": true,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/world/EsriImageryClarity.png",

--- a/sources/world/EsriImageryClarity.geojson
+++ b/sources/world/EsriImageryClarity.geojson
@@ -7,6 +7,8 @@
             "url": "https://wiki.openstreetmap.org/wiki/Esri"
         },
         "default": true,
+        "licence": "COMMERCIAL", 
+        "permission_osm": "explicit",
         "description": "Esri archive imagery that may be clearer and more accurate than the default layer.",
         "i18n": true,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/world/EsriImageryClarity.png",

--- a/sources/world/EsriImageryClarity.geojson
+++ b/sources/world/EsriImageryClarity.geojson
@@ -7,7 +7,7 @@
             "url": "https://wiki.openstreetmap.org/wiki/Esri"
         },
         "default": true,
-        "licence": "COMMERCIAL", 
+        "license": "COMMERCIAL", 
         "permission_osm": "explicit",
         "description": "Esri archive imagery that may be clearer and more accurate than the default layer.",
         "i18n": true,

--- a/sources/world/MapBoxSatellite.geojson
+++ b/sources/world/MapBoxSatellite.geojson
@@ -7,6 +7,8 @@
             "url": "https://www.mapbox.com/about/maps"
         },
         "default": true,
+        "licence": "COMMERCIAL", 
+        "permission_osm": "explicit",
         "description": "Satellite and aerial imagery.",
         "i18n": true,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/world/MapBoxSatellite.png",

--- a/sources/world/MapBoxSatellite.geojson
+++ b/sources/world/MapBoxSatellite.geojson
@@ -7,7 +7,7 @@
             "url": "https://www.mapbox.com/about/maps"
         },
         "default": true,
-        "licence": "COMMERCIAL", 
+        "license": "COMMERCIAL", 
         "permission_osm": "explicit",
         "description": "Satellite and aerial imagery.",
         "i18n": true,


### PR DESCRIPTION
This commit adds information on the licence and the nature of the
permission to use the layer in OSM to the configurations for the global
aerial imagery mosaics.

As there is no fitting SPDX licence id for non open licences I've used
"COMMERCIAL" which seems to be fit well and is reasonably diplomatic.