### PR TITLE
Fixed HRI icon

### DIFF
--- a/sources/europe/fi/hri-orto.geojson
+++ b/sources/europe/fi/hri-orto.geojson
@@ -14,7 +14,7 @@
                 "best": true,
                 "country_code": "FI",
                 "description": "Ortophotos from the municipalities of Espoo, Helsinki, Vantaa, Kirkkonummi and Nurmijärvi + HSL and HSY",
-                "icon": "https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/fi/hri_logo.png",
+                "icon": "https://raw.githubusercontent.com/osmlab/editor-layer-index/gh-pages/sources/europe/fi/hri_logo.png",
                 "id": "hri-orto",
                 "license_url": "https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/fi/HRI_permission_07082018.pdf",
                 "max_zoom": 19,


### PR DESCRIPTION
broken on iD, since it links to HTML page, not to the raw image itself.