### PR TITLE
Do not verify ssl connections in case of failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyyaml>=4.2b1
 transifex-client==0.13.7
 colorlog==3.1.4
 requests==2.22.0
+certifi


### PR DESCRIPTION
In https://github.com/osmlab/editor-layer-index/pull/821 verification of a SSL connection fails. For the purpose of ELI, an SSL connection is not strictly required.

With this PR, first, an SSL connection using up-to-date Root Certificates (using the certifi library) is tried.
If this connection fails, as fallback a connection without SSL verification is tried. 

@grischard  I did not extensively test this, please have a careful look at it. 