### PR TITLE
Verify that layer geometry is a polygon, not that it exists

### DIFF
--- a/scripts/check.py
+++ b/scripts/check.py
@@ -124,9 +124,7 @@ for filename in arguments.path:
         # If we're not global we must have a geometry.
         # The geometry itself is validated by jsonschema
         if 'world' not in filename:
-            try:
-                source['geometry']['type'] == "Polygon"
-            except (TypeError, KeyError):
+            if source['geometry']['type'] != "Polygon":
                 raise ValidationError("{} should have a valid geometry or be global".format(filename))
             if not 'country_code' in source['properties']:
                 raise ValidationError("{} should have a country or be global".format(filename))


### PR DESCRIPTION
Fixed the part of the validation script that ensures each layer’s geometry is a polygon.

/ref https://github.com/osmlab/editor-layer-index/pull/693#issuecomment-522301116