### PR TITLE
Bordeaux 2016 : now hosted by openstreetmap France

### DIFF
--- a/sources/europe/fr/Bordeaux-2016.geojson
+++ b/sources/europe/fr/Bordeaux-2016.geojson
@@ -4,7 +4,7 @@
         "id": "Bordeaux_2016", 
         "name": "Bordeaux 2016", 
         "type": "tms", 
-        "url": "http://tms.bordeaux.inria.fr/bdx2016/{zoom}/{x}/{y}.jpg", 
+        "url": "https://wms.openstreetmap.fr/tms/1.0.0/bordeaux_2016/{zoom}/{x}/{y}", 
         "end_date": "2016",
         "start_date": "2016",
         "country_code": "FR", 


### PR DESCRIPTION
since august 5 2020