### PR TITLE
Stadt Zürich: Use ortho 2013 layer without overlay

### DIFF
--- a/sources/europe/ch/Stadt_Zurich_Orthophoto2013_wms.geojson
+++ b/sources/europe/ch/Stadt_Zurich_Orthophoto2013_wms.geojson
@@ -6,7 +6,7 @@
     "type": "wms",
     "license_url": "https://data.stadt-zuerich.ch/dataset/geo_orthofoto_stadt_zuerich_2013",
     "privacy_policy_url": "https://www.stadt-zuerich.ch/portal/de/index/footer/rechtliche_hinweise.html",
-    "url": "https://www.ogd.stadt-zuerich.ch/wms/geoportal/Orthofoto_Stadt_Zuerich_2013?LAYERS=Orthofoto Stadt Z\u00fcrich 2013&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+    "url": "https://www.ogd.stadt-zuerich.ch/wms/geoportal/Orthofoto_Stadt_Zuerich_2013?LAYERS=OP_2013_STZH.tif&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
     "start_date": "2013",
     "end_date": "2013",
     "country_code": "CH",


### PR DESCRIPTION
I noticed the layer I picked in https://github.com/osmlab/editor-layer-index/pull/861 for the orthophoto 2013 has some kind of grid overlay. This is the correct layer without.
