### PR TITLE
LPI is no more updating NSW DCS Spatial Services sources

### DIFF
--- a/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-County.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-County.geojson
@@ -1,19 +1,19 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "LPI_NSW_Administrative_Boundaries_NPWS_Reserve",
+        "id": "LPI_NSW_Administrative_Boundaries_County",
         "attribution": {
-            "url": "https://www.spatial.nsw.gov.au/mapping_and_imagery/lpi_web_services",
-            "text": "© Department of Customer Service 2019",
+            "url": "https://www.spatial.nsw.gov.au/products_and_services/web_services/access_web_services",
+            "text": "© State of New South Wales (Spatial Services, a business unit of the Department of Customer Service NSW). For current information go to spatial.nsw.gov.au.",
             "required": true
         },
-        "license_url": "https://wiki.openstreetmap.org/wiki/Attribution/New_South_Wales_Government_Data",
-        "privacy_policy_url": "https://maps.six.nsw.gov.au/js/sixmaps/app/coreTerms.html",
-        "name": "LPI NSW Administrative Boundaries NPWS Reserve",
+        "license_url": "https://wiki.openstreetmap.org/wiki/File:SpatialServices_NSW_OSM_Waiver_completed.pdf",
+        "privacy_policy_url": "https://www.spatial.nsw.gov.au/privacy",
+        "name": "DCS NSW Administrative Boundaries County",
         "available_projections": [
             "EPSG:3857"
         ],
-        "url": "https://maps.six.nsw.gov.au/arcgis/services/public/NSW_Administrative_Boundaries/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS={proj}&BBOX={bbox}&WIDTH={width}&HEIGHT={height}&LAYERS=1&STYLES=&FORMAT=image/png32&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE",
+        "url": "https://maps.six.nsw.gov.au/arcgis/services/public/NSW_Administrative_Boundaries/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS={proj}&BBOX={bbox}&WIDTH={width}&HEIGHT={height}&LAYERS=4&STYLES=&FORMAT=image/png32&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE",
         "overlay": true,
         "max_zoom": 21,
         "min_zoom": 1,

--- a/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-County.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-County.geojson
@@ -11,7 +11,9 @@
         "privacy_policy_url": "https://www.spatial.nsw.gov.au/privacy",
         "name": "DCS NSW Administrative Boundaries County",
         "available_projections": [
-            "EPSG:3857"
+            "EPSG:3857",
+            "EPSG:4326",
+            "CRS:84"
         ],
         "url": "https://maps.six.nsw.gov.au/arcgis/services/public/NSW_Administrative_Boundaries/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS={proj}&BBOX={bbox}&WIDTH={width}&HEIGHT={height}&LAYERS=4&STYLES=&FORMAT=image/png32&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE",
         "overlay": true,

--- a/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-LGA.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-LGA.geojson
@@ -11,7 +11,9 @@
         "privacy_policy_url": "https://www.spatial.nsw.gov.au/privacy",
         "name": "DCS NSW Administrative Boundaries LGA",
         "available_projections": [
-            "EPSG:3857"
+            "EPSG:3857",
+            "EPSG:4326",
+            "CRS:84"
         ],
         "url": "https://maps.six.nsw.gov.au/arcgis/services/public/NSW_Administrative_Boundaries/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS={proj}&BBOX={bbox}&WIDTH={width}&HEIGHT={height}&LAYERS=6&STYLES=&FORMAT=image/png32&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE",
         "overlay": true,

--- a/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-LGA.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-LGA.geojson
@@ -1,19 +1,19 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "LPI_NSW_Administrative_Boundaries_Suburb",
+        "id": "LPI_NSW_Administrative_Boundaries_LGA",
         "attribution": {
-            "url": "https://www.spatial.nsw.gov.au/mapping_and_imagery/lpi_web_services",
-            "text": "© Department of Customer Service 2019",
+            "url": "https://www.spatial.nsw.gov.au/products_and_services/web_services/access_web_services",
+            "text": "© State of New South Wales (Spatial Services, a business unit of the Department of Customer Service NSW). For current information go to spatial.nsw.gov.au.",
             "required": true
         },
