### PR TITLE
Add category attribute to most German sources

### DIFF
--- a/sources/europe/de/Bavaria(80cm).geojson
+++ b/sources/europe/de/Bavaria(80cm).geojson
@@ -4,6 +4,7 @@
     "id": "bavaria-80cm",
     "name": "Bavaria (80 cm)",
     "type": "wms",
+    "category": "photo",
     "url": "https://geoservices.bayern.de/wms/v2/ogc_dop80_oa.cgi?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=by_dop80c&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
     "best": true,
     "country_code": "DE",

--- a/sources/europe/de/Bavaria-DOP80.geojson
+++ b/sources/europe/de/Bavaria-DOP80.geojson
@@ -9,6 +9,7 @@
         "min_zoom": 7,
         "max_zoom": 18,
         "type": "tms",
+        "category": "photo",
         "name": "Bavaria DOP 80cm",
         "country_code": "DE",
         "attribution": {

--- a/sources/europe/de/Berlinaerialphotograph2011.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2011.geojson
@@ -4,6 +4,7 @@
     "id": "Berlin-2011",
     "name": "Berlin aerial photography 2011",
     "type": "wms",
+    "category": "historicphoto",
     "url": "https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_luftbild2011_20?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=0&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
     "start_date": "2011",
     "end_date": "2011",

--- a/sources/europe/de/Berlinaerialphotograph2014.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2014.geojson
@@ -4,6 +4,7 @@
     "id": "Berlin-2014",
     "name": "Berlin aerial photography 2014",
     "type": "tms",
+    "category": "historicphoto",
     "url": "https://tiles.codefor.de/berlin-2014/{zoom}/{x}/{y}.png",
     "start_date": "2014",
     "end_date": "2014",

--- a/sources/europe/de/Berlinaerialphotograph2015.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2015.geojson
@@ -4,6 +4,7 @@
     "id": "Berlin-2015",
     "name": "Berlin aerial photography 2015",
     "type": "tms",
+    "category": "historicphoto",
     "url": "https://tiles.codefor.de/berlin-2015/{zoom}/{x}/{y}.png",
     "start_date": "2015-08-02",
     "end_date": "2015-08-03",

--- a/sources/europe/de/Berlinaerialphotograph2016.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2016.geojson
@@ -4,6 +4,7 @@
     "id": "Berlin-2016",
     "name": "Berlin aerial photography 2016",
     "type": "tms",
+    "category": "historicphoto",
     "url": "https://tiles.codefor.de/berlin-2016/{zoom}/{x}/{y}.png",
     "start_date": "2016-04-02",
     "end_date": "2016-04-03",

--- a/sources/europe/de/Berlinaerialphotograph2016infrared.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2016infrared.geojson
@@ -4,6 +4,7 @@
     "id": "Berlin-2016-infrared",
     "name": "Berlin aerial photography 2016 (infrared)",
     "type": "tms",
+    "category": "historicphoto",
     "url": "https://tiles.codefor.de/berlin-2016i/{zoom}/{x}/{y}.png",
     "start_date": "2016-04-02",
     "end_date": "2016-04-03",

--- a/sources/europe/de/Berlinaerialphotograph2017.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2017.geojson
@@ -4,6 +4,7 @@
     "id": "Berlin-2017",
     "name": "Berlin aerial photography 2017",
     "type": "tms",
+    "category": "historicphoto",
     "url": "https://tiles.codefor.de/berlin-2017/{zoom}/{x}/{y}.png",
     "start_date": "2017-03-27",
     "end_date": "2017-03-28",

--- a/sources/europe/de/Berlinaerialphotograph2018.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2018.geojson
@@ -4,6 +4,7 @@
     "id": "Berlin-2018",
     "name": "Berlin aerial photography 2018",
     "type": "tms",
+    "category": "historicphoto",
     "url": "https://tiles.codefor.de/berlin-2018/{zoom}/{x}/{y}.png",
     "start_date": "2018-03-19",
     "end_date": "2018-04-07",

--- a/sources/europe/de/Berlinaerialphotograph2019.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2019.geojson
@@ -4,6 +4,7 @@
     "id": "Berlin-2019",
     "name": "Berlin aerial photography 2019",
     "type": "tms",
+    "category": "photo",
     "url": "https://tiles.codefor.de/berlin-2019/{zoom}/{x}/{y}.png",
     "start_date": "2019-04-01",
     "end_date": "2019-04-06",

--- a/sources/europe/de/DeutscheBahnVzGlinesJanuary2017.geojson
+++ b/sources/europe/de/DeutscheBahnVzGlinesJanuary2017.geojson
@@ -4,6 +4,7 @@
     "id": "db-inspire-2013-11",
     "name": "Deutsche Bahn VzG lines January 2017",
     "type": "wms",
+    "category": "map",
     "url": "https://wms.michreichert.de/vzg-strecken-2017?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=vzg_strecken,station_codes,level_crossings&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
     "start_date": "2013-11",
     "end_date": "2013-11",

--- a/sources/europe/de/DeutscheBahnVzGlinesNov2015.geojson
+++ b/sources/europe/de/DeutscheBahnVzGlinesNov2015.geojson
@@ -4,6 +4,7 @@
     "id": "db-inspire-2015-11",
     "name": "Deutsche Bahn VzG lines Nov 2015",
     "type": "wms",
+    "category": "map",
     "url": "https://wms.michreichert.de/vzg-strecken-2015?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=vzg_strecken,station_codes,level_crossings&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
     "start_date": "2015-11",
     "end_date": "2015-11",

--- a/sources/europe/de/Erlangen2011.geojson
+++ b/sources/europe/de/Erlangen2011.geojson
@@ -17,7 +17,8 @@
             "text": "© Stadt Erlangen | © Aerowest GmbH",
             "required": true
         },
