### PR TITLE
Fix broken wms url for Berlin aerial photography 2011

### DIFF
--- a/sources/europe/de/Berlinaerialphotograph2011.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2011.geojson
@@ -5,10 +5,11 @@
     "name": "Berlin aerial photography 2011",
     "type": "wms",
     "category": "historicphoto",
-    "url": "https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_luftbild2011_20?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=0&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+    "url": "https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_luftbild2011_20?LAYERS=0&STYLES=default&FORMAT=image/png&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap",
     "start_date": "2011",
     "end_date": "2011",
     "country_code": "DE",
+    "description": "Digitale Orthophotos f\u00fcr das gesamte Berliner Stadtgebiet mit einer Bodenaufl\u00f6sung von 0,20 m im Blattschnitt 2 km x 2 km.",
     "available_projections": [
       "EPSG:25833",
       "EPSG:25832",


### PR DESCRIPTION
The wms url requests image/jpeg, but [the server](https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_luftbild2011_20?SERVICE=WMS&Request=GetCapabilities) only understands image/png