### PR TITLE
update Geolittoral WMS URL

### DIFF
--- a/sources/europe/fr/Geolittoral-Orthophotos2000.geojson
+++ b/sources/europe/fr/Geolittoral-Orthophotos2000.geojson
@@ -2,7 +2,7 @@
     "type": "Feature",
     "properties": {
         "id": "Geolittoral-Orthophotos2000",
-        "url": "http://geolittoral.application.developpement-durable.gouv.fr/wms2/metropole?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=ortholittorale&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "http://geolittoral.din.developpement-durable.gouv.fr/wxs?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=ortholittorale&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "attribution": {
             "url": "https://wiki.openstreetmap.org/wiki/WikiProject_France/G%C3%A9oLittoral",
             "text": "Ortho littorale 2000",

--- a/sources/europe/fr/Geolittoral-Sentiers.geojson
+++ b/sources/europe/fr/Geolittoral-Sentiers.geojson
@@ -2,7 +2,7 @@
     "type": "Feature",
     "properties": {
         "id": "Geolittoral-Sentiers",
-        "url": "http://geolittoral.application.developpement-durable.gouv.fr/wms2/metropole?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=n_sentier_littoral_l&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "http://geolittoral.din.developpement-durable.gouv.fr/wxs?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=n_sentier_littoral_l&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "attribution": {
             "url": "https://wiki.openstreetmap.org/wiki/WikiProject_France/G%C3%A9oLittoral",
             "text": "Ortho littorale 2000",

--- a/sources/europe/fr/GeolittoralV2-Orthophotos2010-2012.geojson
+++ b/sources/europe/fr/GeolittoralV2-Orthophotos2010-2012.geojson
@@ -2,7 +2,7 @@
     "type": "Feature",
     "properties": {
         "id": "GeolittoralV2-Orthophotos",
-        "url": "http://geolittoral.application.developpement-durable.gouv.fr/wms2/metropole?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=ortholittorale_v2_rvb&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "http://geolittoral.din.developpement-durable.gouv.fr/wxs?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=ortholittorale_v2_rvb&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "attribution": {
             "url": "https://wiki.openstreetmap.org/wiki/WikiProject_France/G%C3%A9oLittoral",
             "text": "Ortho Littorale V2 - MEDDE",


### PR DESCRIPTION
See [JOSM ticket 17049](https://josm.openstreetmap.de/ticket/17049)

French government has updated its WMS server for "GéoLittoral" orthophotos. The old URLs will be [removed in 2019](http://www.geolittoral.developpement-durable.gouv.fr/services-web-d-interoperabilite-a803.html).