-        "license_url": "https://wiki.openstreetmap.org/wiki/Attribution/New_South_Wales_Government_Data",
-        "privacy_policy_url": "https://maps.six.nsw.gov.au/js/sixmaps/app/coreTerms.html",
-        "name": "LPI NSW Administrative Boundaries Suburb",
+        "license_url": "https://wiki.openstreetmap.org/wiki/File:SpatialServices_NSW_OSM_Waiver_completed.pdf",
+        "privacy_policy_url": "https://www.spatial.nsw.gov.au/privacy",
+        "name": "DCS NSW Administrative Boundaries LGA",
         "available_projections": [
             "EPSG:3857"
         ],
-        "url": "https://maps.six.nsw.gov.au/arcgis/services/public/NSW_Administrative_Boundaries/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS={proj}&BBOX={bbox}&WIDTH={width}&HEIGHT={height}&LAYERS=7&STYLES=&FORMAT=image/png32&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE",
+        "url": "https://maps.six.nsw.gov.au/arcgis/services/public/NSW_Administrative_Boundaries/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS={proj}&BBOX={bbox}&WIDTH={width}&HEIGHT={height}&LAYERS=6&STYLES=&FORMAT=image/png32&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE",
         "overlay": true,
         "max_zoom": 21,
         "min_zoom": 1,

--- a/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-NPWSReserve.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-NPWSReserve.geojson
@@ -1,19 +1,19 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "LPI_NSW_Administrative_Boundaries_County",
+        "id": "LPI_NSW_Administrative_Boundaries_NPWS_Reserve",
         "attribution": {
-            "url": "https://www.spatial.nsw.gov.au/mapping_and_imagery/lpi_web_services",
-            "text": "© Department of Customer Service 2019",
+            "url": "https://www.spatial.nsw.gov.au/products_and_services/web_services/access_web_services",
+            "text": "© State of New South Wales (Spatial Services, a business unit of the Department of Customer Service NSW). For current information go to spatial.nsw.gov.au.",
             "required": true
         },
-        "license_url": "https://wiki.openstreetmap.org/wiki/Attribution/New_South_Wales_Government_Data",
-        "privacy_policy_url": "https://maps.six.nsw.gov.au/js/sixmaps/app/coreTerms.html",
-        "name": "LPI NSW Administrative Boundaries County",
+        "license_url": "https://wiki.openstreetmap.org/wiki/File:SpatialServices_NSW_OSM_Waiver_completed.pdf",
+        "privacy_policy_url": "https://www.spatial.nsw.gov.au/privacy",
+        "name": "DCS NSW Administrative Boundaries NPWS Reserve",
         "available_projections": [
             "EPSG:3857"
         ],
-        "url": "https://maps.six.nsw.gov.au/arcgis/services/public/NSW_Administrative_Boundaries/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS={proj}&BBOX={bbox}&WIDTH={width}&HEIGHT={height}&LAYERS=4&STYLES=&FORMAT=image/png32&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE",
+        "url": "https://maps.six.nsw.gov.au/arcgis/services/public/NSW_Administrative_Boundaries/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS={proj}&BBOX={bbox}&WIDTH={width}&HEIGHT={height}&LAYERS=1&STYLES=&FORMAT=image/png32&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE",
         "overlay": true,
         "max_zoom": 21,
         "min_zoom": 1,

--- a/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-NPWSReserve.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-NPWSReserve.geojson
@@ -11,7 +11,9 @@
         "privacy_policy_url": "https://www.spatial.nsw.gov.au/privacy",
         "name": "DCS NSW Administrative Boundaries NPWS Reserve",
         "available_projections": [
-            "EPSG:3857"
+            "EPSG:3857",
+            "EPSG:4326",
+            "CRS:84"
         ],
         "url": "https://maps.six.nsw.gov.au/arcgis/services/public/NSW_Administrative_Boundaries/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS={proj}&BBOX={bbox}&WIDTH={width}&HEIGHT={height}&LAYERS=1&STYLES=&FORMAT=image/png32&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE",
         "overlay": true,

