### PR TITLE
Update list of editors using editor-layer-index

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 The goal of this project is to maintain a canonical representation of the layers available to [OpenStreetMap](https://www.openstreetmap.org/) editors such as:
 
 * [iD](https://github.com/openstreetmap/iD)
-* [Vespucci](http://vespucci.io/)
-* [Go Map!!](https://wiki.openstreetmap.org/wiki/Go_Map!!)
+* [Vespucci](http://vespucci.io/) (historically)
+* [Go Map!!](https://wiki.openstreetmap.org/wiki/Go_Map!!) (historically)
 * [Potlatch 2](https://github.com/systemed/potlatch2) and
 * [JOSM](https://josm.openstreetmap.de/) (optional)
 
@@ -20,7 +20,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for info on how to contribute new sources
 
 ## Using this index
 
-If you are using iD, Potlatch 2, Vespucci or Go Map!!, you are already using this index!
+If you are using iD or Potlatch 2 you are already using this index!
 
 For JOSM you can add `https://osmlab.github.io/editor-layer-index/imagery.xml` to the preference key `imagery.layers.sites` in advanced preferences. You probably want to remove the `https://josm.openstreetmap.de/maps` entry or you'll get the same layers listed twice.
 


### PR DESCRIPTION
- GoMap!! changed to JOSM's index https://github.com/bryceco/GoMap/commit/109cc9c109c20d770dcf12437e116feb4f028f4f
- Vespucci changed to JOSM's index https://github.com/MarcusWolschon/osmeditor4android/commit/552cee76538dc13266e27d0885ba37516b5e1f97

addresses feedback from @Klumbumbus at https://github.com/osmlab/editor-layer-index/issues/586#issuecomment-661756088