### PR TITLE
Switch from png to jpeg

### DIFF
--- a/sources/europe/ch/Kanton_Bern_dsm_hillshade_wms.geojson
+++ b/sources/europe/ch/Kanton_Bern_dsm_hillshade_wms.geojson
@@ -17,10 +17,10 @@
         "min_zoom": 8,
         "id": "Bern-dsm-hillshade-2015",
         "name": "Kanton Bern, Digitales Oberflaechenmodell 50cm, Relief",
-        "license_url": "https://www.geodienste.ch/pdfs/BE/lwb_rebbaukataster/WMS/agi_dv_nutzungsbedingungen.pdf",
+        "license_url": "http://files.be.ch/bve/agi/geoportal/geo/nutzungsbedingungen/agi_dv_nutzungsbedingungen_de.pdf",
         "privacy_policy_url": "http://www.geo.apps.be.ch/de/rechtliches.html",
         "type": "wms",
-        "url": "https://www.geoservice.apps.be.ch/geoservice2/services/a42geo/a42geo_hoehenwms_d_fk/MapServer/WmsServer?LAYERS=GEODB.LDOM50CM_LORELIEF&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=default&FORMAT=image/png&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
+        "url": "https://www.geoservice.apps.be.ch/geoservice2/services/a42geo/a42geo_hoehenwms_d_fk/MapServer/WmsServer?LAYERS=GEODB.LDOM50CM_LORELIEF&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/ch/Kanton_Bern_dtm_hillshade_wms.geojson
+++ b/sources/europe/ch/Kanton_Bern_dtm_hillshade_wms.geojson
@@ -17,10 +17,10 @@
         "min_zoom": 8,
         "id": "Bern-dtm-hillshade-2015",
         "name": "Kanton Bern, Digitales Terrainmodell 50cm, Relief",
-        "license_url": "https://www.geodienste.ch/pdfs/BE/lwb_rebbaukataster/WMS/agi_dv_nutzungsbedingungen.pdf",
+        "license_url": "http://files.be.ch/bve/agi/geoportal/geo/nutzungsbedingungen/agi_dv_nutzungsbedingungen_de.pdf",
         "privacy_policy_url": "http://www.geo.apps.be.ch/de/rechtliches.html",
         "type": "wms",
-        "url": "https://www.geoservice.apps.be.ch/geoservice2/services/a42geo/a42geo_hoehenwms_d_fk/MapServer/WmsServer?LAYERS=GEODB.LDTM50CM_LTRELIEF&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=default&FORMAT=image/png&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
+        "url": "https://www.geoservice.apps.be.ch/geoservice2/services/a42geo/a42geo_hoehenwms_d_fk/MapServer/WmsServer?LAYERS=GEODB.LDTM50CM_LTRELIEF&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/ch/Kanton_Solothurn_dsm_hillshade_SOGIS_wms.geojson
+++ b/sources/europe/ch/Kanton_Solothurn_dsm_hillshade_SOGIS_wms.geojson
@@ -21,7 +21,7 @@
         "end_date": "2014",
         "min_zoom": 8,
         "type": "wms",