-        "type": "wms"
+        "type": "wms",
+        "category": "historicphoto"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/de/Erlangen2013.geojson
+++ b/sources/europe/de/Erlangen2013.geojson
@@ -17,7 +17,8 @@
             "text": "© Stadt Erlangen | © Aerowest GmbH",
             "required": true
         },
-        "type": "wms"
+        "type": "wms",
+        "category": "historicphoto"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/de/Erlangen2016.geojson
+++ b/sources/europe/de/Erlangen2016.geojson
@@ -4,6 +4,7 @@
         "id": "Erlangen-2016",
         "name": "Erlangen Luftbild (2016 5,0 cm)",
         "type": "tms",
+        "category": "historicphoto",
         "start_date": "2016-03-18",
         "end_date": "2016-03-18",
         "url": "https://osm.rrze.fau.de/protected/YgktSWTTo6HS9nKi/lbe2016/{zoom}/{x}/{y}.jpg",

--- a/sources/europe/de/Erlangen2018.geojson
+++ b/sources/europe/de/Erlangen2018.geojson
@@ -4,6 +4,7 @@
         "id": "Erlangen-2018",
         "name": "Erlangen Luftbild (2018 5,0 cm)",
         "type": "tms",
+        "category": "photo",
         "start_date": "2018-04-09",
         "end_date": "2018-04-09",
         "url": "https://osm.rrze.fau.de/protected/YgktSWTTo6HS9nKi/lbe2018/{zoom}/{x}/{y}.jpg",

--- a/sources/europe/de/Hamburg-20cm.geojson
+++ b/sources/europe/de/Hamburg-20cm.geojson
@@ -4,6 +4,7 @@
     "id": "hamburg-20cm",
     "url": "https://geodienste.hamburg.de/HH_WMS_DOP20?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=1&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
     "type": "wms",
