### PR TITLE
Fix europe / ch /  Kanton Solothurn 2018 DTM

### DIFF
--- a/sources/europe/ch/Kanton_Solothurn_SOGIS_DTM_2018.geojson
+++ b/sources/europe/ch/Kanton_Solothurn_SOGIS_DTM_2018.geojson
@@ -918,9 +918,8 @@
             "EPSG:3857",
             "EPSG:4326"
         ],
-        "best": true,
+        "best": false,
         "country_code": "CH",
-        "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/ch/KantonSolothurn-SOGIS-wms.png",
         "id": "Solothurn-sogis2018-dtm-wms",
         "license_url": "https://wiki.openstreetmap.org/wiki/SOGIS_WMS",
         "min_zoom": 8,

--- a/sources/europe/ch/Kanton_Solothurn_SOGIS_DTM_2018.geojson
+++ b/sources/europe/ch/Kanton_Solothurn_SOGIS_DTM_2018.geojson
@@ -912,11 +912,11 @@
             "text": "Kanton Solothurn, DTM Relief 2018, WMS Solothurn (SOGIS)"
         },
         "available_projections": [
-            "EPSG:21781",
-            "EPSG:4326",
+            "CRS:84",
             "EPSG:2056",
-			"EPSG:3857",
-			"EPSG:84"
+            "EPSG:21781",
+            "EPSG:3857",
+            "EPSG:4326"
         ],
         "best": true,
         "country_code": "CH",
@@ -928,8 +928,9 @@
         "start_date": "2018",
 		"end_date": "2018",
         "type": "wms",
-        "url": "https://geo.so.ch/api/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/jpeg&TRANSPARENT=true&LAYERS=ch.bl.agi.lidar_2018.dtm_relief&STYLES=&SRS={proj}&CRS={proj}&TILED=false&DPI=96&OPACITIES=255&t=675&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
-        "privacy_policy_url": "https://www.so.ch/rechtliches/"
+        "url": "https://geo.so.ch/api/wms?LAYERS=ch.bl.agi.lidar_2018.dtm_relief&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "privacy_policy_url": "https://www.so.ch/rechtliches/",
+        "category": "elevation"
     },
     "type": "Feature"
 }


### PR DESCRIPTION
- Add category
- Fix WMS:
```
Warning: WMS 1.3.0 urls should not contain SRS parameter.
Warning: Layer 'ch.bl.agi.lidar_2018.dtm_relief': CRS 'EPSG:84' not in: EPSG:3857,EPSG:21781,CRS:84,EPSG:4326,EPSG:2056
Warning: Layer 'ch.bl.agi.lidar_2018.dtm_relief': CRS 'CRS:84' not included in available_projections but supported by server.
Info: WMS AccessConstraints: none
Info: WMS Fees: none
```