### PR TITLE
Fix north-america/us/tx  Orthophotos

### DIFF
--- a/sources/north-america/us/tx/Texas_Orthophoto_NAIP_2012_WMS.geojson
+++ b/sources/north-america/us/tx/Texas_Orthophoto_NAIP_2012_WMS.geojson
@@ -1,19 +1,26 @@
 {
     "type": "Feature",
     "properties": {
-        "license_url": "https://wiki.openstreetmap.org/wiki/Potential_Datasources#Texas",
-        "id": "tnris.org",
-        "type": "tms",
-        "name": "Texas Orthophoto",
-        "url": "https://txgi.tnris.org/login/path/ecology-fiona-poem-romeo/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=texas&STYLE=&FORMAT=image/png&tileMatrixSet=0to20&tileMatrix=0to20:{zoom}&tileRow={y}&tileCol={x}",
+        "license_url": "https://data.tnris.org/collection/924d3c6f-9f74-4147-8044-d4025f12eac3",
+        "id": "texas_naip_2012_wms",
+        "type": "wms",
+        "name": "Texas NAIP Imagery 2012",
+        "url": "https://webservices.tnris.org/arcgis/services/NAIP/NAIP12_NC_CIR_1m/ImageServer/WMSServer?LAYERS=0&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
         "start_date": "2012",
-        "max_zoom": 20,
+        "end_date": "2012",
         "country_code": "US",
         "attribution": {
-            "url": "https://tnris.org/maps-and-data/online-mapping-services",
-            "text": "Texas Natural Resources Information System",
-            "required": true
-        }
+            "url": "https://data.tnris.org/collection/924d3c6f-9f74-4147-8044-d4025f12eac3",
+            "text": "United States Department of Agriculture (USDA). Texas NAIP Imagery, 2012-10-01",
+            "required": false
+        },
+        "available_projections": [
+            "CRS:84",
+            "EPSG:3857",
+            "EPSG:4326"
+        ],
+        "category": "historicphoto",
+        "privacy_policy_url": "https://tnris.org/site-policies/#privacy-and-security-policy"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/north-america/us/tx/Texas_Orthophoto_NAIP_2014_WMS.geojson
+++ b/sources/north-america/us/tx/Texas_Orthophoto_NAIP_2014_WMS.geojson
@@ -1,0 +1,132 @@
+{
+    "type": "Feature",
+    "properties": {
+        "license_url": "https://data.tnris.org/collection/e7d2ccee-5288-4257-85bc-e4a2babf91ee",
+        "id": "texas_naip_2014_wms",
+        "type": "wms",
+        "name": "Texas NAIP Imagery 2014",
+        "url": "https://webservices.tnris.org/arcgis/services/NAIP/NAIP14_NC_CIR_1m/ImageServer/WMSServer?LAYERS=0&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "start_date": "2014",
+        "end_date": "2014",
+        "country_code": "US",
+        "attribution": {
+            "url": "https://data.tnris.org/collection/e7d2ccee-5288-4257-85bc-e4a2babf91ee",
+            "text": "United States Department of Agriculture (USDA). Texas NAIP Imagery, 2014-10-31",
+            "required": false
+        },
+        "available_projections": [
+            "CRS:84",
+            "EPSG:3857",
+            "EPSG:4326"
+        ],
+        "category": "historicphoto",
+        "privacy_policy_url": "https://tnris.org/site-policies/#privacy-and-security-policy"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -99.99854390000,
+                    34.56018340000
+                ],
+                [
+                    -95.55654502453,
+                    33.99257450647
+                ],
+                [
+                    -93.89679027134,
+                    33.61039304449
+                ],
+                [
+                    -93.98468089634,
+                    32.04103124103
+                ],
+                [
+                    -93.41613841587,
+                    31.02505269211
+                ],
+                [
+                    -93.74531484297,
+                    29.57268254375
+                ],
+                [
+                    -96.50492070332,
+                    28.23158511753
+                ],
+                [
+                    -97.36942054453,
+                    26.95467452634
+                ],
+                [
+                    -97.04866958924,
+                    25.80530249434
+                ],
+                [
+                    -99.07341778890,
+                    26.32559221139
+                ],
+                [
+                    -100.76599193149,
+                    29.02531904433
+                ],
+                [
+                    -102.33154368930,
+                    29.84338922630
+                ],
+                [
+                    -103.13354564242,
+                    28.88112103669
+                ],
+                [
+                    -104.28878742220,
+                    29.28831477845
+                ],
+                [
+                    -104.72697839350,
+                    29.94815782859
+                ],
+                [
+                    -104.72696778796,
+                    30.23535241761
+                ],
+                [
+                    -106.53450082091,
+                    31.78456647831
+                ],
+                [
+                    -106.75767043939,
+                    31.78457253947
+                ],
+                [
+                    -106.75766067978,
+                    32.04385536686
+                ],
+                [
+                    -106.61848436611,
+                    32.04385159755
+                ],
+                [
+                    -103.11949492759,
+                    32.04375683439
+                ],
+                [
+                    -103.09544343487,
+                    36.50045758762
+                ],
+                [
+                    -103.05798056071,
+                    36.54268645422
+                ],
+                [
+                    -100.00042146824,
+                    36.54222227302
+                ],
+                [
+                    -99.99854390000,
+                    34.56018340000
+                ]
+            ]
+        ]
+    }
+}

