### PR TITLE
Berlin areal images: Add 2019

### DIFF
--- a/sources/europe/de/Berlinaerialphotograph2011.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2011.geojson
@@ -16,7 +16,8 @@
       "EPSG:4258"
     ],
     "attribution": {
-      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2011"
+      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2011",
+      "required": true
     },
     "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=367583#p367583"
   },

--- a/sources/europe/de/Berlinaerialphotograph2014.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2014.geojson
@@ -9,7 +9,8 @@
     "end_date": "2014",
     "country_code": "DE",
     "attribution": {
-      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2014"
+      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2014",
+      "required": true
     },
     "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=367583#p367583"
   },

--- a/sources/europe/de/Berlinaerialphotograph2015.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2015.geojson
@@ -9,7 +9,8 @@
     "end_date": "2015-08-03",
     "country_code": "DE",
     "attribution": {
-      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2015"
+      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2015",
+      "required": true
     },
     "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=367583#p367583"
   },

--- a/sources/europe/de/Berlinaerialphotograph2016.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2016.geojson
@@ -9,7 +9,8 @@
     "end_date": "2016-04-03",
     "country_code": "DE",
     "attribution": {
-      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2016"
+      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2016",
+      "required": true
     },
     "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=367583#p367583"
   },

--- a/sources/europe/de/Berlinaerialphotograph2016infrared.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2016infrared.geojson
@@ -9,7 +9,8 @@
     "end_date": "2016-04-03",
     "country_code": "DE",
     "attribution": {
-      "text": "Geoportal Berlin/Digitale Color-Infrarot-Orthophotos 2016"
+      "text": "Geoportal Berlin/Digitale Color-Infrarot-Orthophotos 2016",
+      "required": true
     },
     "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=367583#p367583"
   },

--- a/sources/europe/de/Berlinaerialphotograph2017.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2017.geojson
@@ -9,7 +9,8 @@
     "end_date": "2017-03-28",
     "country_code": "DE",
     "attribution": {
-      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2017"
+      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2017",
+      "required": true
     },
     "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=367583#p367583"
   },

--- a/sources/europe/de/Berlinaerialphotograph2018.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2018.geojson
@@ -10,7 +10,8 @@
     "country_code": "DE",
     "best": true,
     "attribution": {
-      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2018"
+      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2018",
+      "required": true
     },
     "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=367583#p367583"
   },

--- a/sources/europe/de/Berlinaerialphotograph2019.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2019.geojson
@@ -1,18 +1,19 @@
 {
   "type": "Feature",
   "properties": {
-    "id": "Berlin-2018",
-    "name": "Berlin aerial photography 2018",
+    "id": "Berlin-2019",
+    "name": "Berlin aerial photography 2019",
     "type": "tms",
-    "url": "https://tiles.codefor.de/berlin-2018/{zoom}/{x}/{y}.png",
-    "start_date": "2018-03-19",
-    "end_date": "2018-04-07",
+    "url": "https://tiles.codefor.de/berlin-2019/{zoom}/{x}/{y}.png",
+    "start_date": "2019-04-01",
+    "end_date": "2019-04-06",
     "country_code": "DE",
+    "best": true,
     "attribution": {
-      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2018",
+      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2019 (DOP20RGB)",
       "required": true
     },
-    "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=367583#p367583"
+    "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf"
   },
   "geometry": {
     "type": "Polygon",


### PR DESCRIPTION
Add the new data for 2019.

**Licence**
The license URL is a new one, since the license changed this year and there is a new official document.

> Für die Nutzung der Daten ist die Datenlizenz Deutschland - Namensnennung - Version 2.0 anzuwenden. Die Lizenz ist über https://www.govdata.de/dl-de/by-2-0 abrufbar. Der Quellenvermerk gemäß (2) der Lizenz lautet "Geoportal Berlin / Digitale farbige Orthophotos 2019 (DOP20RGB)".

Special document: https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf

**Other links**

- Tiles are cached via https://github.com/jochenklar/berlin-maps/issues/5 / https://berlin.codefor.de/maps/
- Official data doc https://daten.berlin.de/datensaetze/digitale-farbige-orthophotos-2019-dop20rgb-wms
- Mailing list about this license change https://lists.openstreetmap.de/pipermail/berlin/2019-June/001303.html, https://lists.openstreetmap.de/pipermail/berlin/2019-June/001298.html
- News about the new license https://www.stadtentwicklung.berlin.de//geoinformation/aktuelles/index.shtml
  > 29.05.2019
Ablösung der „Nutzungsbestimmungen“ durch die „Datenlizenz Deutschland – Namensnennung – Version 2.0“
Ablösung der „Nutzungsbestimmungen“ durch die „Datenlizenz Deutschland – Namensnennung – Version 2.0“ Als Beitrag zur Vereinheitlichung des Lizenzrechts wird ab 6.6.2019 die Standardlizenz „Datenlizenz Deutschland – Namensnennung – Version 2.0“ für die Geodaten im Zuständigkeitsbereich der Abteilung Geoinformation der Senatsverwaltung für Stadtentwicklung und Wohnen verwendet. Hierbei handelt es sich im Wesentlichen um die unter „Basisdaten/Luftbilder“ zusammengefassten Datensätze und einige Umweltatlasdaten. Damit wird die Abkehr von den bislang verwendeten besonderen Berliner Nutzungsbestimmungen vollzogen. Es ist davon auszugehen, dass die Datenlizenz Deutschland bis auf Einzelfälle auch für die Geodaten im Zuständigkeitsbereich anderer geodatenhaltender Stellen übernommen wird. 
Beide Lizenzen stimmen weitgehend überein. Die Nutzungsbestimmung findet sich wie gewohnt in den Metadaten jedes Datensatzes unter den Informationen (Schaltfläche "I").
Die Lizenz ist über https://www.govdata.de/dl-de/by-2-0 abrufbar.

**Attribution required:true**
This PR also make the attribution required for all berlin images. I am pretty sure this attribute is not used by the consumers but it is more correct to set it than not to …