### PR TITLE
Update orthophoto for Lyon - correct a non-loading layer

### DIFF
--- a/sources/europe/fr/Lyon-Orthophoto-2015-05-8cm.geojson
+++ b/sources/europe/fr/Lyon-Orthophoto-2015-05-8cm.geojson
@@ -3,25 +3,18 @@
     "properties": {
         "id": "orthophoto_lyon_2015_8cm",
         "name": "Lyon Orthophoto 2015-05 8cm",
-        "type": "wms",
-        "url": "https://download.data.grandlyon.com/wms/grandlyon?language=fre&FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=1835_5155_8cm_CC46,1835_5160_8cm_CC46,1835_5165_8cm_CC46,1835_5170_8cm_CC46,1835_5180_8cm_CC46,1835_5175_8cm_CC46,1845_5175_8cm_CC46,1845_5180_8cm_CC46,1845_5185_8cm_CC46,1845_5190_8cm_CC46,1850_5165_8cm_CC46,1850_5160_8cm_CC46,1850_5155_8cm_CC46,1850_5170_8cm_CC46,1850_5175_8cm_CC46,1850_5180_8cm_CC46,1850_5185_8cm_CC46,1855_5155_8cm_CC46,1855_5160_8cm_CC46,1855_5185_8cm_CC46,1855_5180_8cm_CC46,1855_5175_8cm_CC46,1855_5170_8cm_CC46,1855_5165_8cm_CC46,1860_5160_8cm_CC46,1860_5155_8cm_CC46,1860_5165_8cm_CC46,1835_5185_8cm_CC46,1835_5190_8cm_CC46,1835_5195_8cm_CC46,1840_5160_8cm_CC46,1840_5155_8cm_CC46,1840_5150_8cm_CC46,1830_5195_8cm_CC46,1830_5190_8cm_CC46,1830_5175_8cm_CC46,1830_5170_8cm_CC46,1830_5165_8cm_CC46,1830_5160_8cm_CC46,1830_5155_8cm_CC46,1830_5180_8cm_CC46,1830_5185_8cm_CC46,1835_5150_8cm_CC46,1860_5170_8cm_CC46,1860_5175_8cm_CC46,1840_5180_8cm_CC46,1840_5175_8cm_CC46,1840_5185_8cm_CC46,1840_5190_8cm_CC46,1840_5195_8cm_CC46,1845_5150_8cm_CC46,1845_5155_8cm_CC46,1845_5160_8cm_CC46,1845_5170_8cm_CC46,1845_5165_8cm_CC46,1840_5170_8cm_CC46,1840_5165_8cm_CC46,1860_5180_8cm_CC46,1860_5185_8cm_CC46,1865_5155_8cm_CC46,1865_5160_8cm_CC46,1865_5165_8cm_CC46,1865_5170_8cm_CC46,1830_5150_8cm_CC46&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "type": "tms",
+        "url": "http://wms.openstreetmap.fr/tms/1.0.0/lyon/{zoom}/{x}/{y}",
         "best": true,
         "end_date": "2015-05",
         "start_date": "2015-05",
         "country_code": "FR",
-        "available_projections": [
-            "EPSG:4171",
-            "EPSG:4326",
-            "EPSG:2154",
-            "EPSG:27572",
-            "EPSG:27562",
-            "EPSG:3946",
-            "EPSG:3857"
-        ],
+        "max_zoom": 22,
+        "min_zoom": 2,
         "attribution": {
-            "url": "https://data.grandlyon.com/imagerie/orthophotographie-2015-du-grand-lyon",
+            "url": "https://data.grandlyon.com/imagerie/orthophotographie-2015-du-grand-lyon/",
             "text": "M\u00e9tropole de Lyon DINSI",
-            "required": false
+            "required": true
         },
         "license_url": "https://download.data.grandlyon.com/files/grandlyon/LicenceOuverte.pdf"
     },


### PR DESCRIPTION
Add the Lyon orthophoto from the OSM-FR WMS server