### PR TITLE
Filter deprecated EPSG codes in wms_sync

### DIFF
--- a/requirements-wms_sync.txt
+++ b/requirements-wms_sync.txt
@@ -1,9 +1,10 @@
 pillow==8.0.1
-aiohttp==3.7.1
-aiofiles==0.5.0
-imagehash==4.1.0
+aiohttp==3.7.3
+aiofiles==0.6.0
+imagehash==4.2.0
 mercantile==1.1.6
 shapely==1.7.1
-pyproj==2.6.1.post1
+pyproj==3.0.0.post1
 jsonschema==3.2.0
-colorlog==4.4.0
+colorlog==4.6.2
+pyproj==3.0.0.post1


### PR DESCRIPTION
JOSM seems to ignore deprecated EPSG codes, let's do the same here.