### PR TITLE
 Slovenia road lines: updated copyright year in attribution, fixed links

### DIFF
--- a/sources/europe/si/GURSBuildingoutlines.geojson
+++ b/sources/europe/si/GURSBuildingoutlines.geojson
@@ -718,7 +718,7 @@
         "attribution": {
             "required": true,
             "text": "CC-BY \u00a92020 Geodetska uprava Republike Slovenije (gu.gov.si).",
-            "url": "http://egp.gu.gov.si/"
+            "url": "https://egp.gu.gov.si/"
         },
         "country_code": "SI",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/si/GURSRoadlines.png",

--- a/sources/europe/si/GURSBuildingoutlines.geojson
+++ b/sources/europe/si/GURSBuildingoutlines.geojson
@@ -717,8 +717,8 @@
     "properties": {
         "attribution": {
             "required": true,
-            "text": "CC-BY \u00a92020 Geodetska uprava Republike Slovenije (gu.gov.si).",
-            "url": "https://egp.gu.gov.si/"
+            "text": "CC-BY \u00a92020 Geodetska uprava Republike Slovenije (gov.si).",
+            "url": "https://www.gov.si/drzavni-organi/organi-v-sestavi/geodetska-uprava/"
         },
         "country_code": "SI",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/si/GURSRoadlines.png",

--- a/sources/europe/si/GURSRoadlines.geojson
+++ b/sources/europe/si/GURSRoadlines.geojson
@@ -717,8 +717,8 @@
     "properties": {
         "attribution": {
             "required": true,
-            "text": "CC-BY \u00a92019 Geodetska uprava Republike Slovenije (gu.gov.si).",
-            "url": "http://egp.gu.gov.si/"
+            "text": "CC-BY \u00a92020 Geodetska uprava Republike Slovenije (gu.gov.si).",
+            "url": "https://egp.gu.gov.si/"
         },
         "country_code": "SI",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/si/GURSRoadlines.png",

--- a/sources/europe/si/GURSRoadlines.geojson
+++ b/sources/europe/si/GURSRoadlines.geojson
@@ -717,8 +717,8 @@
     "properties": {
         "attribution": {
             "required": true,
-            "text": "CC-BY \u00a92020 Geodetska uprava Republike Slovenije (gu.gov.si).",
-            "url": "https://egp.gu.gov.si/"
+            "text": "CC-BY \u00a92020 Geodetska uprava Republike Slovenije (gov.si).",
+            "url": "https://www.gov.si/drzavni-organi/organi-v-sestavi/geodetska-uprava/"
         },
         "country_code": "SI",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/si/GURSRoadlines.png",


### PR DESCRIPTION
Updated road line data with fossgis/wms.openstreetmap.de@6d092f2
Fixed attribution links
