### PR TITLE
Add Gothenburg orthophoto

### DIFF
--- a/sources/europe/se/gotenburg_citymap.geojson
+++ b/sources/europe/se/gotenburg_citymap.geojson
@@ -3,7 +3,6 @@
   "properties": {
     "id": "gothenburg-citymap",
     "name": "Gothenburg City map",
-    "best": true,
     "country_code": "SE",
     "i18n": true,
     "description": "The city map is an overview map that describes Gothenburg. It contains general information about land, communications, hydrography, buildings, address numbers and street names, administrative division and other orientation text.",
@@ -22,8 +21,7 @@
     "available_projections": [
       "EPSG:3006",
       "EPSG:3007",
-      "EPSG:3857",
-      "CRS:84"
+      "EPSG:3857"
     ]
   },
   "geometry": {

--- a/sources/europe/se/gothenburg_ortho.geojson
+++ b/sources/europe/se/gothenburg_ortho.geojson
@@ -74,8 +74,7 @@
                 "min_zoom": 6,
                 "name": "Gothenburg Orthophoto",
                 "type": "wms",
-                "url": "https://opengeodata.goteborg.se/services/ortofoto.wms.v1/ows?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=orto&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
-                "valid-georeference": true
+                "url": "https://opengeodata.goteborg.se/services/ortofoto.wms.v1/ows?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=orto&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
             },
             "type": "Feature"
         }

--- a/sources/europe/se/gothenburg_ortho.geojson
+++ b/sources/europe/se/gothenburg_ortho.geojson
@@ -1,0 +1,81 @@
+        {
+            "geometry": {
+                "coordinates": [
+                    [
+                        [
+                            11.71898,
+                            57.54716
+                        ],
+                        [
+                            12.01767,
+                            57.56411
+                        ],
+                        [
+                            11.95862,
+                            57.66818
+                        ],
+                        [
+                            12.09595,
+                            57.68177
+                        ], 
+                        [
+                            12.06574, 
+                            57.73166
+                        ], 
+                        [
+                            12.1138,
+                            57.77086
+                        ], 
+                        [
+                            12.24289,
+                            57.79466
+                        ], 
+                        [
+                            12.16187,
+                            57.86704
+                        ], 
+                        [
+                            11.95519, 
+                            57.86631
+                        ], 
+                        [
+                            11.68534, 
+                            57.72396
+                        ], 
+                        [
+                            11.71898, 
+                            57.54716
+                        ]
+                    ]
+                ],
+                "type": "Polygon"
+            },
+            "properties": {
+                "attribution": {
+                    "required": true,
+                    "text": "\u00a9 Gothenburg municipality, CC0",
+                    "url": "https://catalog.goteborg.se/catalog/6/datasets/892"
+                },
+                "available_projections": [
+                    "EPSG:3006",
+                    "EPSG:3007",
+                    "EPSG:3857"
+                ],
+                "best": true,
+                "category": "photo",
+                "country_code": "SE",
+                "description": "Orthophoto for Gothenburg municipality",
+                "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/97/G%C3%B6teborg_kommunvapen_-_Riksarkivet_Sverige.png/206px-G%C3%B6teborg_kommunvapen_-_Riksarkivet_Sverige.png",
+                "id": "gothenburg-ortho",
+                "i18n": true,
+                "license_url": "https://catalog.goteborg.se/catalog/6/datasets/892",
+                "privacy_policy_url": "https://goteborg.se/wps/portal/start/kommun-o-politik/beslut-insyn-och-rattskerhet/sa-har-behandlar-kommunen-dina-personuppgifter/",
+                "max_zoom": 20,
+                "min_zoom": 6,
+                "name": "Gothenburg Orthophoto",
+                "type": "wms",
+                "url": "https://opengeodata.goteborg.se/services/ortofoto.wms.v1/ows?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=orto&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+                "valid-georeference": true
+            },
+            "type": "Feature"
+        }


### PR DESCRIPTION
Product description: [link](https://catalog.goteborg.se/store/6/resource/2691)
Licence: CC0

Will replace the [Gothenburg city map](https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/se/gotenburg_citymap.geojson) as best in ELI