### PR TITLE
Fix sicily 2008, add sicily 2012

### DIFF
--- a/sources/europe/it/Sicily-Italy_2008.geojson
+++ b/sources/europe/it/Sicily-Italy_2008.geojson
@@ -20,7 +20,8 @@
             "required": true
         },
         "license_url": "http://www.sitr.regione.sicilia.it/geoportale/it/Home/Terms",
-        "privacy_policy_url": "http://pti.regione.sicilia.it/portal/page/portal/PIR_PORTALE/PIR_Privacy"
+        "privacy_policy_url": "http://pti.regione.sicilia.it/portal/page/portal/PIR_PORTALE/PIR_Privacy",
+        "category": "photo"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/it/Sicily-Italy_2008.geojson
+++ b/sources/europe/it/Sicily-Italy_2008.geojson
@@ -19,7 +19,8 @@
             "url": "http://www.sitr.regione.sicilia.it",
             "required": true
         },
-        "license_url": "http://www.sitr.regione.sicilia.it/geoportale/it/Home/Terms"
+        "license_url": "http://www.sitr.regione.sicilia.it/geoportale/it/Home/Terms",
+        "privacy_policy_url": "http://pti.regione.sicilia.it/portal/page/portal/PIR_PORTALE/PIR_Privacy"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/it/Sicily-Italy_2008.geojson
+++ b/sources/europe/it/Sicily-Italy_2008.geojson
@@ -2,15 +2,24 @@
     "type": "Feature",
     "properties": {
         "id": "Sicily-ATA2007",
-        "url": "http://map.sitr.regione.sicilia.it/ArcGIS/services/WGS84_F33/Ortofoto_ATA20072008_f33/MapServer/WMSServer?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&Layers=0&STYLES=default&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "http://map.sitr.regione.sicilia.it/gis/services/ATA_2007_2008/Ortofoto_ATA_2007_2008_GB/MapServer/WMSServer?LAYERS=0&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
         "type": "wms",
-        "name": "Sicily - Italy",
+        "name": "Sicily 2008",
         "country_code": "IT",
+        "start_date": "2007",
+        "end_date": "2008",
         "available_projections": [
-            "EPSG:4326",
-            "EPSG:3857",
-            "EPSG:32633"
-        ]
+            "CRS:84",
+            "EPSG:102092",
+            "EPSG:3004",
+            "EPSG:4326"
+        ],
+        "attribution": {
+            "text": "© Regione Siciliana - SITR CC BY-SA 3.0 IT",
+            "url": "http://www.sitr.regione.sicilia.it",
+            "required": true
+        },
+        "license_url": "http://www.sitr.regione.sicilia.it/geoportale/it/Home/Terms"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/it/Sicily-Italy_2012.geojson
+++ b/sources/europe/it/Sicily-Italy_2012.geojson
@@ -1,0 +1,83 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "Sicily-ATA2012",
+        "url": "http://map.sitr.regione.sicilia.it/gis/services/ATA_2012_2013/Ortofoto_ATA_2012_2013/MapServer/WMSServer?LAYERS=0&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "type": "wms",
+        "name": "Sicily 2012",
+        "country_code": "IT",
+        "start_date": "2012",
+        "end_date": "2013",
+        "available_projections": [
+            "CRS:84",
+            "EPSG:102100",
+            "EPSG:3857",
+            "EPSG:4326"
+        ],
+        "attribution": {
+            "text": "© Regione Siciliana - SITR CC BY-SA 3.0 IT",
+            "url": "http://www.sitr.regione.sicilia.it",
+            "required": true
+        },
+        "license_url": "http://www.sitr.regione.sicilia.it/geoportale/it/Home/Terms"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    15.711650848388677,
+                    38.25894105289697
+                ],
+                [
+                    15.237178802490236,
+                    38.81938114846882
+                ],
+                [
+                    14.271240234375,
+                    38.55246141354153
+                ],
+                [
+                    13.150634765625,
+                    38.75408327579141
+                ],
+                [
+                    11.964111328125,
+                    37.97451499202459
+                ],
+                [
+                    12.5244140625,
+                    37.54022177661216
+                ],
+                [
+                    11.87896728515625,
+                    36.796089518731506
+                ],
+                [
+                    12.496948242187498,
+                    35.47409160773029
+                ],
+                [
+                    12.689208984375,
+                    35.46961797120201
+                ],
+                [
+                    14.5733642578125,
+                    36.6640126988417
+                ],
+                [
+                    15.297088623046873,
+                    36.62875385775956
+                ],
+                [
+                    15.398540496826199,
+                    37.42170795425973
+                ],
+                [
+                    15.711650848388677,
+                    38.25894105289697
+                ]
+            ]
+        ]
+    }
+}

--- a/sources/europe/it/Sicily-Italy_2012.geojson
+++ b/sources/europe/it/Sicily-Italy_2012.geojson
@@ -20,7 +20,8 @@
             "required": true
         },
         "license_url": "http://www.sitr.regione.sicilia.it/geoportale/it/Home/Terms",
-        "privacy_policy_url": "http://pti.regione.sicilia.it/portal/page/portal/PIR_PORTALE/PIR_Privacy"
+        "privacy_policy_url": "http://pti.regione.sicilia.it/portal/page/portal/PIR_PORTALE/PIR_Privacy",
+        "category": "photo"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/it/Sicily-Italy_2012.geojson
+++ b/sources/europe/it/Sicily-Italy_2012.geojson
@@ -19,7 +19,8 @@
             "url": "http://www.sitr.regione.sicilia.it",
             "required": true
         },
-        "license_url": "http://www.sitr.regione.sicilia.it/geoportale/it/Home/Terms"
+        "license_url": "http://www.sitr.regione.sicilia.it/geoportale/it/Home/Terms",
+        "privacy_policy_url": "http://pti.regione.sicilia.it/portal/page/portal/PIR_PORTALE/PIR_Privacy"
     },
     "geometry": {
         "type": "Polygon",


### PR DESCRIPTION
- Fix broken url for "Sicily - Italy" source
- Add 2012 source from the same portal

While the WMS server does not indicate any access restrictions, the following page indicates the data is licensed under CC BY-SA 3.0 IT: http://www.sitr.regione.sicilia.it/geoportale/it/Home/Terms

For the ATA 2007-2008 layer, I found the following information in the osm wiki: https://wiki.openstreetmap.org/wiki/Sicilia/Comunit%C3%A0
@cortesimone you seemed to have had contact with the provider.  Is it necessary to reask for permission? If you are not https://wiki.openstreetmap.org/wiki/User:Simone, I apologize. 
 