### PR TITLE
Fix europe / pl / Gliwice

### DIFF
--- a/sources/europe/pl/GliwiceBuildings.geojson
+++ b/sources/europe/pl/GliwiceBuildings.geojson
@@ -4,34 +4,22 @@
         "id": "Gliwice-buildings",
         "name": "Gliwice: Buildings",
         "type": "wms",
-        "url": "http://185.60.246.14:9090/isdp/gs/ows?FORMAT=image/png&transparent=true&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=default:EGIB_budynek,default:pkt_adr&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "http://msip-mapa.um.gliwice.pl:9090/isdp/gs/ows/wms?LAYERS=default:EGIB_budynek,default:pkt_adr&STYLES=&FORMAT=image/png&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&TRANSPARENT=True",
         "country_code": "PL",
+        "overlay": true,
         "available_projections": [
-            "EPSG:3329",
-            "EPSG:3333",
-            "EPSG:3330",
-            "EPSG:3331",
-            "EPSG:3334",
-            "EPSG:3332",
-            "EPSG:3120",
-            "EPSG:2172",
-            "EPSG:2173",
-            "EPSG:2174",
+            "CRS:84",
             "EPSG:2175",
-            "EPSG:2180",
-            "EPSG:2176",
             "EPSG:2177",
-            "EPSG:2178",
-            "EPSG:2179",
-            "EPSG:32633",
-            "EPSG:32634",
-            "EPSG:32635",
-            "EPSG:4326"
+            "EPSG:2180",
+            "EPSG:4326",
+            "EPSG:900913"
         ],
         "attribution": {
             "text": "Urząd Miasta Gliwice"
         },
-        "category": "other"
+        "category": "other",
+        "privacy_policy_url": "https://gliwice.eu/polityka-prywatnosci"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/pl/GliwiceBuildings.geojson
+++ b/sources/europe/pl/GliwiceBuildings.geojson
@@ -19,7 +19,8 @@
             "text": "Urząd Miasta Gliwice"
         },
         "category": "other",
-        "privacy_policy_url": "https://gliwice.eu/polityka-prywatnosci"
+        "privacy_policy_url": "https://gliwice.eu/polityka-prywatnosci",
+        "license_url": "https://msip.gliwice.eu/portal-planistyczny/otwarte-dane.html"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/pl/GliwiceOrthophotomap2013(aerialimage).geojson
+++ b/sources/europe/pl/GliwiceOrthophotomap2013(aerialimage).geojson
@@ -21,7 +21,8 @@
         },
         "min_zoom": 14,
         "category": "historicphoto",
-        "privacy_policy_url": "https://gliwice.eu/polityka-prywatnosci"
+        "privacy_policy_url": "https://gliwice.eu/polityka-prywatnosci",
+        "license_url": "https://msip.gliwice.eu/portal-planistyczny/otwarte-dane.html"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/pl/GliwiceOrthophotomap2017(aerialimage).geojson
+++ b/sources/europe/pl/GliwiceOrthophotomap2017(aerialimage).geojson
@@ -21,7 +21,8 @@
         },
         "min_zoom": 14,
         "category": "historicphoto",
-        "privacy_policy_url": "https://gliwice.eu/polityka-prywatnosci"
+        "privacy_policy_url": "https://gliwice.eu/polityka-prywatnosci",
+        "license_url": "https://msip.gliwice.eu/portal-planistyczny/otwarte-dane.html"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/pl/GliwiceOrthophotomap2017(aerialimage).geojson
+++ b/sources/europe/pl/GliwiceOrthophotomap2017(aerialimage).geojson
@@ -1,12 +1,12 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "Gliwice-2013",
-        "name": "Gliwice: Orthophotomap 2013 (aerial image)",
+        "id": "Gliwice-2017",
+        "name": "Gliwice: Orthophotomap 2017 (aerial image)",
         "type": "wms",
-        "url": "http://msip-mapa.um.gliwice.pl:9090/isdp/gs/ows/wms2?LAYERS=default:orto_2013&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
-        "start_date": "2013",
-        "end_date": "2013",
+        "url": "http://msip-mapa.um.gliwice.pl:9090/isdp/gs/ows/wms2?LAYERS=default:orto_2017&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "start_date": "2017",
+        "end_date": "2017",
         "country_code": "PL",
         "available_projections": [
             "CRS:84",

--- a/sources/europe/pl/GliwiceOrthophotomap2018(aerialimage).geojson
+++ b/sources/europe/pl/GliwiceOrthophotomap2018(aerialimage).geojson
@@ -21,7 +21,8 @@
         },
         "min_zoom": 14,
         "category": "historicphoto",
