### PR TITLE
Add orthophotos for Stockholm and Helsingborg

### DIFF
--- a/sources/europe/se/helsingborg-orto.geojson
+++ b/sources/europe/se/helsingborg-orto.geojson
@@ -1,0 +1,53 @@
+        {
+            "type": "Feature",
+            "properties": {
+                "id": "helsingborg-orto",
+                "name": "Helsingborg Orthophoto",
+                "best": true,
+                "country_code": "SE",
+                "description": "Orthophotos from the municipality of Helsingborg 2016, public domain",
+                "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/Helsingborg_vapen.svg/198px-Helsingborg_vapen.svg.png",
+                "i18n": true,
+                "license_url": "https://helsingborg.opendatasoft.com/explore/dataset/flygbilder/information/",
+                "max_zoom": 20,
+                "min_zoom": 5,
+                "type": "tms",
+                "url": "http://mapproxy.openstreetmap.se/tiles/1.0.0/hborg2016_EPSG3857/{zoom}/{x}/{y}.jpeg",
+                "attribution": {
+                    "required": true,
+                    "text": "\u00a9 Helsingborg municipality",
+                    "url": "https://helsingborg.opendatasoft.com/"
+                }
+            },
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            12.7434514,
+                            55.9499704
+                        ],
+                        [
+                            12.937774,
+                            55.9080399
+                        ],
+                        [
+                            13.0036873,
+                            55.9684218
+                        ],
+                        [
+                            12.7908271,
+                            56.2502203
+                        ],
+                        [
+                            12.5669834,
+                            56.1356043
+                        ],
+                        [
+                            12.7434514,
+                            55.9499704
+                        ]
+                    ]
+                ]
+            }
+        }

--- a/sources/europe/se/stockholm-orto.geojson
+++ b/sources/europe/se/stockholm-orto.geojson
@@ -1,0 +1,149 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "stockholm-orto",
+        "name": "Stockholm Orthophoto",
+        "best": true,
+        "country_code": "SE",
+        "i18n": true,
+        "description": "Orthophotos from the municipality of Stockholm 2015, CC0 license",
+        "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/Stockholm_vapen_bra.svg/196px-Stockholm_vapen_bra.svg.png",
+        "license_url": "http://dataportalen.stockholm.se/dataportalen/GetMetaDataById?id=94b3816a-3cfb-4eb9-a12e-698b803f80f4",
+        "type": "wms",
+        "url": "http://openmap.stockholm.se/bios/wms/app/baggis/web/WMS_STHLM_ORTOFOTO_2015?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=p_1002820&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "max_zoom": 21,
+        "min_zoom": 5,
+        "attribution": {
+            "required": true,
+            "text": "\u00a9 Stockholm municipality, CC0",
+            "url": "http://dataportalen.stockholm.se/dataportalen/"
+        },
+        "available_projections": [
+            "EPSG:3857",
+            "EPSG:4326",
+            "EPSG:25832",
+            "EPSG:25833",
+            "EPSG:25835",
+            "EPSG:25884",
+            "EPSG:3006",
+            "EPSG:3007",
+            "EPSG:3008",
+            "EPSG:3009",
+            "EPSG:3010",
+            "EPSG:3011",
+            "EPSG:3012",
+            "EPSG:3013",
+            "EPSG:3014",
+            "EPSG:3015",
+            "EPSG:3016",
+            "EPSG:3017",
+            "EPSG:3018",
+            "EPSG:3044",
+            "EPSG:3152",
+            "EPSG:32632",
+            "EPSG:32633",
+            "EPSG:5850",
+            "EPSG:5973",
+            "EPSG:5975"
+        ],
+    },
+    "geometry": {
+        "type": "Polygon"
+        "coordinates": [
+                    [
+                        [
+                            17.8754961,
+                            59.2624957
+                        ],
+                        [
+                            17.9441064,
+                            59.273074
+                        ],
+                        [
+                            18.0955121,
+                            59.2260289
+                        ],
+                        [
+                            18.1958183,
+                            59.2278623
+                        ],
+                        [
+                            18.2029718,
+                            59.2488575
+                        ],
+                        [
+                            18.1253808,
+                            59.3077894
+                        ],
+                        [
+                            18.1785962,
+                            59.3256591
+                        ],
+                        [
+                            18.0987606,
+                            59.3720958
+                        ],
+                        [
+                            18.0426404,
+                            59.3781631
+                        ],
+                        [
+                            18.0079648,
+                            59.3433445
+                        ],
+                        [
+                            17.9365537,
+                            59.3764143
+                        ],
+                        [
+                            17.9748341,
+                            59.4024625
+                        ],
+                        [
+                            17.9088193,
+                            59.4417
+                        ],
+                        [
+                            17.8853986,
+                            59.4379187
+                        ],
+                        [
+                            17.8891751,
+                            59.4138195
+                        ],
+                        [
+                            17.8407666,
+                            59.385682
+                        ],
+                        [
+                            17.8170773,
+                            59.4005401
+                        ],
+                        [
+                            17.7772516,
+                            59.3998412
+                        ],
+                        [
+                            17.7562153,
+                            59.3916033
+                        ],
+                        [
+                            17.7989896,
+                            59.3620354
+                        ],
+                        [
+                            17.9499318,
+                            59.311211
+                        ],
+                        [
+                            17.8562158,
+                            59.2841236
+                        ],
+                        [
+                            17.8754961,
+                            59.2624957
+                        ]
+                    ]
+                ]
+    }
+}

--- a/sources/europe/se/stockholm-orto.geojson
+++ b/sources/europe/se/stockholm-orto.geojson
@@ -48,7 +48,7 @@
         ]
     },
     "geometry": {
-        "type": "Polygon"
+        "type": "Polygon",
         "coordinates": [
                     [
                         [

--- a/sources/europe/se/stockholm-orto.geojson
+++ b/sources/europe/se/stockholm-orto.geojson
@@ -45,7 +45,7 @@
             "EPSG:5850",
             "EPSG:5973",
             "EPSG:5975"
-        ],
+        ]
     },
     "geometry": {
         "type": "Polygon"


### PR DESCRIPTION
Stockholm CC0 license: [link](http://dataportalen.stockholm.se/dataportalen/GetMetaDataById?id=19b64d54-5f3c-4e77-968f-4b75bd0d0496) --> "Restriktioner"

Helsingborg "Public Domain" license: [link](https://helsingborg.opendatasoft.com/explore/dataset/flygbilder/information/)

Solves #350 