### PR TITLE
wms ortho layers 2013, 2015, 2017 for canton Glarus, Switzerland

### DIFF
--- a/sources/europe/ch/Kanton_Glarus_ortho2013.geojson
+++ b/sources/europe/ch/Kanton_Glarus_ortho2013.geojson
@@ -1,6 +1,5 @@
 {
     "type": "Feature",
-    "bbox": "",
     "properties": {
         "name": "Kanton Glarus Orthophoto 2013",
         "i18n": false,

--- a/sources/europe/ch/Kanton_Glarus_ortho2013.geojson
+++ b/sources/europe/ch/Kanton_Glarus_ortho2013.geojson
@@ -1,0 +1,101 @@
+{
+    "type": "Feature",
+    "bbox": "",
+    "properties": {
+        "name": "Kanton Glarus Orthophoto 2013",
+        "i18n": false,
+        "type": "wms",
+        "url": "https://wms.geo.gl.ch?LAYERS=ch.gl.imagery.orthofoto2013&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "min_zoom": 8,
+        "license_url": "https://www.gl.ch/public/upload/assets/5053/ktgl-ogd-geo-20180601.pdf",
+        "privacy_policy_url": "https://www.gl.ch/services/datenschutzerklaerung.html/18",
+        "id": "KTGL_ORTHO_2013",
+        "description": "",
+        "country_code": "CH",
+        "best": false,
+        "start_date": "2013",
+        "end_date": "2013",
+        "available_projections": [
+            "EPSG:4326",
+            "EPSG:3857",
+            "CRS:84",
+            "EPSG:21781",
+            "EPSG:2056"
+        ],
+        "attribution": {
+            "text": "Kanton Glarus, Luftbild Orthofoto 2013",
+            "required": true
+        }
+    },
+    "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+        [
+            [
+                8.990936279296875,
+                47.18504600164052
+            ],
+            [
+                8.9483642578125,
+                47.13462206077371
+            ],
+            [
+                8.9373779296875,
+                47.05608969226366
+            ],
+            [
+                8.87420654296875,
+                47.033630599264086
+            ],
+            [
+                8.941497802734375,
+                46.93807395606992
+            ],
+            [
+                8.865966796875,
+                46.84422512910668
+            ],
+            [
+                8.864593505859375,
+                46.80851951372979
+            ],
+            [
+                8.91815185546875,
+                46.785956378641224
+            ],
+            [
+                9.045867919921875,
+                46.807579571992385
+            ],
+            [
+                9.244995117187498,
+                46.89680070399431
+            ],
+            [
+                9.261474609375,
+                46.922131240914
+            ],
+            [
+                9.251861572265625,
+                47.018652617389186
+            ],
+            [
+                9.218902587890625,
+                47.04673288595977
+            ],
+            [
+                9.196929931640625,
+                47.12154137528177
+            ],
+            [
+                9.062347412109375,
+                47.150501425705635
+            ],
+            [
+                8.990936279296875,
+                47.18504600164052
+            ]
+        ]
+    ]
+    }
+}

--- a/sources/europe/ch/Kanton_Glarus_ortho2015.geojson
+++ b/sources/europe/ch/Kanton_Glarus_ortho2015.geojson
@@ -1,0 +1,101 @@
+{
+    "type": "Feature",
+    "bbox": "",
+    "properties": {
+        "name": "Kanton Glarus Orthophoto 2015",
+        "i18n": false,
+        "type": "wms",
+        "url": "https://wms.geo.gl.ch?LAYERS=ch.gl.imagery.orthofoto2015&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "min_zoom": 8,
+        "license_url": "https://www.gl.ch/public/upload/assets/5053/ktgl-ogd-geo-20180601.pdf",
+        "privacy_policy_url": "https://www.gl.ch/services/datenschutzerklaerung.html/18",
+        "id": "KTGL_ORTHO_2015",
+        "description": "",
+        "country_code": "CH",
+        "best": false,
+        "start_date": "2015",
+        "end_date": "2015",
+        "available_projections": [
+            "EPSG:4326",
+            "EPSG:3857",
+            "CRS:84",
+            "EPSG:21781",
+            "EPSG:2056"
+        ],
+        "attribution": {
+            "text": "Kanton Glarus, Luftbild Orthofoto 2015",
+            "required": true
+        }
+    },
+    "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+        [
+            [
+                8.990936279296875,
+                47.18504600164052
+            ],
+            [
+                8.9483642578125,
+                47.13462206077371
+            ],
+            [
+                8.9373779296875,
+                47.05608969226366
+            ],
+            [
+                8.87420654296875,
+                47.033630599264086
+            ],
+            [
+                8.941497802734375,
+                46.93807395606992
+            ],
+            [
+                8.865966796875,
+                46.84422512910668
+            ],
+            [
+                8.864593505859375,
+                46.80851951372979
+            ],
+            [
+                8.91815185546875,
+                46.785956378641224
+            ],
+            [
+                9.045867919921875,
+                46.807579571992385
+            ],
+            [
+                9.244995117187498,
+                46.89680070399431
+            ],
+            [
+                9.261474609375,
+                46.922131240914
+            ],
+            [
+                9.251861572265625,
+                47.018652617389186
+            ],
+            [
+                9.218902587890625,
+                47.04673288595977
+            ],
+            [
+                9.196929931640625,
+                47.12154137528177
+            ],
+            [
+                9.062347412109375,
+                47.150501425705635
+            ],
+            [
+                8.990936279296875,
+                47.18504600164052
+            ]
+        ]
+    ]
+    }
+}

