### PR TITLE
Add Kanton Zug 2019 Orthophoto

### DIFF
--- a/sources/europe/ch/KantonZug2019wms.geojson
+++ b/sources/europe/ch/KantonZug2019wms.geojson
@@ -22,6 +22,7 @@
         "privacy_policy_url": "https://www.zg.ch/datenschutzerklaerung",
         "type": "wms",
         "min_zoom": 8,
+        "description": "Orthofoto für das Gebiet von Walchwil und Zug (Alpli). Die Befliegung für das genannte Orthofoto fand am 29. März 2019 statt.",
         "category": "photo",
         "url": "https://services.geo.zg.ch/ows/Orthofotos?LAYERS=zg.orthofoto_2019_kt_zg&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
     },

--- a/sources/europe/ch/KantonZug2019wms.geojson
+++ b/sources/europe/ch/KantonZug2019wms.geojson
@@ -1,0 +1,74 @@
+{
+    "type": "Feature",
+    "properties": {
+        "attribution": {
+            "text": "GIS Kanton Zug",
+            "required": true
+        },
+        "available_projections": [
+            "EPSG:3857",
+            "CRS:84",
+            "EPSG:4326",
+            "EPSG:21781",
+            "EPSG:2056"
+        ],
+        "best": true,
+        "country_code": "CH",
+        "start_date": "2019",
+        "end_date": "2019",
+        "id": "Zug-2019-wms",
+        "name": "Kanton Zug (Walchwil und Zug (Alpli)) 2019",
+        "license_url": "https://www.zg.ch/behoerden/direktion-des-innern/geoportal/geodaten-einbinden/wms",
+        "privacy_policy_url": "https://www.zg.ch/datenschutzerklaerung",
+        "type": "wms",
+        "min_zoom": 8,
+        "category": "photo",
+        "url": "https://services.geo.zg.ch/ows/Orthofotos?LAYERS=zg.orthofoto_2019_kt_zg&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    8.493873,
+                    47.115287
+                ],
+                [
+                    8.512098,
+                    47.133727
+                ],
+                [
+                    8.555821,
+                    47.129004
+                ],
+                [
+                    8.586553,
+                    47.079537
+                ],
+                [
+                    8.573994,
+                    47.07633
+                ],
+                [
+                    8.518619,
+                    47.085072
+                ],
+                [
+                    8.518619,
+                    47.085072
+                ],
+                [
+                    8.518386,
+                    47.085318
+                ],
+                [
+                    8.493873,
+                    47.115287
+                ]
+            ]
+        ]
+    }
+}
+
+
+


### PR DESCRIPTION
This PR adds a orthophoto from 2019 that partially covers Kanton of Zug. 

License is the same as the existing sources for Kanton Zug:

> Die hier bereitgestellten Geodatendienste stehen zur freien Nutzung zur Verfügung. Für die Nutzenden bedeutet dies
> 
> Sie dürfen diesen Datensatz sowohl für nicht-kommerzielle wie auch kommerzielle Zwecke nutzen.
> Eine Quellenangabe ist erwünscht ("Quelle: GIS Kanton Zug").
> Der Kanton Zug übernimmt keine Garantie für die Aktualität, Richtigkeit, Vollständigkeit und Genauigkeit der veröffentlichten Daten. Fragen hierzu beantworten die Metadaten auf Geocat sowie die Abteilung Geoinformation.
> 
> (Aus Performancegründen sind nur Requests mit Maximaldimensionen 7500 * 7500 px zugelassen.)

https://www.zg.ch/behoerden/direktion-des-innern/geoportal/geodaten-einbinden/wms

None of the Swisstopo Imagery from [1] looks similar.

[1] https://map.geo.admin.ch/?lang=en&topic=ech&bgLayer=ch.swisstopo.swissimage&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,ch.swisstopo.swissimage-product&layers_opacity=1,1,1,0.8,1&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,1980&catalogNodes=457,527,485&E=2684639.81&N=1215390.74&zoom=8&time=1980