+    "category": "photo",
     "name": "Hamburg (20 cm)",
     "attribution": {
       "url": "https://www.hamburg.de/bsw/landesbetrieb-geoinformation-und-vermessung",

--- a/sources/europe/de/Mainz-Gint-OpenDataWMS.geojson
+++ b/sources/europe/de/Mainz-Gint-OpenDataWMS.geojson
@@ -4,6 +4,7 @@
         "id": "mainzallaerialimageries", 
         "name": "Mainz all aerial imageries", 
         "type": "wms_endpoint", 
+        "category": "photo",
         "url": "https://gint.mainz.de/gint1-cgi/mapserv?map=/data/mapbender-int/umn-www/client/a62/luftbild.map", 
         "country_code": "DE", 
         "available_projections": [

--- a/sources/europe/de/Mainz-Gint-latest.geojson
+++ b/sources/europe/de/Mainz-Gint-latest.geojson
@@ -4,6 +4,7 @@
         "id": "mainzlatestaerialimagery", 
         "name": "Mainz latest aerial imagery", 
         "type": "wms", 
+        "category": "photo",
         "url": "https://geodaten.mainz.de/map/service?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=ortho_2018&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}", 
         "country_code": "DE", 
         "available_projections": [

--- a/sources/europe/de/MetropoleRuhrLuftbilder(10cm).geojson
+++ b/sources/europe/de/MetropoleRuhrLuftbilder(10cm).geojson
@@ -4,6 +4,7 @@
     "id": "Metropole_Ruhr_RVR-DOP10",
     "name": "Metropole Ruhr: Luftbilder (10 cm)",
     "type": "wms",
+    "category": "photo",
     "url": "https://geodaten.metropoleruhr.de/dop/dop?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=DOP&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
     "country_code": "DE",
     "available_projections": [

--- a/sources/europe/de/Munich-latest-aerialimagery60cm.geojson
+++ b/sources/europe/de/Munich-latest-aerialimagery60cm.geojson
@@ -4,6 +4,7 @@
         "id": "MunichLatestAerialImagery", 
         "name": "Munich latest aerial imagery 60cm", 
         "type": "wms", 
+        "category": "historicphoto",
         "url": "https://ogc.muenchen.de/wms/opendata_luftbild?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=bgl0&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}", 
         "start_date": "2015", 
         "end_date": "2015", 

--- a/sources/europe/de/Saxony-latest.geojson
+++ b/sources/europe/de/Saxony-latest.geojson
@@ -525,6 +525,7 @@
         "license_url": "https://wiki.openstreetmap.org/wiki/GeoSN_Open_Data",
         "name": "Saxony latest aerial imagery",
         "type": "wms",
+        "category": "photo",
         "url": "https://geodienste.sachsen.de/wms_geosn_dop-rgb/guest?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=sn_dop_020&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
     },
     "type": "Feature"

--- a/sources/europe/de/Saxonydigitalterrainmodel.geojson
+++ b/sources/europe/de/Saxonydigitalterrainmodel.geojson
@@ -1376,6 +1376,7 @@
         "license_url": "https://wiki.openstreetmap.org/wiki/GeoSN_Open_Data",
         "name": "Saxony digital terrain model",
         "type": "wms_endpoint",
+        "category": "elevation",
         "url": "https://geodienste.sachsen.de/wms_geosn_hoehe/guest"
     },
     "type": "Feature"

--- a/sources/europe/de/Saxonyhistoricalaerialimagery2005.geojson
+++ b/sources/europe/de/Saxonyhistoricalaerialimagery2005.geojson
@@ -546,6 +546,7 @@
         "name": "Saxony historical aerial imagery 2005",
         "start_date": "2005",
         "type": "wms",
+        "category": "historicphoto",
         "url": "https://geodienste.sachsen.de/wms_geosn_dop-2005/guest?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=dop_2005&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
     },
     "type": "Feature"

--- a/sources/europe/de/Saxonyhistoricalaerialimagery2012-2014.geojson
+++ b/sources/europe/de/Saxonyhistoricalaerialimagery2012-2014.geojson
@@ -546,6 +546,7 @@
         "name": "Saxony historical aerial imagery 2012-2014",
         "start_date": "2012",
         "type": "wms",
+        "category": "historicphoto",
         "url": "https://geodienste.sachsen.de/wms_geosn_dop_2012_2014/guest?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=dop_2012_2014_rgb&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
     },
     "type": "Feature"

--- a/sources/europe/de/Saxonytopographicmap.geojson
+++ b/sources/europe/de/Saxonytopographicmap.geojson
@@ -524,6 +524,7 @@
         "license_url": "https://wiki.openstreetmap.org/wiki/GeoSN_Open_Data",
         "name": "Saxony topographic map",
         "type": "wms",
+        "category": "map",
         "url": "https://geodienste.sachsen.de/wms_geosn_dtk-pg-color/guest?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=sn_dtk_pg_color&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
     },
     "type": "Feature"

--- a/sources/europe/de/osmim-imagicode-northsea_s2_2016.geojson
+++ b/sources/europe/de/osmim-imagicode-northsea_s2_2016.geojson
@@ -50,6 +50,7 @@
         "name": "imagico.de: North Sea Coast 2016",
         "start_date": "2016-09-25",
         "type": "tms",
+        "category": "historicphoto",
         "url": "http://imagico.de/map/osmim_tiles.php?layer=northsea_s2_2016&z={zoom}&x={x}&y={-y}"
     },
     "type": "Feature"

--- a/sources/europe/de/osmim-imagicode-northsea_s2_2017.geojson
+++ b/sources/europe/de/osmim-imagicode-northsea_s2_2017.geojson
@@ -46,6 +46,7 @@
         "name": "imagico.de: North Sea Coast 2017",
         "start_date": "2017-06-02",
         "type": "tms",
+        "category": "historicphoto",
         "url": "http://imagico.de/map/osmim_tiles.php?layer=northsea_s2_2017&z={zoom}&x={x}&y={-y}"
     },
     "type": "Feature"

--- a/sources/europe/de/osmim-imagicode-northsea_s2_2018.geojson
+++ b/sources/europe/de/osmim-imagicode-northsea_s2_2018.geojson
@@ -50,6 +50,7 @@
         "name": "imagico.de: North Sea Coast spring 2018",
         "start_date": "2018-05-08",
         "type": "tms",
+        "category": "photo",
         "url": "http://imagico.de/map/osmim_tiles.php?layer=northsea_s2_2018&z={zoom}&x={x}&y={-y}"
     },
     "type": "Feature"


### PR DESCRIPTION
This categorizes most of the German sources.

Notes:

- we currently haven't agreed how to classify IR and NIR imagery
- it would in general be really helpful if the description attribute was present, as is, I'm not quite sure how anybody, not to mention newbies could make sense out of lot of the layers.