### PR TITLE
update au/act/ACTmapi Imagery URL

### DIFF
--- a/sources/oceania/au/act/ACTmapi-Imagery2017.geojson
+++ b/sources/oceania/au/act/ACTmapi-Imagery2017.geojson
@@ -11,10 +11,9 @@
         "license": "CC-BY-4.0",
         "name": "ACTmapi Imagery 2017",
         "available_projections": [
-            "EPSG:4326",
-            "EPSG:28355"
+            "EPSG:3857"
         ],
-        "url": "https://data.actmapi.act.gov.au/arcgis/services/actmapi/imagery2017mga/ImageServer/WMSServer?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=0&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://data.actmapi.act.gov.au/arcgis/rest/services/actmapi/imagery2017mga/ImageServer/exportImage?f=image&format=jpeg&imageSR=3857&bboxSR=3857&bbox={bbox}&size={width},{height}&foo={proj}",
         "start_date": "2017-05",
         "end_date": "2017-05",
         "max_zoom": 21,

--- a/sources/oceania/au/act/ACTmapi-Imagery2018.geojson
+++ b/sources/oceania/au/act/ACTmapi-Imagery2018.geojson
@@ -10,10 +10,9 @@
         "license": "CC-BY-4.0",
         "name": "ACTmapi Imagery 2018",
         "available_projections": [
-            "EPSG:4326",
-            "EPSG:28355"
+            "EPSG:3857"
         ],
-        "url": "https://data.actmapi.act.gov.au/arcgis/services/actmapi/imagery2018mga/ImageServer/WMSServer?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=0&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://data.actmapi.act.gov.au/arcgis/rest/services/actmapi/imagery2018mga/ImageServer/exportImage?f=image&format=jpeg&imageSR=3857&bboxSR=3857&bbox={bbox}&size={width},{height}&foo={proj}",
         "best": true,
         "start_date": "2018-03-19",
         "end_date": "2018-03-19",


### PR DESCRIPTION
closes #590 

Updates to the au/act imagery layer due to accomodate changes made to the service.

JOSM is a bit more powerful and does seem to be able to reproject the source tiles so could use a more efficient approach, but given iD and other consumers can't, this is the method with broadest support.

For the record I did also get mapproxy working, but given this PR seems to work (I tested in JOSM and iD) we probably don't need to worry about setting up a proxy.

```
services:
  demo:
  wmts:
  tms:
    use_grid_names: true
    # origin for /tiles service
    origin: 'nw'

layers:
  - name: actmapi_imagery2018
    title: ACTMapi Imagery 2018
    sources: [actmapi_imagery2018]

caches:
    actmapi_imagery2018:
        grids: [GLOBAL_WEBMERCATOR]
        sources: [actmapi_imagery2018]
        format: image/jpeg
        request_format: image/jpeg                                                                                                                                                                                                             

sources:
  actmapi_imagery2018:
    type: arcgis
    coverage:
        bbox: [662000.0000076389, 6059000.000222229, 719000.0000076389, 6112000.000222229]
        srs: 'EPSG:28355'
    req:
      url: http://data.actmapi.act.gov.au/arcgis/rest/services/actmapi/imagery2018mga/ImageServer
      format: jpg
```
then
`/wmts/actmapi_imagery2018/GLOBAL_WEBMERCATOR/{z}/{x}/{y}.jpeg` 