### PR TITLE
update au/act attribution per contract

### DIFF
--- a/sources/oceania/au/act/ACTmapi-Imagery201906.geojson
+++ b/sources/oceania/au/act/ACTmapi-Imagery201906.geojson
@@ -4,7 +4,7 @@
         "id": "ACT201906",
         "attribution": {
             "url": "http://actmapi.act.gov.au/terms.html",
-            "text": "Aerial Imagery from ACTMapi ©ACT Government and Spookfish",
+            "text": "Aerial Imagery from ACTMapi ©ACT Government and Spookfish Australia Pty Ltd",
             "required": true
         },
         "license_url": "https://osmlab.github.io/editor-layer-index/sources/australia/au/act/ACTmapi-Imagery.PDF",


### PR DESCRIPTION
follow up to #702 with correct attribution per contract at https://tenders.act.gov.au/ets/contract/view.do?id=84879

PS. That contract is an interesting read, particularly how the department ensured that the imagery being procured is able to be used for OpenStreetMap. Really well done ACT Government.

Hat tip to @FrakGart for the link.