--- a/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-Parish.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-Parish.geojson
@@ -3,13 +3,13 @@
     "properties": {
         "id": "LPI_NSW_Administrative_Boundaries_Parish",
         "attribution": {
-            "url": "https://www.spatial.nsw.gov.au/mapping_and_imagery/lpi_web_services",
-            "text": "© Department of Customer Service 2019",
+            "url": "https://www.spatial.nsw.gov.au/products_and_services/web_services/access_web_services",
+            "text": "© State of New South Wales (Spatial Services, a business unit of the Department of Customer Service NSW). For current information go to spatial.nsw.gov.au.",
             "required": true
         },
-        "license_url": "https://wiki.openstreetmap.org/wiki/Attribution/New_South_Wales_Government_Data",
-        "privacy_policy_url": "https://maps.six.nsw.gov.au/js/sixmaps/app/coreTerms.html",
-        "name": "LPI NSW Administrative Boundaries Parish",
+        "license_url": "https://wiki.openstreetmap.org/wiki/File:SpatialServices_NSW_OSM_Waiver_completed.pdf",
+        "privacy_policy_url": "https://www.spatial.nsw.gov.au/privacy",
+        "name": "DCS NSW Administrative Boundaries Parish",
         "available_projections": [
             "EPSG:3857"
         ],

--- a/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-Parish.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-Parish.geojson
@@ -11,7 +11,9 @@
         "privacy_policy_url": "https://www.spatial.nsw.gov.au/privacy",
         "name": "DCS NSW Administrative Boundaries Parish",
         "available_projections": [
-            "EPSG:3857"
+            "EPSG:3857",
+            "EPSG:4326",
+            "CRS:84"
         ],
         "url": "https://maps.six.nsw.gov.au/arcgis/services/public/NSW_Administrative_Boundaries/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS={proj}&BBOX={bbox}&WIDTH={width}&HEIGHT={height}&LAYERS=3&STYLES=&FORMAT=image/png32&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE",
         "overlay": true,

--- a/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-StateForest.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-StateForest.geojson
@@ -3,13 +3,13 @@
     "properties": {
         "id": "LPI_NSW_Administrative_Boundaries_StateForest",
         "attribution": {
-            "url": "https://www.spatial.nsw.gov.au/mapping_and_imagery/lpi_web_services",
-            "text": "© Department of Customer Service 2019",
+            "url": "https://www.spatial.nsw.gov.au/products_and_services/web_services/access_web_services",
+            "text": "© State of New South Wales (Spatial Services, a business unit of the Department of Customer Service NSW). For current information go to spatial.nsw.gov.au.",
             "required": true
         },
-        "license_url": "https://wiki.openstreetmap.org/wiki/Attribution/New_South_Wales_Government_Data",
-        "privacy_policy_url": "https://maps.six.nsw.gov.au/js/sixmaps/app/coreTerms.html",
-        "name": "LPI NSW Administrative Boundaries State Forest",
+        "license_url": "https://wiki.openstreetmap.org/wiki/File:SpatialServices_NSW_OSM_Waiver_completed.pdf",
+        "privacy_policy_url": "https://www.spatial.nsw.gov.au/privacy",
+        "name": "DCS NSW Administrative Boundaries State Forest",
         "available_projections": [
             "EPSG:3857"
         ],

--- a/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-StateForest.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-StateForest.geojson
@@ -11,7 +11,9 @@
         "privacy_policy_url": "https://www.spatial.nsw.gov.au/privacy",
         "name": "DCS NSW Administrative Boundaries State Forest",
         "available_projections": [
-            "EPSG:3857"
+            "EPSG:3857",
+            "EPSG:4326",
+            "CRS:84"
         ],
         "url": "https://maps.six.nsw.gov.au/arcgis/services/public/NSW_Administrative_Boundaries/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS={proj}&BBOX={bbox}&WIDTH={width}&HEIGHT={height}&LAYERS=2&STYLES=&FORMAT=image/png32&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE",
         "overlay": true,

--- a/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-Suburb.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-Suburb.geojson
@@ -11,7 +11,9 @@
         "privacy_policy_url": "https://www.spatial.nsw.gov.au/privacy",
         "name": "DCS NSW Administrative Boundaries Suburb",
         "available_projections": [
-            "EPSG:3857"
+            "EPSG:3857",
+            "EPSG:4326",
+            "CRS:84"
         ],
         "url": "https://maps.six.nsw.gov.au/arcgis/services/public/NSW_Administrative_Boundaries/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS={proj}&BBOX={bbox}&WIDTH={width}&HEIGHT={height}&LAYERS=7&STYLES=&FORMAT=image/png32&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE",
         "overlay": true,

--- a/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-Suburb.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-AdministrativeBoundaries-Suburb.geojson
@@ -1,19 +1,19 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "LPI_NSW_Administrative_Boundaries_LGA",
+        "id": "LPI_NSW_Administrative_Boundaries_Suburb",
         "attribution": {
-            "url": "https://www.spatial.nsw.gov.au/mapping_and_imagery/lpi_web_services",
-            "text": "© Department of Customer Service 2019",
+            "url": "https://www.spatial.nsw.gov.au/products_and_services/web_services/access_web_services",
+            "text": "© State of New South Wales (Spatial Services, a business unit of the Department of Customer Service NSW). For current information go to spatial.nsw.gov.au.",
             "required": true
         },
-        "license_url": "https://wiki.openstreetmap.org/wiki/Attribution/New_South_Wales_Government_Data",
-        "privacy_policy_url": "https://maps.six.nsw.gov.au/js/sixmaps/app/coreTerms.html",
-        "name": "LPI NSW Administrative Boundaries LGA",
+        "license_url": "https://wiki.openstreetmap.org/wiki/File:SpatialServices_NSW_OSM_Waiver_completed.pdf",
+        "privacy_policy_url": "https://www.spatial.nsw.gov.au/privacy",
+        "name": "DCS NSW Administrative Boundaries Suburb",
         "available_projections": [
             "EPSG:3857"
         ],
-        "url": "https://maps.six.nsw.gov.au/arcgis/services/public/NSW_Administrative_Boundaries/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS={proj}&BBOX={bbox}&WIDTH={width}&HEIGHT={height}&LAYERS=6&STYLES=&FORMAT=image/png32&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE",
+        "url": "https://maps.six.nsw.gov.au/arcgis/services/public/NSW_Administrative_Boundaries/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS={proj}&BBOX={bbox}&WIDTH={width}&HEIGHT={height}&LAYERS=7&STYLES=&FORMAT=image/png32&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE",
         "overlay": true,
         "max_zoom": 21,
         "min_zoom": 1,

--- a/sources/oceania/au/nsw/NSW-WebServices-BaseMap.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-BaseMap.geojson
@@ -2,13 +2,13 @@
     "type": "Feature",
     "properties": {
         "attribution": {
-            "url": "https://www.spatial.nsw.gov.au/mapping_and_imagery/lpi_web_services",
-            "text": "© Department of Customer Service 2019",
+            "url": "https://www.spatial.nsw.gov.au/products_and_services/web_services/access_web_services",
+            "text": "© State of New South Wales (Spatial Services, a business unit of the Department of Customer Service NSW). For current information go to spatial.nsw.gov.au.",
             "required": true
         },
-        "license_url": "https://wiki.openstreetmap.org/wiki/Attribution/New_South_Wales_Government_Data",
-        "privacy_policy_url": "https://maps.six.nsw.gov.au/js/sixmaps/app/coreTerms.html",
-        "name": "LPI NSW Base Map",
+        "license_url": "https://wiki.openstreetmap.org/wiki/File:SpatialServices_NSW_OSM_Waiver_completed.pdf",
+        "privacy_policy_url": "https://www.spatial.nsw.gov.au/privacy",
+        "name": "DCS NSW Base Map",
         "url": "https://maps.six.nsw.gov.au/arcgis/rest/services/public/NSW_Base_Map/MapServer/tile/{zoom}/{y}/{x}",
         "max_zoom": 19,
         "min_zoom": 1,

--- a/sources/oceania/au/nsw/NSW-WebServices-BaseMap.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-BaseMap.geojson
@@ -15,7 +15,8 @@
         "country_code": "AU",
         "type": "tms",
         "id": "NSW_LPI_BaseMap",
-        "icon": "https://www.spatial.nsw.gov.au/__data/assets/file/0017/224801/favicon.ico"
+        "icon": "https://www.spatial.nsw.gov.au/__data/assets/file/0017/224801/favicon.ico",
+        "category": "map"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/oceania/au/nsw/NSW-WebServices-Imagery-Dates.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-Imagery-Dates.geojson
@@ -2,21 +2,24 @@
     "type": "Feature",
     "properties": {
         "attribution": {
-            "url": "https://www.spatial.nsw.gov.au/mapping_and_imagery/lpi_web_services",
-            "text": "© Department of Customer Service 2019",
+            "url": "https://www.spatial.nsw.gov.au/products_and_services/web_services/access_web_services",
+            "text": "© State of New South Wales (Spatial Services, a business unit of the Department of Customer Service NSW). For current information go to spatial.nsw.gov.au.",
             "required": true
         },
-        "license_url": "https://wiki.openstreetmap.org/wiki/Attribution/New_South_Wales_Government_Data",
-        "privacy_policy_url": "https://maps.six.nsw.gov.au/js/sixmaps/app/coreTerms.html",
-        "name": "LPI NSW Imagery",
-        "url": "https://maps.six.nsw.gov.au/arcgis/rest/services/public/NSW_Imagery/MapServer/tile/{zoom}/{y}/{x}",
+        "license_url": "https://wiki.openstreetmap.org/wiki/File:SpatialServices_NSW_OSM_Waiver_completed.pdf",
+        "privacy_policy_url": "https://www.spatial.nsw.gov.au/privacy",
+        "name": "DCS NSW Imagery Dates",
+        "id": "NSW_LPI_Imagery_Dates",
+        "available_projections": [
+            "EPSG:3857"
+        ],
+        "url": "https://maps.six.nsw.gov.au/arcgis/services/public/NSW_Imagery_Dates/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS={proj}&BBOX={bbox}&WIDTH={width}&HEIGHT={height}&LAYERS=0&STYLES=&FORMAT=image/png32&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE",
+        "overlay": true,
         "max_zoom": 21,
-        "min_zoom": 1,
         "country_code": "AU",
-        "type": "tms",
-        "id": "NSW_LPI_Imagery",
-        "best": true,
-        "icon": "https://www.spatial.nsw.gov.au/__data/assets/file/0017/224801/favicon.ico"
+        "type": "wms",
+        "icon": "https://www.spatial.nsw.gov.au/__data/assets/file/0017/224801/favicon.ico",
+        "category": "other"
     },
     "geometry": {
         "type": "Polygon",
@@ -378,14 +381,14 @@
                 ],
                 [
                     159.28993462443,
-                    -31.79392907620
+                    -31.7939290762
                 ],
                 [
                     159.26156758189,
                     -31.79394731412
                 ],
                 [
-                    159.22681688190,
+                    159.2268168819,
                     -31.75482783648
                 ],
                 [
@@ -432,7 +435,7 @@
                 ],
                 [
                     159.08205270231,
-                    -31.49566607950
+                    -31.4956660795
                 ],
                 [
                     159.08563613355,
@@ -460,7 +463,7 @@
                 ],
                 [
                     159.09537255228,
-                    -31.51723518950
+                    -31.5172351895
                 ],
                 [
                     159.10276472032,
@@ -483,11 +486,11 @@
                     -31.54888007941
                 ],
                 [
-                    159.12617504060,
+                    159.1261750406,
                     -31.55795868718
                 ],
                 [
-                    159.11840736330,
+                    159.1184073633,
                     -31.56323356505
                 ],
                 [
@@ -496,10 +499,10 @@
                 ],
                 [
                     159.11149799287,
-                    -31.55983281140
+                    -31.5598328114
                 ],
                 [
-                    159.11153554380,
+                    159.1115355438,
                     -31.60157944557
                 ],
                 [
@@ -560,7 +563,7 @@
                 ],
                 [
                     159.04846608102,
-                    -31.55793126070
+                    -31.5579312607
                 ],
                 [
                     159.04237210214,
@@ -568,14 +571,14 @@
                 ],
                 [
                     159.04533326089,
-                    -31.55037952770
+                    -31.5503795277
                 ],
                 [
                     159.03782844007,
                     -31.54763204463
                 ],
                 [
-                    159.03801619470,
+                    159.0380161947,
                     -31.54722974415
                 ],
                 [
@@ -604,7 +607,7 @@
                 ],
                 [
                     159.02305483282,
-                    -31.52934847960
+                    -31.5293484796
                 ],
                 [
                     159.03783916891,

--- a/sources/oceania/au/nsw/NSW-WebServices-Imagery-Dates.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-Imagery-Dates.geojson
@@ -11,7 +11,9 @@
         "name": "DCS NSW Imagery Dates",
         "id": "NSW_LPI_Imagery_Dates",
         "available_projections": [
-            "EPSG:3857"
+            "EPSG:3857",
+            "EPSG:4326",
+            "CRS:84"
         ],
         "url": "https://maps.six.nsw.gov.au/arcgis/services/public/NSW_Imagery_Dates/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS={proj}&BBOX={bbox}&WIDTH={width}&HEIGHT={height}&LAYERS=0&STYLES=&FORMAT=image/png32&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE",
         "overlay": true,

--- a/sources/oceania/au/nsw/NSW-WebServices-Imagery.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-Imagery.geojson
@@ -2,24 +2,21 @@
     "type": "Feature",
     "properties": {
         "attribution": {
-            "url": "https://www.spatial.nsw.gov.au/mapping_and_imagery/lpi_web_services",
-            "text": "© Department of Customer Service 2019",
+            "url": "https://www.spatial.nsw.gov.au/products_and_services/web_services/access_web_services",
+            "text": "© State of New South Wales (Spatial Services, a business unit of the Department of Customer Service NSW). For current information go to spatial.nsw.gov.au.",
             "required": true
         },
-        "license_url": "https://wiki.openstreetmap.org/wiki/Attribution/New_South_Wales_Government_Data",
-        "privacy_policy_url": "https://maps.six.nsw.gov.au/js/sixmaps/app/coreTerms.html",
-        "name": "LPI NSW Imagery Dates",
-        "id": "NSW_LPI_Imagery_Dates",
-        "available_projections": [
-            "EPSG:3857"
-        ],
-        "url": "https://maps.six.nsw.gov.au/arcgis/services/public/NSW_Imagery_Dates/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS={proj}&BBOX={bbox}&WIDTH={width}&HEIGHT={height}&LAYERS=0&STYLES=&FORMAT=image/png32&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE",
-        "overlay": true,
+        "license_url": "https://wiki.openstreetmap.org/wiki/File:SpatialServices_NSW_OSM_Waiver_completed.pdf",
+        "privacy_policy_url": "https://www.spatial.nsw.gov.au/privacy",
+        "name": "DCS NSW Imagery",
+        "url": "https://maps.six.nsw.gov.au/arcgis/rest/services/public/NSW_Imagery/MapServer/tile/{zoom}/{y}/{x}",
         "max_zoom": 21,
+        "min_zoom": 1,
         "country_code": "AU",
-        "type": "wms",
-        "icon": "https://www.spatial.nsw.gov.au/__data/assets/file/0017/224801/favicon.ico",
-        "category": "other"
+        "type": "tms",
+        "id": "NSW_LPI_Imagery",
+        "best": true,
+        "icon": "https://www.spatial.nsw.gov.au/__data/assets/file/0017/224801/favicon.ico"
     },
     "geometry": {
         "type": "Polygon",
@@ -381,14 +378,14 @@
                 ],
                 [
                     159.28993462443,
-                    -31.7939290762
+                    -31.79392907620
                 ],
                 [
                     159.26156758189,
                     -31.79394731412
                 ],
                 [
-                    159.2268168819,
+                    159.22681688190,
                     -31.75482783648
                 ],
                 [
@@ -435,7 +432,7 @@
                 ],
                 [
                     159.08205270231,
-                    -31.4956660795
+                    -31.49566607950
                 ],
                 [
                     159.08563613355,
@@ -463,7 +460,7 @@
                 ],
                 [
                     159.09537255228,
-                    -31.5172351895
+                    -31.51723518950
                 ],
                 [
                     159.10276472032,
@@ -486,11 +483,11 @@
                     -31.54888007941
                 ],
                 [
-                    159.1261750406,
+                    159.12617504060,
                     -31.55795868718
                 ],
                 [
-                    159.1184073633,
+                    159.11840736330,
                     -31.56323356505
                 ],
                 [
@@ -499,10 +496,10 @@
                 ],
                 [
                     159.11149799287,
-                    -31.5598328114
+                    -31.55983281140
                 ],
                 [
-                    159.1115355438,
+                    159.11153554380,
                     -31.60157944557
                 ],
                 [
@@ -563,7 +560,7 @@
                 ],
                 [
                     159.04846608102,
-                    -31.5579312607
+                    -31.55793126070
                 ],
                 [
                     159.04237210214,
@@ -571,14 +568,14 @@
                 ],
                 [
                     159.04533326089,
-                    -31.5503795277
+                    -31.55037952770
                 ],
                 [
                     159.03782844007,
                     -31.54763204463
                 ],
                 [
-                    159.0380161947,
+                    159.03801619470,
                     -31.54722974415
                 ],
                 [
@@ -607,7 +604,7 @@
                 ],
                 [
                     159.02305483282,
-                    -31.5293484796
+                    -31.52934847960
                 ],
                 [
                     159.03783916891,

--- a/sources/oceania/au/nsw/NSW-WebServices-Imagery.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-Imagery.geojson
@@ -16,7 +16,8 @@
         "type": "tms",
         "id": "NSW_LPI_Imagery",
         "best": true,
-        "icon": "https://www.spatial.nsw.gov.au/__data/assets/file/0017/224801/favicon.ico"
+        "icon": "https://www.spatial.nsw.gov.au/__data/assets/file/0017/224801/favicon.ico",
+        "category": "photo"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/oceania/au/nsw/NSW-WebServices-TopographicMap.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-TopographicMap.geojson
@@ -15,7 +15,8 @@
         "country_code": "AU",
         "type": "tms",
         "id": "NSW_LPI_TopographicMap",
-        "icon": "https://www.spatial.nsw.gov.au/__data/assets/file/0017/224801/favicon.ico"
+        "icon": "https://www.spatial.nsw.gov.au/__data/assets/file/0017/224801/favicon.ico",
+        "category": "map"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/oceania/au/nsw/NSW-WebServices-TopographicMap.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-TopographicMap.geojson
@@ -2,13 +2,13 @@
     "type": "Feature",
     "properties": {
         "attribution": {
-            "url": "https://www.spatial.nsw.gov.au/mapping_and_imagery/lpi_web_services",
-            "text": "© Department of Customer Service 2019",
+            "url": "https://www.spatial.nsw.gov.au/products_and_services/web_services/access_web_services",
+            "text": "© State of New South Wales (Spatial Services, a business unit of the Department of Customer Service NSW). For current information go to spatial.nsw.gov.au.",
             "required": true
         },
-        "license_url": "https://wiki.openstreetmap.org/wiki/Attribution/New_South_Wales_Government_Data",
-        "privacy_policy_url": "https://maps.six.nsw.gov.au/js/sixmaps/app/coreTerms.html",
-        "name": "LPI NSW Topographic Map",
+        "license_url": "https://wiki.openstreetmap.org/wiki/File:SpatialServices_NSW_OSM_Waiver_completed.pdf",
+        "privacy_policy_url": "https://www.spatial.nsw.gov.au/privacy",
+        "name": "DCS NSW Topographic Map",
         "url": "https://maps.six.nsw.gov.au/arcgis/rest/services/public/NSW_Topo_Map/MapServer/tile/{zoom}/{y}/{x}",
         "max_zoom": 16,
         "min_zoom": 1,


### PR DESCRIPTION
- Update attribution text per https://www.spatial.nsw.gov.au/copyright
- Update attribution URL to current link
- Update license URL to new LWG waiver completed
- Update privacy policy URL
- Update names to remove reference to LPI which does not exist and not used by the source anymore, 

will ask local community for feedback before merging