### PR TITLE
Add a short description to all sources proxied by SOSM

### DIFF
--- a/sources/europe/ch/BernStadt-10cm25cm-2012.geojson
+++ b/sources/europe/ch/BernStadt-10cm25cm-2012.geojson
@@ -13,6 +13,7 @@
             "text": "Orthophoto 2012, Vermessungsamt Stadt Bern",
             "required": false
         },
+        "description": "This imagery is provided via a proxy operated by https://sosm.ch/", 
         "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
         "max_zoom": 19,
         "min_zoom": 14

--- a/sources/europe/ch/CantonFribourg-2016.geojson
+++ b/sources/europe/ch/CantonFribourg-2016.geojson
@@ -2,7 +2,6 @@
     "type": "Feature",
     "properties": {
         "license_url": "https://www.geocat.ch/geonetwork/srv/fre/catalog.search#/metadata/9c059550-1cf7-4338-aa51-f39474a67639",
-        "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
         "start_date": "2016",
         "end_date": "2016",
         "id": "CTFRIBOURG2016",
@@ -12,6 +11,8 @@
         },
         "name": "Canton Fribourg 2016",
         "url": "https://mapproxy.osm.ch/tiles/fribourg_2016/EPSG900913/{zoom}/{x}/{y}.png?origin=nw",
+        "description": "This imagery is provided via a proxy operated by https://sosm.ch/", 
+        "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
         "max_zoom": 21,
         "min_zoom": 1,
         "country_code": "CH",

