### PR TITLE
Update NZ Aerial Imagery url to use authoritative LINZ Basemaps service

### DIFF
--- a/sources/oceania/nz/LINZ-NZ-Aerial-Imagery.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Aerial-Imagery.geojson
@@ -6,10 +6,11 @@
             "text": "Sourced from LINZ CC-BY 4.0",
             "required": true
         },
-        "license_url": "https://wiki.openstreetmap.org/wiki/Contributors#LINZ",
+        "license_url": "https://wiki.openstreetmap.org/wiki/Contributors#New_Zealand",
         "name": "LINZ NZ Aerial Imagery",
+        "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "photo",
-        "url": "https://map.cazzaserver.com/linz_aerial/{zoom}/{x}/{y}.png",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial/EPSG:3857/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",


### PR DESCRIPTION
LINZ has released a new authoritative basemaps service. This will be updated more frequently than the LINZ Data Service set that the current caching proxy server uses as its source.

If you encounter any issues with this service, please raise them on the issue tracker at https://github.com/linz/basemaps.

Thanks to @Cameron-D for setting up the caching proxy server that was used to reinstate access to aerial imagery sourced from LINZ in the interim (ref: https://github.com/osmlab/editor-layer-index/issues/602).