### PR TITLE
Update BE_OrthoPhoto2018_Brussels_WMS.geojson

### DIFF
--- a/sources/europe/be/BE_OrthoPhoto2018_Brussels_WMS.geojson
+++ b/sources/europe/be/BE_OrthoPhoto2018_Brussels_WMS.geojson
@@ -269,7 +269,6 @@
             "EPSG:4326",
             "EPSG:3857"
         ],
-        "best": true,
         "country_code": "BE",
         "end_date": "2018",
         "i18n": true,


### PR DESCRIPTION
Deprecate 2018 orthophoto for Brussels as best (since 2019 is released).