--- a/sources/europe/ch/KantonAargau25cm-AGIS2014.geojson
+++ b/sources/europe/ch/KantonAargau25cm-AGIS2014.geojson
@@ -2,6 +2,7 @@
     "type": "Feature",
     "properties": {
         "license_url": "https://wiki.openstreetmap.org/wiki/Switzerland/AGIS",
+        "description": "This imagery is provided via a proxy operated by https://sosm.ch/", 
         "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
         "id": "Aargau-AGIS-2014",
         "attribution": {

--- a/sources/europe/ch/KantonAargau25cm-AGIS2016.geojson
+++ b/sources/europe/ch/KantonAargau25cm-AGIS2016.geojson
@@ -2,6 +2,7 @@
     "type": "Feature",
     "properties": {
         "license_url": "https://wiki.openstreetmap.org/wiki/Switzerland/AGIS",
+        "description": "This imagery is provided via a proxy operated by https://sosm.ch/", 
         "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
         "id": "Aargau-AGIS-2016",
         "attribution": {

--- a/sources/europe/ch/KantonAargau25cm-AGIS2017.geojson
+++ b/sources/europe/ch/KantonAargau25cm-AGIS2017.geojson
@@ -2,6 +2,7 @@
     "type": "Feature",
     "properties": {
         "license_url": "https://wiki.openstreetmap.org/wiki/Switzerland/AGIS",
+        "description": "This imagery is provided via a proxy operated by https://sosm.ch/", 
         "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
         "id": "Aargau-AGIS-2017",
         "attribution": {

--- a/sources/europe/ch/KantonBasel-Landschaft12cm-2015.geojson
+++ b/sources/europe/ch/KantonBasel-Landschaft12cm-2015.geojson
@@ -9,6 +9,7 @@
             "url": "https://www.geo.bl.ch/fileadmin/user_upload/Geodaten/Nutzungsbedingungen_GBD_BL_V3p2.pdf",
             "required": true
         },
+        "description": "This imagery is provided via a proxy operated by https://sosm.ch/", 
         "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
         "name": "Kanton Basel-Landschaft 10cm (2015)",
         "url": "https://mapproxy.osm.ch/tiles/KTBASELLANDSCHAFT2015/EPSG900913/{zoom}/{x}/{y}.png?origin=nw",

--- a/sources/europe/ch/KantonBaselStadt-2015-TMS.geojson
+++ b/sources/europe/ch/KantonBaselStadt-2015-TMS.geojson
@@ -8,6 +8,7 @@
             "text": "Kanton Basel-Stadt OF 2015",
             "required": true
         },
+        "description": "This imagery is provided via a proxy operated by https://sosm.ch/", 
         "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
         "name": "Kanton Basel-Stadt 2015",
         "url": "https://mapproxy.osm.ch/tiles/KTBASELSTADT2015/EPSG900913/{zoom}/{x}/{y}.png?origin=nw",

--- a/sources/europe/ch/KantonBaselStadt-2017-TMS.geojson
+++ b/sources/europe/ch/KantonBaselStadt-2017-TMS.geojson
@@ -8,6 +8,7 @@
             "text": "Kanton Basel-Stadt OF 2017",
             "required": true
         },
+        "description": "This imagery is provided via a proxy operated by https://sosm.ch/", 
         "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
         "name": "Kanton Basel-Stadt 2017",
         "url": "https://mapproxy.osm.ch/tiles/KTBASELSTADT2017/EPSG900913/{zoom}/{x}/{y}.png?origin=nw",

--- a/sources/europe/ch/KantonSolothurn-SOGIS-tms.geojson
+++ b/sources/europe/ch/KantonSolothurn-SOGIS-tms.geojson
@@ -665,6 +665,7 @@
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/ch/KantonSolothurn-SOGIS-wms.png",
         "id": "Solothurn-sogis2014-tms",
         "license_url": "https://wiki.openstreetmap.org/wiki/SOGIS_WMS",
+        "description": "This imagery is provided via a proxy operated by https://sosm.ch/", 
         "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
         "max_zoom": 19,
         "min_zoom": 15,

--- a/sources/europe/ch/KantonThurgau-2017-TMS.geojson
+++ b/sources/europe/ch/KantonThurgau-2017-TMS.geojson
@@ -6,6 +6,7 @@
 			"text": "Kanton Thurgau OF 2017",
 			"required": true
 		},
+		"description": "This imagery is provided via a proxy operated by https://sosm.ch/", 
 		"privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
 		"name": "Kanton Thurgau OF 2017",
 		"url": "https://mapproxy.osm.ch/tiles/KTTHURGAU2017/EPSG900913/{zoom}/{x}/{y}.png?origin=nw",

--- a/sources/europe/ch/KantonZuerich10cm-2015-TMS.geojson
+++ b/sources/europe/ch/KantonZuerich10cm-2015-TMS.geojson
@@ -2,6 +2,7 @@
     "type": "Feature",
     "properties": {
         "license_url": "http://www.are.zh.ch/internet/baudirektion/are/de/geoinformation/geodaten_uebersicht/Open_Data_Kanton_Zuerich.html",
+        "description": "This imagery is provided via a proxy operated by https://sosm.ch/", 
         "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
         "start_date": "2014",
         "end_date": "2015",

--- a/sources/europe/ch/StadtBern10cm-2016-TMS.geojson
+++ b/sources/europe/ch/StadtBern10cm-2016-TMS.geojson
@@ -2,6 +2,7 @@
     "type": "Feature",
     "properties": {
         "license_url": "http://lists.openstreetmap.ch/pipermail/talk-ch/2016-November/003868.html",
+        "description": "This imagery is provided via a proxy operated by https://sosm.ch/", 
         "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
         "start_date": "2016",
         "end_date": "2016",

--- a/sources/europe/ch/StadtUsterOrthophoto200810cm.geojson
+++ b/sources/europe/ch/StadtUsterOrthophoto200810cm.geojson
@@ -2,6 +2,7 @@
     "type": "Feature",
     "properties": {
         "license_url": "https://wiki.openstreetmap.org/wiki/Stadt_Uster_WMS",
+        "description": "This imagery is provided via a proxy operated by https://sosm.ch/", 
         "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
         "start_date": "2008",
         "end_date": "2008",

--- a/sources/europe/ch/StadtZuerichOrthophoto2011.geojson
+++ b/sources/europe/ch/StadtZuerichOrthophoto2011.geojson
@@ -2,6 +2,7 @@
     "type": "Feature",
     "properties": {
         "license_url": "https://data.stadt-zuerich.ch/portal/de/index/ogd/nutzungsbedingungen.secure.html",
+        "description": "This imagery is provided via a proxy operated by https://sosm.ch/", 
         "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
         "start_date": "2011",
         "end_date": "2011",

--- a/sources/europe/ch/StadtplanZrich.geojson
+++ b/sources/europe/ch/StadtplanZrich.geojson
@@ -2,6 +2,7 @@
     "type": "Feature",
     "properties": {
         "license_url": "https://data.stadt-zuerich.ch/portal/de/index/ogd/nutzungsbedingungen.secure.html",
+        "description": "This imagery is provided via a proxy operated by https://sosm.ch/", 
         "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
         "id": "Zuerich-city_map",
         "url": "https://mapproxy.osm.ch/tiles/zh_stadtplan/EPSG900913/{zoom}/{x}/{y}.png?origin=nw",

--- a/sources/europe/ch/UbersichtsplanZucrich.geojson
+++ b/sources/europe/ch/UbersichtsplanZucrich.geojson
@@ -2,6 +2,7 @@
     "type": "Feature",
     "properties": {
         "license_url": "https://data.stadt-zuerich.ch/dataset/uebersichtsplan",
+        "description": "This imagery is provided via a proxy operated by https://sosm.ch/", 
         "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
         "id": "Zuerich-zh_uebersichtsplan-tms",
         "attribution": {

--- a/sources/europe/de/Bavaria-DOP80.geojson
+++ b/sources/europe/de/Bavaria-DOP80.geojson
@@ -4,6 +4,7 @@
         "id": "bavaria-DOP80",
         "url": "https://mapproxy.osm.ch/tiles/BAYERNDOP80/EPSG900913/{zoom}/{x}/{y}.png?origin=nw",
         "license": "CC-BY-3.0",
+        "description": "This imagery is provided via a proxy operated by https://sosm.ch/", 
         "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
         "min_zoom": 7,
         "max_zoom": 18,


### PR DESCRIPTION
This just adds a one-liner pointing out that the sources are proxied by SOSM, otherwise the privacy policy link is confusing.