--- a/sources/europe/ch/Kanton_Glarus_ortho2015.geojson
+++ b/sources/europe/ch/Kanton_Glarus_ortho2015.geojson
@@ -1,6 +1,5 @@
 {
     "type": "Feature",
-    "bbox": "",
     "properties": {
         "name": "Kanton Glarus Orthophoto 2015",
         "i18n": false,

--- a/sources/europe/ch/Kanton_Glarus_ortho2017.geojson
+++ b/sources/europe/ch/Kanton_Glarus_ortho2017.geojson
@@ -1,0 +1,101 @@
+{
+    "type": "Feature",
+    "bbox": "",
+    "properties": {
+        "name": "Kanton Glarus Orthophoto 2017",
+        "i18n": false,
+        "type": "wms",
+        "url": "https://wms.geo.gl.ch?LAYERS=ch.gl.imagery.orthofoto2017&STYLES=default&FORMAT=image/jpeg&CRS={proj}&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "min_zoom": 8,
+        "license_url": "https://www.gl.ch/public/upload/assets/5053/ktgl-ogd-geo-20180601.pdf",
+        "privacy_policy_url": "https://www.gl.ch/services/datenschutzerklaerung.html/18",
+        "id": "KTGL_ORTHO_2017",
+        "description": "",
+        "country_code": "CH",
+        "best": true,
+        "start_date": "2017",
+        "end_date": "2017",
+        "available_projections": [
+            "EPSG:4326",
+            "EPSG:3857",
+            "CRS:84",
+            "EPSG:21781",
+            "EPSG:2056"
+        ],
+        "attribution": {
+            "text": "Kanton Glarus, Luftbild Orthofoto 2017",
+            "required": true
+        }
+    },
+    "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+        [
+            [
+                8.990936279296875,
+                47.18504600164052
+            ],
+            [
+                8.9483642578125,
+                47.13462206077371
+            ],
+            [
+                8.9373779296875,
+                47.05608969226366
+            ],
+            [
+                8.87420654296875,
+                47.033630599264086
+            ],
+            [
+                8.941497802734375,
+                46.93807395606992
+            ],
+            [
+                8.865966796875,
+                46.84422512910668
+            ],
+            [
+                8.864593505859375,
+                46.80851951372979
+            ],
+            [
+                8.91815185546875,
+                46.785956378641224
+            ],
+            [
+                9.045867919921875,
+                46.807579571992385
+            ],
+            [
+                9.244995117187498,
+                46.89680070399431
+            ],
+            [
+                9.261474609375,
+                46.922131240914
+            ],
+            [
+                9.251861572265625,
+                47.018652617389186
+            ],
+            [
+                9.218902587890625,
+                47.04673288595977
+            ],
+            [
+                9.196929931640625,
+                47.12154137528177
+            ],
+            [
+                9.062347412109375,
+                47.150501425705635
+            ],
+            [
+                8.990936279296875,
+                47.18504600164052
+            ]
+        ]
+    ]
+    }
+}

--- a/sources/europe/ch/Kanton_Glarus_ortho2017.geojson
+++ b/sources/europe/ch/Kanton_Glarus_ortho2017.geojson
@@ -1,6 +1,5 @@
 {
     "type": "Feature",
-    "bbox": "",
     "properties": {
         "name": "Kanton Glarus Orthophoto 2017",
         "i18n": false,


### PR DESCRIPTION
WMS layers for the canton of Glarus, Switzerland, Europe

Licence:
> Daten dürfen nicht-kommerziell und kommerziell genutzt werden.
> Daten dürfen Dritten zu gleichen Bedingungen weitergegeben werden.
> Eine Quellenangabe soll in geeigneter Weise angebracht werden.
>  (konform zur [Open Definition](http://opendefinition.org/od/2.0/de/))

DeepL translation:

> Data may be used non-commercially and commercially.
> Data may be passed on to third parties under the same conditions.
> The source should be indicated in an appropriate manner.

https://www.gl.ch/verwaltung/bau-und-umwelt/hochbau/raumentwicklung-und-geoinformation/geoportal-kanton-glarus.html/808
