### PR TITLE
New URL for wind power WMS in Norway

### DIFF
--- a/sources/europe/no/NVEWindPowerPlantsoverlay.geojson
+++ b/sources/europe/no/NVEWindPowerPlantsoverlay.geojson
@@ -4,7 +4,7 @@
     "id": "nve-vindkraft",
     "name": "NVE Wind Power Plants overlay",
     "type": "wms",
-    "url": "https://gis3.nve.no/map/services/Vindkraft/MapServer/WmsServer?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=Vindkraft_utbygd,Vindkraft_under_bygging,Vindkraftomrade_konsesjonsbehandling,Vindturbin_konsesjonsbehandling&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+    "url": "https://gis3.nve.no/map/services/Vindkraft1/MapServer/WmsServer?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=Vindkraft_konsesjon_gitt_ikke_utbygd,Vindkraft_under_bygging,Vindkraft_utbygd,Vindkraftomrade,Vindturbin&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
     "overlay": true,
     "country_code": "NO",
     "available_projections": [
@@ -31,7 +31,7 @@
     "max_zoom": 22,
     "min_zoom": 6,
     "license_url": "https://lists.nuug.no/pipermail/kart/2017-December/006312.html",
-    "description": "Wind power turbines, farms and concession areas. Red colour = concession denied."
+    "description": "Wind power turbines, farms and concession areas."
   },
   "geometry": {
     "type": "Polygon",


### PR DESCRIPTION
New URL and new layer names.
Synced with [JOSM maps](https://josm.openstreetmap.de/wiki/Maps/Norway#NVEWindPowerPlantsoverlay).