### PR TITLE
Repair typo (#783). Tahnk yuo @LucasLarson

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ about which licenses are compatible with this index.
 The 'source' documents for this project are the .geojson files in `sources`. To add
 a new imagery source, add a new file to this directory.
 
-Each source must be a GeoJSON `Feature` and must minimally have `name`, `type`,`url` and `category` properties.
+Each source must be a GeoJSON `Feature` and must minimally have `name`, `type`, `url`, and `category` properties.
 To improve readability, the keys of the GeoJSON document should be ordered consistently: `type`, `properties`, then `geometry`.
 
 We further recommend to add the licence related and `privacy_policy_url` properties.


### PR DESCRIPTION
Add a space and restore a serial comma:

    𝚝𝚢𝚙𝚎, 𝚞𝚛𝚕, and 𝚌𝚊𝚝𝚎𝚐𝚘𝚛𝚢 properties
and not 

    𝚝𝚢𝚙𝚎,𝚞𝚛𝚕 and 𝚌𝚊𝚝𝚎𝚐𝚘𝚛𝚢 properties