### PR TITLE
Repairing access to USGS imagery

### DIFF
--- a/sources/north-america/us/USGSImagery.geojson
+++ b/sources/north-america/us/USGSImagery.geojson
@@ -4186,7 +4186,7 @@
         "min_zoom": 12,
         "name": "USGS Imagery",
         "type": "tms",
-        "url": "https://ags-proxy.openstreetmap.us/tiles/{zoom}/{x}/{y}?url=https%3A%2F%2Fbasemap.nationalmap.gov%2Farcgis%2Frest%2Fservices%2FUSGSImageryOnly%2FMapServer",
+        "url": "https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/{zoom}/{y}/{x}",
         "description": "Public domain aerial imagery, mostly NAIP"
     },
     "type": "Feature"


### PR DESCRIPTION
Access was broken because we were requesting the data through an overescaped URI (it should have been `https://ags-proxy.openstreetmap.us/tiles/{zoom}/{x}/{y}?url=https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer` instead of `https://ags-proxy.openstreetmap.us/tiles/{zoom}/{x}/{y}?url=https%3A%2F%2Fbasemap.nationalmap.gov%2Farcgis%2Frest%2Fservices%2FUSGSImageryOnly%2FMapServer`), but the proxy isn’t even necessary, so I’m removing that as well.