--- a/sources/north-america/us/tx/Texas_Orthophoto_NAIP_2016_WMS.geojson
+++ b/sources/north-america/us/tx/Texas_Orthophoto_NAIP_2016_WMS.geojson
@@ -1,0 +1,132 @@
+{
+    "type": "Feature",
+    "properties": {
+        "license_url": "https://data.tnris.org/collection/a40c2ff9-ccac-4c76-99a1-2382c09cf716",
+        "id": "texas_naip_2016_wms",
+        "type": "wms",
+        "name": "Texas NAIP Imagery 2016",
+        "url": "https://webservices.tnris.org/arcgis/services/NAIP/NAIP16_NC_CIR_1m/ImageServer/WMSServer?LAYERS=0&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "start_date": "2016",
+        "end_date": "2016",
+        "country_code": "US",
+        "attribution": {
+            "url": "https://data.tnris.org/collection/a40c2ff9-ccac-4c76-99a1-2382c09cf716",
+            "text": "United States Department of Agriculture (USDA). Texas NAIP Imagery, 2016-12-15",
+            "required": false
+        },
+        "available_projections": [
+            "CRS:84",
+            "EPSG:3857",
+            "EPSG:4326"
+        ],
+        "category": "historicphoto",
+        "privacy_policy_url": "https://tnris.org/site-policies/#privacy-and-security-policy"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -99.99854390000,
+                    34.56018340000
+                ],
+                [
+                    -95.55654502453,
+                    33.99257450647
+                ],
+                [
+                    -93.89679027134,
+                    33.61039304449
+                ],
+                [
+                    -93.98468089634,
+                    32.04103124103
+                ],
+                [
+                    -93.41613841587,
+                    31.02505269211
+                ],
+                [
+                    -93.74531484297,
+                    29.57268254375
+                ],
+                [
+                    -96.50492070332,
+                    28.23158511753
+                ],
+                [
+                    -97.36942054453,
+                    26.95467452634
+                ],
+                [
+                    -97.04866958924,
+                    25.80530249434
+                ],
+                [
+                    -99.07341778890,
+                    26.32559221139
+                ],
+                [
+                    -100.76599193149,
+                    29.02531904433
+                ],
+                [
+                    -102.33154368930,
+                    29.84338922630
+                ],
+                [
+                    -103.13354564242,
+                    28.88112103669
+                ],
+                [
+                    -104.28878742220,
+                    29.28831477845
+                ],
+                [
+                    -104.72697839350,
+                    29.94815782859
+                ],
+                [
+                    -104.72696778796,
+                    30.23535241761
+                ],
+                [
+                    -106.53450082091,
+                    31.78456647831
+                ],
+                [
+                    -106.75767043939,
+                    31.78457253947
+                ],
+                [
+                    -106.75766067978,
+                    32.04385536686
+                ],
+                [
+                    -106.61848436611,
+                    32.04385159755
+                ],
+                [
+                    -103.11949492759,
+                    32.04375683439
+                ],
+                [
+                    -103.09544343487,
+                    36.50045758762
+                ],
+                [
+                    -103.05798056071,
+                    36.54268645422
+                ],
+                [
+                    -100.00042146824,
+                    36.54222227302
+                ],
+                [
+                    -99.99854390000,
+                    34.56018340000
+                ]
+            ]
+        ]
+    }
+}

