### PR TITLE
Remove eox.at as best layer

### DIFF
--- a/sources/world/eox.at-2018-cloudless.geojson
+++ b/sources/world/eox.at-2018-cloudless.geojson
@@ -17,7 +17,6 @@
         "available_projections": [
             "EPSG:3857"
         ],
-        "best": true,
         "start_date": "2018",
         "end_date": "2018",
         "max_zoom": 18,


### PR DESCRIPTION
eox.at cloudless layer (#644) has the `best` attribute.  
I haven't checked anywhere, but in many places it is certainly not the preferred imagery.  
I believe it is also practice not to offer worldwide imagery as the best layer.

This Pull removes the `best` attribute from the "eox.at cloudless 2018" layer.