### PR TITLE
Fix Lombardia - Italy (CTR)

### DIFF
--- a/sources/europe/it/Lombardia-Italy-CTR.geojson
+++ b/sources/europe/it/Lombardia-Italy-CTR.geojson
@@ -7,15 +7,18 @@
             "text": "Regione Lombardia - Infrastruttura per l'informazione territoriale",
             "required": false
         },
-        "name": "Lombardia - Italy (CTR)",
+        "name": "Lombardia - Italy (C.T.R. 10000 - 1980-94)",
         "available_projections": [
-            "EPSG:3857",
+            "CRS:84",
             "EPSG:32632",
             "EPSG:4326"
         ],
-        "url": "https://www.cartografia.regione.lombardia.it/ArcGIS10/services/wms/ctr_wms/MapServer/WMSServer?STYLES=&FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&Layers=0&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "category": "map",
+        "url": "https://www.cartografia.servizirl.it/arcgis/services/wms/ctr_wms/MapServer/WmsServer?LAYERS=C.T.R. 10000 - 1980-94&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
         "country_code": "IT",
-        "type": "wms"
+        "type": "wms",
+        "license_url": "http://www.geoportale.regione.lombardia.it/en/metadati?p_p_id=PublishedMetadata_WAR_geoportalemetadataportlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_PublishedMetadata_WAR_geoportalemetadataportlet_view=editPublishedMetadata&_PublishedMetadata_WAR_geoportalemetadataportlet_uuid={4314F5A6-7099-4DFB-BCE2-F71001E1C615}&_PublishedMetadata_WAR_geoportalemetadataportlet_editType=view&_PublishedMetadata_WAR_geoportalemetadataportlet_fromAsset=true&rid=local",
+        "privacy_policy_url": "http://www.geoportale.regione.lombardia.it/en/privacy"
     },
     "geometry": {
         "type": "Polygon",


### PR DESCRIPTION
- Fix WMS url for Lombardia - Italy (CTR)
- Add privacy policy url
- Add license url

License: IODL 2.0

http://www.geoportale.regione.lombardia.it/en/note-legali

> The IODL 2.0 license allows you to:
> reproduce, distribute publicly, rent out, present and show in public, inform the public, or make the data available to the public, broadcast or re-broadcast in any form, execute, perform, represent, include in collective or composite works, publish, extract or page-layout the information;
> create derivative works and exercise the above rights on it, for example through a combination with other information (mashup).
> On condition that you:
> indicate the source of the information and the name of the Licensor (Regione Lombardia) including, if possible, a copy of the license or a link to it;
> do not reuse the information in such a way that suggests official use or that the Licensor has approved the use being made of the information;
> take all reasonable steps to ensure that the above uses do not deceive anyone or that the information is misunderstood.

The other Lombardia source is also broken: https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/it/Lombardia-Italy-CTRDBT.geojson
The raw data for this source is available under the same license: http://www.geoportale.regione.lombardia.it/en/metadati?p_p_id=PublishedMetadata_WAR_geoportalemetadataportlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_PublishedMetadata_WAR_geoportalemetadataportlet_view=editPublishedMetadata&_PublishedMetadata_WAR_geoportalemetadataportlet_uuid=%7b1CE0E71B-6451-4B5D-8E4D-BC0FF6E0A46F%7d&_PublishedMetadata_WAR_geoportalemetadataportlet_editType=view&_PublishedMetadata_WAR_geoportalemetadataportlet_fromAsset=true&rid=local
But there is no service linked to this dataset.

JOSM uses https://www.cartografia.servizirl.it/arcgis2/services/BaseMap/CTR_DBT/MapServer/WMSServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}, but I did not find a link to his wms server, respectively its license.