-        "privacy_policy_url": "https://gliwice.eu/polityka-prywatnosci"
+        "privacy_policy_url": "https://gliwice.eu/polityka-prywatnosci",
+        "license_url": "https://msip.gliwice.eu/portal-planistyczny/otwarte-dane.html"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/pl/GliwiceOrthophotomap2018(aerialimage).geojson
+++ b/sources/europe/pl/GliwiceOrthophotomap2018(aerialimage).geojson
@@ -1,12 +1,12 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "Gliwice-2013",
-        "name": "Gliwice: Orthophotomap 2013 (aerial image)",
+        "id": "Gliwice-2018",
+        "name": "Gliwice: Orthophotomap 2018 (aerial image)",
         "type": "wms",
-        "url": "http://msip-mapa.um.gliwice.pl:9090/isdp/gs/ows/wms2?LAYERS=default:orto_2013&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
-        "start_date": "2013",
-        "end_date": "2013",
+        "url": "http://msip-mapa.um.gliwice.pl:9090/isdp/gs/ows/wms2?LAYERS=default:orto_2018&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "start_date": "2018",
+        "end_date": "2018",
         "country_code": "PL",
         "available_projections": [
             "CRS:84",

--- a/sources/europe/pl/GliwiceOrthophotomap2020(aerialimage).geojson
+++ b/sources/europe/pl/GliwiceOrthophotomap2020(aerialimage).geojson
@@ -21,7 +21,8 @@
         },
         "min_zoom": 14,
         "category": "photo",
-        "privacy_policy_url": "https://gliwice.eu/polityka-prywatnosci"
+        "privacy_policy_url": "https://gliwice.eu/polityka-prywatnosci",
+        "license_url": "https://msip.gliwice.eu/portal-planistyczny/otwarte-dane.html"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/pl/GliwiceOrthophotomap2020(aerialimage).geojson
+++ b/sources/europe/pl/GliwiceOrthophotomap2020(aerialimage).geojson
@@ -1,12 +1,12 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "Gliwice-2013",
-        "name": "Gliwice: Orthophotomap 2013 (aerial image)",
+        "id": "Gliwice-2020",
+        "name": "Gliwice: Orthophotomap 2020 (aerial image)",
         "type": "wms",
-        "url": "http://msip-mapa.um.gliwice.pl:9090/isdp/gs/ows/wms2?LAYERS=default:orto_2013&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
-        "start_date": "2013",
-        "end_date": "2013",
+        "url": "http://msip-mapa.um.gliwice.pl:9090/isdp/gs/ows/wms2?LAYERS=default:orto_2020&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "start_date": "2020",
+        "end_date": "2020",
         "country_code": "PL",
         "available_projections": [
             "CRS:84",
@@ -20,7 +20,7 @@
             "text": "Urząd Miasta Gliwice"
         },
         "min_zoom": 14,
-        "category": "historicphoto",
+        "category": "photo",
         "privacy_policy_url": "https://gliwice.eu/polityka-prywatnosci"
     },
     "geometry": {


### PR DESCRIPTION
The following sources are not working at the moment:
- Gliwice: Buildings
- Gliwice: Orthophotomap 2013 (aerial image)

This PR updates the two sources and adds orthophotos for the year 2017, 2018 and 2020.

License:
The WMS servers are linked from https://msip.gliwice.eu/portal-planistyczny/uslugi-danych-przestrzennych.html 
This is a subpage for https://msip.gliwice.eu/portal-planistyczny/otwarte-dane.html

Which states: 

> OPEN DATA is complete and up-to-date information on local spatial development plans in force in the city of Gliwice. They are shared:
> 
> in an effective way (e.g. using dedicated portals and services) - and also used for any purpose, including economic purposes;
> in a permanent manner and without unnecessary barriers;
> without limitation, e.g. due to the rights, privileges of a specific group of people, etc .;
> in as little processed as possible (not in aggregated and modified form);
> in open data formats;
> in such a form that they can be read automatically.
> Openness of public data is the basis for modern city management, especially for:
> 
> transparent decision making,
> social participation,
> creating new values ​​and innovations by entrepreneurs and non-governmental organizations (including new services).

@jendrusk @Asteliks Could you have a look at this PR? Especially if there are more license terms that I have missed. The translation sounds good (any purpose, including economic purposes, without limitation), although it mentions nothing about attribution.
