### PR TITLE
Let OpenRailwayMap overlays be localized

### DIFF
--- a/sources/world/OpenRailwayMap.geojson
+++ b/sources/world/OpenRailwayMap.geojson
@@ -14,7 +14,8 @@
     "privacy_policy_url": "https://www.openrailwaymap.org/en/imprint",
     "icon": "https://www.openrailwaymap.org/img/openrailwaymap-64.png",
     "max_zoom": 20,
-    "description": "Overlay imagery showing railway infrastructure based on OpenStreetMap data"
+    "description": "Overlay imagery showing railway infrastructure based on OpenStreetMap data",
+    "i18n": true
   },
   "geometry": null
 }

--- a/sources/world/OpenRailwayMapMaxspeeds.geojson
+++ b/sources/world/OpenRailwayMapMaxspeeds.geojson
@@ -13,7 +13,8 @@
     "privacy_policy_url": "https://www.openrailwaymap.org/en/imprint",
     "icon": "https://www.openrailwaymap.org/img/openrailwaymap-64.png",
     "max_zoom": 20,
-    "description": "Overlay imagery showing railway speed limits based on OpenStreetMap data"
+    "description": "Overlay imagery showing railway speed limits based on OpenStreetMap data",
+    "i18n": true
   },
   "geometry": null
   }

--- a/sources/world/OpenRailwayMapSignalling.geojson
+++ b/sources/world/OpenRailwayMapSignalling.geojson
@@ -13,7 +13,8 @@
     "privacy_policy_url": "https://www.openrailwaymap.org/en/imprint",
     "icon": "https://www.openrailwaymap.org/img/openrailwaymap-64.png",
     "max_zoom": 20,
-    "description": "Overlay imagery showing railway signals based on OpenStreetMap data"
+    "description": "Overlay imagery showing railway signals based on OpenStreetMap data",
+    "i18n": true
   },
   "geometry": null
   }


### PR DESCRIPTION
This PR adds the `i18n` attribute to the OpenRailwayMap overlays in order to make them localizable.