-        "url": "https://geoweb.so.ch/wms/wms_lidar?LAYERS=dom_relief2014_50cm&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://geoweb.so.ch/wms/wms_lidar?LAYERS=dom_relief2014_50cm&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "privacy_policy_url": "https://www.so.ch/rechtliches/"
     },
     "geometry": {

--- a/sources/europe/ch/Kanton_Solothurn_dtm_hillshade_SOGIS_wms.geojson
+++ b/sources/europe/ch/Kanton_Solothurn_dtm_hillshade_SOGIS_wms.geojson
@@ -21,7 +21,7 @@
         "end_date": "2014",
         "min_zoom": 8,
         "type": "wms",
-        "url": "https://geoweb.so.ch/wms/wms_lidar?LAYERS=dtm_relief2014_50cm&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://geoweb.so.ch/wms/wms_lidar?LAYERS=dtm_relief2014_50cm&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "privacy_policy_url": "https://www.so.ch/rechtliches/"
     },
     "geometry": {

--- a/sources/europe/ch/Kanton_Zurich_dom_hillshade_wms.geojson
+++ b/sources/europe/ch/Kanton_Zurich_dom_hillshade_wms.geojson
@@ -24,7 +24,7 @@
         "license_url": "https://opendata.swiss/de/dataset/wms-digitales-hohenmodell-ogd",
         "privacy_policy_url": "https://www.zh.ch/internet/de/service/nav/footer/nutzungsregelungen.html",
         "type": "wms",
-        "url": "https://wms.zh.ch/OGDLidarZH?FORMAT=image/png&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=dom2014hillshade&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
+        "url": "https://wms.zh.ch/OGDLidarZH?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=dom2014hillshade&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/ch/Kanton_Zurich_dtm_hillshade_wms.geojson
+++ b/sources/europe/ch/Kanton_Zurich_dtm_hillshade_wms.geojson
@@ -24,7 +24,7 @@
         "license_url": "https://opendata.swiss/de/dataset/wms-digitales-hohenmodell-ogd",
         "privacy_policy_url": "https://www.zh.ch/internet/de/service/nav/footer/nutzungsregelungen.html",
         "type": "wms",
-        "url": "https://wms.zh.ch/OGDLidarZH?FORMAT=image/png&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=dtm2014hillshade&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
+        "url": "https://wms.zh.ch/OGDLidarZH?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=dtm2014hillshade&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/ch/Kanton_Zurich_ortho_2015_wms.geojson
+++ b/sources/europe/ch/Kanton_Zurich_ortho_2015_wms.geojson
@@ -24,7 +24,7 @@
         "license_url": "https://opendata.swiss/de/dataset/wms-orthofotos-ogd",
         "privacy_policy_url": "https://www.zh.ch/internet/de/service/nav/footer/nutzungsregelungen.html",
         "type": "wms",
-        "url": "https://wms.zh.ch/OGDOrthoZH?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=ortho_s_14&FORMAT=image/png&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
+        "url": "https://wms.zh.ch/OGDOrthoZH?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=ortho_s_14&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/ch/Kanton_Zurich_ortho_2016_wms.geojson
+++ b/sources/europe/ch/Kanton_Zurich_ortho_2016_wms.geojson
@@ -24,7 +24,7 @@
         "license_url": "https://opendata.swiss/de/dataset/wms-orthofotos-ogd",
         "privacy_policy_url": "https://www.zh.ch/internet/de/service/nav/footer/nutzungsregelungen.html",
         "type": "wms",
-        "url": "https://wms.zh.ch/OGDOrthoZH?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=ortho_w_15&FORMAT=image/png&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
+        "url": "https://wms.zh.ch/OGDOrthoZH?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=ortho_w_15&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/ch/Kanton_Zurich_ortho_2018_wms.geojson
+++ b/sources/europe/ch/Kanton_Zurich_ortho_2018_wms.geojson
@@ -25,7 +25,7 @@
         "license_url": "https://opendata.swiss/de/dataset/wms-orthofotos-ogd",
         "privacy_policy_url": "https://www.zh.ch/internet/de/service/nav/footer/nutzungsregelungen.html",
         "type": "wms",
-        "url": "https://wms.zh.ch/OGDOrthoZH?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=ortho&FORMAT=image/png&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
+        "url": "https://wms.zh.ch/OGDOrthoZH?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=ortho&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
     },
     "geometry": {
         "type": "Polygon",


### PR DESCRIPTION
As recommended by @simonpoole switching from png to jpeg. 

+ Updated license_url for Kanton_Bern_dsm_hillshade_wms.geojson and Kanton_Bern_dtm_hillshade_wms.geojson. Same file, but directly hosted on a be.ch server and not geodienste.ch. 