### PR TITLE
Fix the from/to JOSM xml format scripts

### DIFF
--- a/scripts/convert_individual.py
+++ b/scripts/convert_individual.py
@@ -108,6 +108,10 @@ for imagery in imageries:
     if description_node:
         properties['description'] = description_node[0].childNodes[0].nodeValue
 
+    category_node = imagery.getElementsByTagName('category')
+    if category_node:
+        properties['category'] = category_node[0].childNodes[0].nodeValue
+
     (bbox, rings) = util.getrings(imagery)
 
     if rings:

--- a/scripts/convert_xml.py
+++ b/scripts/convert_xml.py
@@ -86,6 +86,10 @@ def add_source(source):
     if 'max_zoom' in props:
         max_zoom = ET.SubElement(entry, "max-zoom")
         max_zoom.text = str(props['max_zoom'])
+        
+    if 'category' in props:
+        max_zoom = ET.SubElement(entry, "category")
+        max_zoom.text = str(props['category'])
 
     geometry = source.get('geometry')
     if geometry:


### PR DESCRIPTION
This fixes the scripts from/to JOSM XML format. 

For the record: the convert_indivdual.py script doesn't handle empty XML nodes which the convert_xml.py script produces.

Not sure if we need to do anything about validation at this point in time.