### PR TITLE
Rename AGIV to current name AIV

### DIFF
--- a/sources/europe/be/AIV10cm.geojson
+++ b/sources/europe/be/AIV10cm.geojson
@@ -413,7 +413,7 @@
     "properties": {
         "attribution": {
             "required": true,
-            "text": "Orthophoto Flanders \u00a9 AGIV"
+            "text": "\u00a9 agentschap Informatie Vlaanderen"
         },
         "available_projections": [
             "EPSG:4326",
@@ -429,9 +429,9 @@
         "end_date": "2015",
         "i18n": true,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/be/BE_GRB_Flanders_TMS.png",
-        "id": "AGIV10cm",
+        "id": "AIV10cm",
         "license_url": "https://download.agiv.be/Producten/Detail?id=1209&title=Orthofotomozaiek_grootschalig_winteropnamen_kleur_2013_2015_Vlaanderen",
-        "name": "AGIV Flanders 2013-2015 aerial imagery 10cm",
+        "name": "AIV Flanders 2013-2015 aerial imagery 10cm",
         "start_date": "2013",
         "type": "wms",
         "url": "https://geoservices.informatievlaanderen.be/raadpleegdiensten/OGW/wms?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=OGWRGB13_15VL&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"

--- a/sources/europe/be/AIV10cm.geojson
+++ b/sources/europe/be/AIV10cm.geojson
@@ -429,7 +429,7 @@
         "end_date": "2015",
         "i18n": true,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/be/BE_GRB_Flanders_TMS.png",
-        "id": "AIV10cm",
+        "id": "AGIV10cm",
         "license_url": "https://download.agiv.be/Producten/Detail?id=1209&title=Orthofotomozaiek_grootschalig_winteropnamen_kleur_2013_2015_Vlaanderen",
         "name": "AIV Flanders 2013-2015 aerial imagery 10cm",
         "start_date": "2013",

--- a/sources/europe/be/BE_GRB_Flanders_TMS.geojson
+++ b/sources/europe/be/BE_GRB_Flanders_TMS.geojson
@@ -465,16 +465,16 @@
     "properties": {
         "attribution": {
             "required": true,
-            "text": "GRB Flanders \u00a9 AGIV"
+            "text": "\u00a9 agentschap Informatie Vlaanderen"
         },
         "best": false,
         "country_code": "BE",
         "i18n": true,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/be/BE_GRB_Flanders_TMS.png",
-        "id": "AGIVFlandersGRB",
+        "id": "AIVFlandersGRB",
         "license_url": "https://www.agiv.be/~/media/agiv/producten/grb/documenten/grb%20open%20data%20licentie.pdf",
         "max_zoom": 21,
-        "name": "AGIV Flanders GRB",
+        "name": "AIV Flanders GRB",
         "type": "tms",
         "url": "https://tile.informatievlaanderen.be/ws/raadpleegdiensten/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=grb_bsk&STYLE=&FORMAT=image/png&tileMatrixSet=GoogleMapsVL&tileMatrix={zoom}&tileRow={y}&tileCol={x}"
     },

--- a/sources/europe/be/BE_GRB_Flanders_TMS.geojson
+++ b/sources/europe/be/BE_GRB_Flanders_TMS.geojson
@@ -471,7 +471,7 @@
         "country_code": "BE",
         "i18n": true,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/be/BE_GRB_Flanders_TMS.png",
-        "id": "AIVFlandersGRB",
+        "id": "AGIVFlandersGRB",
         "license_url": "https://www.agiv.be/~/media/agiv/producten/grb/documenten/grb%20open%20data%20licentie.pdf",
         "max_zoom": 21,
         "name": "AIV Flanders GRB",

--- a/sources/europe/be/BE_OrthoPhoto_Flanders_TMS.geojson
+++ b/sources/europe/be/BE_OrthoPhoto_Flanders_TMS.geojson
@@ -627,7 +627,7 @@
         "country_code": "BE",
         "i18n": true,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/be/BE_GRB_Flanders_TMS.png",
-        "id": "AIV",
+        "id": "AGIV",
         "license_url": "https://download.agiv.be/Producten/Detail?id=1545&title=Orthofotomozaiek_middenschalig_winteropnamen_kleur_meest_recent_Vlaanderen_2016_04",
         "max_zoom": 21,
         "name": "AIV Flanders most recent aerial imagery",

--- a/sources/europe/be/BE_OrthoPhoto_Flanders_TMS.geojson
+++ b/sources/europe/be/BE_OrthoPhoto_Flanders_TMS.geojson
@@ -621,16 +621,16 @@
     "properties": {
         "attribution": {
             "required": true,
-            "text": "Orthophoto Flanders most recent \u00a9 AGIV"
+            "text": "\u00a9 agentschap Informatie Vlaanderen"
         },
         "best": true,
         "country_code": "BE",
         "i18n": true,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/be/BE_GRB_Flanders_TMS.png",
-        "id": "AGIV",
+        "id": "AIV",
         "license_url": "https://download.agiv.be/Producten/Detail?id=1545&title=Orthofotomozaiek_middenschalig_winteropnamen_kleur_meest_recent_Vlaanderen_2016_04",
         "max_zoom": 21,
-        "name": "AGIV Flanders most recent aerial imagery",
+        "name": "AIV Flanders most recent aerial imagery",
         "type": "tms",
         "url": "https://tile.informatievlaanderen.be/ws/raadpleegdiensten/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=omwrgbmrvl&STYLE=&FORMAT=image/png&tileMatrixSet=GoogleMapsVL&tileMatrix={zoom}&tileRow={y}&tileCol={x}"
     },


### PR DESCRIPTION
AGIV is now called [AIV (agentschap Informatie Vlaanderen)](https://overheid.vlaanderen.be/informatie-vlaanderen)