--- a/sources/north-america/us/tx/Texas_Orthophoto_NAIP_2018_WMS.geojson
+++ b/sources/north-america/us/tx/Texas_Orthophoto_NAIP_2018_WMS.geojson
@@ -1,0 +1,132 @@
+{
+    "type": "Feature",
+    "properties": {
+        "license_url": "https://data.tnris.org/collection/f1d66250-4021-47df-9fe9-9fca286b0f50",
+        "id": "texas_naip_2018_wms",
+        "type": "wms",
+        "name": "Texas NAIP Imagery 2018",
+        "url": "https://webservices.tnris.org/arcgis/services/NAIP/NAIP18_NC_CIR_60cm/ImageServer/WMSServer?LAYERS=0&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "start_date": "2018",
+        "end_date": "2018",
+        "country_code": "US",
+        "attribution": {
+            "url": "https://data.tnris.org/collection/f1d66250-4021-47df-9fe9-9fca286b0f50",
+            "text": "United States Department of Agriculture (USDA). Texas NAIP Imagery, 2018-12-31",
+            "required": false
+        },
+        "available_projections": [
+            "CRS:84",
+            "EPSG:3857",
+            "EPSG:4326"
+        ],
+        "category": "photo",
+        "privacy_policy_url": "https://tnris.org/site-policies/#privacy-and-security-policy"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -99.99854390000,
+                    34.56018340000
+                ],
+                [
+                    -95.55654502453,
+                    33.99257450647
+                ],
+                [
+                    -93.89679027134,
+                    33.61039304449
+                ],
+                [
+                    -93.98468089634,
+                    32.04103124103
+                ],
+                [
+                    -93.41613841587,
+                    31.02505269211
+                ],
+                [
+                    -93.74531484297,
+                    29.57268254375
+                ],
+                [
+                    -96.50492070332,
+                    28.23158511753
+                ],
+                [
+                    -97.36942054453,
+                    26.95467452634
+                ],
+                [
+                    -97.04866958924,
+                    25.80530249434
+                ],
+                [
+                    -99.07341778890,
+                    26.32559221139
+                ],
+                [
+                    -100.76599193149,
+                    29.02531904433
+                ],
+                [
+                    -102.33154368930,
+                    29.84338922630
+                ],
+                [
+                    -103.13354564242,
+                    28.88112103669
+                ],
+                [
+                    -104.28878742220,
+                    29.28831477845
+                ],
+                [
+                    -104.72697839350,
+                    29.94815782859
+                ],
+                [
+                    -104.72696778796,
+                    30.23535241761
+                ],
+                [
+                    -106.53450082091,
+                    31.78456647831
+                ],
+                [
+                    -106.75767043939,
+                    31.78457253947
+                ],
+                [
+                    -106.75766067978,
+                    32.04385536686
+                ],
+                [
+                    -106.61848436611,
+                    32.04385159755
+                ],
+                [
+                    -103.11949492759,
+                    32.04375683439
+                ],
+                [
+                    -103.09544343487,
+                    36.50045758762
+                ],
+                [
+                    -103.05798056071,
+                    36.54268645422
+                ],
+                [
+                    -100.00042146824,
+                    36.54222227302
+                ],
+                [
+                    -99.99854390000,
+                    34.56018340000
+                ]
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
The existing Texas Orthophoto source is broken. I found replacement imagery on https://data.tnris.org/. I'm not sure that the Texas NAIP Imagery 2012 corresponds to the old imagery, thus the new id. 

All sources are licensed under "Public Domain (Creative Commons CC0)" https://creativecommons.org/publicdomain/zero/1.0/

2012: https://data.tnris.org/collection/924d3c6f-9f74-4147-8044-d4025f12eac3
2014: https://data.tnris.org/collection/e7d2ccee-5288-4257-85bc-e4a2babf91ee
2016: https://data.tnris.org/collection/a40c2ff9-ccac-4c76-99a1-2382c09cf716
2018: https://data.tnris.org/collection/f1d66250-4021-47df-9fe9-9fca286b0f50