### PR TITLE
add privacy policy url for Bing

### DIFF
--- a/sources/world/Bing.geojson
+++ b/sources/world/Bing.geojson
@@ -9,6 +9,7 @@
         "license": "COMMERCIAL",
         "permission_osm": "explicit",
         "license_url": "https://wiki.openstreetmap.org/wiki/Bing_Maps",
+        "privacy_policy_url": "https://privacy.microsoft.com/en-gb/privacystatement",
         "min_zoom": 1,
         "max_zoom": 22,
         "no_tile_header": {


### PR DESCRIPTION
fixes tiny part of #690

this url is linked from bottom left ('Privacy and Cookies') text
on Bing Maps, for example from https://www.bing.com/maps?FORM=Z9LH3