### PR TITLE
bilingual (de/fr) version of licence url

### DIFF
--- a/sources/europe/ch/Kanton_Bern_dsm_hillshade_wms.geojson
+++ b/sources/europe/ch/Kanton_Bern_dsm_hillshade_wms.geojson
@@ -17,7 +17,7 @@
         "min_zoom": 8,
         "id": "Bern-dsm-hillshade-2015",
         "name": "Kanton Bern, Digitales Oberflaechenmodell 50cm, Relief",
-        "license_url": "http://files.be.ch/bve/agi/geoportal/geo/nutzungsbedingungen/agi_dv_nutzungsbedingungen_de.pdf",
+        "license_url": "http://files.be.ch/bve/agi/geoportal/geo/nutzungsbedingungen/agi_dv_nutzungsbedingungen.pdf",
         "privacy_policy_url": "http://www.geo.apps.be.ch/de/rechtliches.html",
         "type": "wms",
         "url": "https://www.geoservice.apps.be.ch/geoservice2/services/a42geo/a42geo_hoehenwms_d_fk/MapServer/WmsServer?LAYERS=GEODB.LDOM50CM_LORELIEF&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"

--- a/sources/europe/ch/Kanton_Bern_dtm_hillshade_wms.geojson
+++ b/sources/europe/ch/Kanton_Bern_dtm_hillshade_wms.geojson
@@ -17,7 +17,7 @@
         "min_zoom": 8,
         "id": "Bern-dtm-hillshade-2015",
         "name": "Kanton Bern, Digitales Terrainmodell 50cm, Relief",
-        "license_url": "http://files.be.ch/bve/agi/geoportal/geo/nutzungsbedingungen/agi_dv_nutzungsbedingungen_de.pdf",
+        "license_url": "http://files.be.ch/bve/agi/geoportal/geo/nutzungsbedingungen/agi_dv_nutzungsbedingungen.pdf",
         "privacy_policy_url": "http://www.geo.apps.be.ch/de/rechtliches.html",
         "type": "wms",
         "url": "https://www.geoservice.apps.be.ch/geoservice2/services/a42geo/a42geo_hoehenwms_d_fk/MapServer/WmsServer?LAYERS=GEODB.LDTM50CM_LTRELIEF&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"


### PR DESCRIPTION
As suggested by @don-vip in https://github.com/osmlab/editor-layer-index/pull/652 it is better to use the bilingual version for the license url. 