### PR TITLE
Add "best" flag for GRAFCAN, since the resolution is better than PNAO spain in the Canary Islands.

### DIFF
--- a/sources/europe/es/GRAFCAN-CanaryIslands.geojson
+++ b/sources/europe/es/GRAFCAN-CanaryIslands.geojson
@@ -10,7 +10,8 @@
         "type": "wms",
         "available_projections": ["EPSG:4326", "EPSG:32628", "EPSG:32627"],
         "name": "GRAFCAN - Canary Islands",
-        "country_code": "ES"
+        "country_code": "ES",
+        "best": true
     },
     "geometry": {
         "type": "Polygon",


### PR DESCRIPTION
"GRAFCAN - Canary Islands" is better than "PNOA Spain" in the Canary islands, since it's much sharper (higher resolution). Issue here with screenshots: https://github.com/osmlab/editor-layer-index/issues/731

I think I got the JSON right, but check to make sure.