### PR TITLE
Fix min_zoom for oceania / au / qld sources

### DIFF
--- a/sources/oceania/au/qld/QLDMap_Lite.geojson
+++ b/sources/oceania/au/qld/QLDMap_Lite.geojson
@@ -11,7 +11,7 @@
         "name": "QLDMap Lite",
         "url": "https://gisservices.information.qld.gov.au/arcgis/rest/services/Basemaps/QldMap_Lite/MapServer/WMTS/tile/1.0.0/Basemaps_QldMap_Lite/default/GoogleMapsCompatible/{zoom}/{y}/{x}.png",
         "max_zoom": 18,
-        "min_zoom": 0,
+        "min_zoom": 4,
         "country_code": "AU",
         "type": "tms",
         "id": "QLDMap_Lite",

--- a/sources/oceania/au/qld/QLDMap_Topo.geojson
+++ b/sources/oceania/au/qld/QLDMap_Topo.geojson
@@ -11,7 +11,7 @@
         "name": "QLDMap Topo",
         "url": "https://gisservices.information.qld.gov.au/arcgis/rest/services/Basemaps/QldMap_Topo/MapServer/WMTS/tile/1.0.0/Basemaps_QldMap_Topo/default/GoogleMapsCompatible/{zoom}/{y}/{x}.png",
         "max_zoom": 18,
-        "min_zoom": 0,
+        "min_zoom": 4,
         "country_code": "AU",
         "type": "tms",
         "id": "QLDMap_Topo",


### PR DESCRIPTION
These sources seem only to deliver tiles for zoom level 4 and above. 