### PR TITLE
Limit WMS sync bot to osmlab/editor-layer-index repository

### DIFF
--- a/.github/workflows/sync_wms.yml
+++ b/.github/workflows/sync_wms.yml
@@ -2,14 +2,13 @@ name: ELI WMS sync
 
 on:
   schedule:
-    - cron: '0 0 * * 6'
+    - cron: '0 0 * * 0'
 
 jobs:
-  build:
+  wms_sync:
     name: WMS_sync_cron
-
+    if: github.repository == 'osmlab/editor-layer-index'
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
I did not consider that this bot would run on every fork of Eli (as github actions unlike e.g. travis are activated by default).

This PR should limit the bot to this repository. Also, the scheduled time is moved to Sunday 00:00,  as then it should run when it's weekend all over the world.
