### PR TITLE
imagico.de osmim 2020-02 update

### DIFF
--- a/sources/antarctica/osmim-imagicode-LC80691332019346LGN01.geojson
+++ b/sources/antarctica/osmim-imagicode-LC80691332019346LGN01.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ 30.0359, -72.8301 ], [ 30.0359, -72.2248 ], [ 32.3599, -72.2248 ], [ 32.3595, -72.7236 ], [ 31.7635, -72.8301 ], [ 30.0359, -72.8301 ] ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "category": "photo",
+        "country_code": "AQ",
+        "description": "Landsat 8 evening image of the Belgica Mountains showing a different lighting compared to the daytime image (true color)",
+        "end_date": "2019-12-12",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
+        "id": "osmim-imagicode-LC80691332019346LGN01",
+        "license_url": "https://imagico.de/map/osmim_tiles.php",
+        "name": "imagico.de: Belgica Mountains evening",
+        "max_zoom": 12,
+        "permission_osm": "explicit",
+        "privacy_policy_url": "http://services.imagico.de/privacy.php",
+        "start_date": "2019-12-12",
+        "type": "tms",
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=LC80691332019346LGN01&z={zoom}&x={x}&y={-y}"
+    },
+    "type": "Feature"
+}

--- a/sources/antarctica/osmim-imagicode-S2B_R005_S7X_20200303T061749.geojson
+++ b/sources/antarctica/osmim-imagicode-S2B_R005_S7X_20200303T061749.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ 19.143, -75.7213 ], [ 19.143, -75.667 ], [ 37.6211, -67.6112 ], [ 37.6431, -67.6029 ], [ 43.949, -67.6029 ], [ 44.9157, -67.6196 ], [ 44.9157, -68.1489 ], [ 43.5974, -69.3432 ], [ 42.4549, -70.2905 ], [ 40.7631, -71.5399 ], [ 39.0273, -72.667 ], [ 36.94, -73.8499 ], [ 35.9073, -74.379 ], [ 35.0505, -74.7878 ], [ 33.9079, -75.298 ], [ 32.9192, -75.7104 ], [ 32.8753, -75.7213 ], [ 19.143, -75.7213 ] ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "category": "photo",
+        "country_code": "AQ",
+        "description": "Recent Sentinel-2 image of the Yamato or Queen Fabiola Mountains, Belgica Mountains and Lützow-Holm Bay (true color)",
+        "end_date": "2020-03-03",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
+        "id": "osmim-imagicode-S2B_R005_S7X_20200303T061749",
+        "license_url": "https://imagico.de/map/osmim_tiles.php",
+        "name": "imagico.de: Yamato/Queen Fabiola Mountains",
+        "max_zoom": 13,
+        "permission_osm": "explicit",
+        "privacy_policy_url": "http://services.imagico.de/privacy.php",
+        "start_date": "2020-03-03",
+        "type": "tms",
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=S2B_R005_S7X_20200303T061749&z={zoom}&x={x}&y={-y}"
+    },
+    "type": "Feature"
+}

--- a/sources/antarctica/osmim-imagicode-S2B_R043_S67_20190301T220359.geojson
+++ b/sources/antarctica/osmim-imagicode-S2B_R043_S67_20190301T220359.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ 164.9206, -67.7033 ], [ 162.6383, -67.6861 ], [ 162.2717, -66.7722 ], [ 162.2717, -66.6441 ], [ 162.6365, -66.3561 ], [ 165.2182, -66.3561 ], [ 165.2306, -67.7031 ], [ 164.9206, -67.7033 ] ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "category": "photo",
+        "country_code": "AQ",
+        "description": "Mostly cloud free image, including southern Young Island (true color)",
+        "end_date": "2019-03-01",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
+        "id": "osmim-imagicode-S2B_R043_S67_20190301T220359",
+        "license_url": "https://imagico.de/map/osmim_tiles.php",
+        "name": "imagico.de: Sturge Island/Buckle Island March 2019",
+        "max_zoom": 13,
+        "permission_osm": "explicit",
+        "privacy_policy_url": "http://services.imagico.de/privacy.php",
+        "start_date": "2019-03-01",
+        "type": "tms",
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=S2B_R043_S67_20190301T220359&z={zoom}&x={x}&y={-y}"
+    },
+    "type": "Feature"
+}

--- a/sources/antarctica/osmim-imagicode-S2B_R057_S7X_20190210T213409.geojson
+++ b/sources/antarctica/osmim-imagicode-S2B_R057_S7X_20190210T213409.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ 155.6745, -78.1324 ], [ 154.3999, -77.8999 ], [ 152.6637, -77.5638 ], [ 148.1367, -76.6121 ], [ 147.3236, -76.4175 ], [ 147.3236, -76.3035 ], [ 164.2451, -70.2968 ], [ 172.9257, -70.2968 ], [ 172.9257, -70.62 ], [ 172.9037, -70.6419 ], [ 171.6291, -71.5664 ], [ 170.5742, -72.2685 ], [ 168.4865, -73.5088 ], [ 167.7173, -73.9215 ], [ 166.3109, -74.6239 ], [ 164.9484, -75.2461 ], [ 163.2782, -75.9347 ], [ 161.5421, -76.5764 ], [ 159.806, -77.1553 ], [ 158.3995, -77.5827 ], [ 157.0809, -77.955 ], [ 156.3997, -78.1324 ], [ 155.6745, -78.1324 ] ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "category": "photo",
+        "country_code": "AQ",
+        "description": "Recent Sentinel-2 image of the eastern part of Victoria Land, some clouds at the coast (true color)",
+        "end_date": "2019-02-10",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
+        "id": "osmim-imagicode-S2B_R057_S7X_20190210T213409",
+        "license_url": "https://imagico.de/map/osmim_tiles.php",
+        "name": "imagico.de: Victoria Land east",
+        "max_zoom": 13,
+        "permission_osm": "explicit",
+        "privacy_policy_url": "http://services.imagico.de/privacy.php",
+        "start_date": "2019-02-10",
+        "type": "tms",
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=S2B_R057_S7X_20190210T213409&z={zoom}&x={x}&y={-y}"
+    },
+    "type": "Feature"
+}

--- a/sources/antarctica/osmim-imagicode-S2B_R061_S7X_20200226T041719.geojson
+++ b/sources/antarctica/osmim-imagicode-S2B_R061_S7X_20200226T041719.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ 65.0308, -74.6419 ], [ 63.6901, -74.4193 ], [ 60.8329, -73.9098 ], [ 58.0416, -73.3842 ], [ 57.4921, -73.2708 ], [ 57.4921, -73.0992 ], [ 67.8441, -67.6029 ], [ 73.9322, -67.6029 ], [ 75.0092, -67.6196 ], [ 75.0092, -68.2467 ], [ 74.9652, -68.2955 ], [ 74.0201, -69.1561 ], [ 72.9651, -70.0441 ], [ 72.1739, -70.6643 ], [ 71.075, -71.4626 ], [ 69.8442, -72.2892 ], [ 68.4155, -73.1503 ], [ 67.0968, -73.8794 ], [ 66.0858, -74.3897 ], [ 65.5583, -74.6419 ], [ 65.0308, -74.6419 ] ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "category": "photo",
+        "country_code": "AQ",
+        "description": "Recent Sentinel-2 image of the western part of the Lambert Glacier region (true color)",
+        "end_date": "2020-02-26",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
+        "id": "osmim-imagicode-S2B_R061_S7X_20200226T041719",
+        "license_url": "https://imagico.de/map/osmim_tiles.php",
+        "name": "imagico.de: Lambert Glacier west",
+        "max_zoom": 13,
+        "permission_osm": "explicit",
+        "privacy_policy_url": "http://services.imagico.de/privacy.php",
+        "start_date": "2020-02-26",
+        "type": "tms",
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=S2B_R061_S7X_20200226T041719&z={zoom}&x={x}&y={-y}"
+    },
+    "type": "Feature"
+}

--- a/sources/antarctica/osmim-imagicode-S2B_R071_S72_20200216T210519.geojson
+++ b/sources/antarctica/osmim-imagicode-S2B_R071_S72_20200216T210519.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ 165.8304, -73.0695 ], [ 170.0783, -71.1973 ], [ 171.2715, -71.2021 ], [ 171.2727, -72.9873 ], [ 169.691, -73.0299 ], [ 168.0541, -73.0608 ], [ 167.3965, -73.0695 ], [ 165.8304, -73.0695 ] ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "category": "photo",
+        "country_code": "AQ",
+        "description": "Recent Sentinel-2 image of Cape Adare and parts of northern Victoria Land (true color)",
+        "end_date": "2020-02-16",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
+        "id": "osmim-imagicode-S2B_R071_S72_20200216T210519",
+        "license_url": "https://imagico.de/map/osmim_tiles.php",
+        "name": "imagico.de: Cape Adare",
+        "max_zoom": 13,
+        "permission_osm": "explicit",
+        "privacy_policy_url": "http://services.imagico.de/privacy.php",
+        "start_date": "2020-02-16",
+        "type": "tms",
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=S2B_R071_S72_20200216T210519&z={zoom}&x={x}&y={-y}"
+    },
+    "type": "Feature"
+}

--- a/sources/antarctica/osmim-imagicode-S2B_R075_S7X_20190113T034629.geojson
+++ b/sources/antarctica/osmim-imagicode-S2B_R075_S7X_20190113T034629.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ 68.8748, -75.7213 ], [ 68.3695, -75.6398 ], [ 66.436, -75.2924 ], [ 62.2835, -74.491 ], [ 61.6244, -74.3494 ], [ 61.6244, -74.3019 ], [ 75.3343, -67.6196 ], [ 76.7844, -67.6029 ], [ 82.9143, -67.6029 ], [ 82.9143, -67.8775 ], [ 82.8924, -67.9023 ], [ 81.0468, -69.5821 ], [ 79.8164, -70.5701 ], [ 78.4762, -71.5469 ], [ 77.07, -72.4695 ], [ 75.3343, -73.4916 ], [ 74.1479, -74.1226 ], [ 73.0054, -74.6837 ], [ 72.1046, -75.096 ], [ 70.6325, -75.7158 ], [ 70.6105, -75.7213 ], [ 68.8748, -75.7213 ] ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "category": "photo",
+        "country_code": "AQ",
+        "description": "Recent Sentinel-2 image of the western part of the Lambert Glacier region and the eastern Prydz Bay coast (true color)",
+        "end_date": "2019-01-13",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
+        "id": "osmim-imagicode-S2B_R075_S7X_20190113T034629",
+        "license_url": "https://imagico.de/map/osmim_tiles.php",
+        "name": "imagico.de: Lambert Glacier east",
+        "max_zoom": 13,
+        "permission_osm": "explicit",
+        "privacy_policy_url": "http://services.imagico.de/privacy.php",
+        "start_date": "2019-01-13",
+        "type": "tms",
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=S2B_R075_S7X_20190113T034629&z={zoom}&x={x}&y={-y}"
+    },
+    "type": "Feature"
+}

--- a/sources/antarctica/osmim-imagicode-S2B_R095_S6X_20200119T131859.geojson
+++ b/sources/antarctica/osmim-imagicode-S2B_R095_S6X_20200119T131859.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ -68.9971, -73.0747 ], [ -72.0726, -72.1629 ], [ -72.3142, -70.6072 ], [ -72.3142, -70.2615 ], [ -64.7792, -64.9187 ], [ -58.2107, -64.9187 ], [ -58.2107, -65.3528 ], [ -59.5727, -66.8905 ], [ -60.4075, -67.7459 ], [ -61.484, -68.7709 ], [ -62.6922, -69.8191 ], [ -64.0103, -70.8465 ], [ -65.7018, -72.0346 ], [ -67.3714, -73.0683 ], [ -67.3934, -73.0747 ], [ -68.9971, -73.0747 ] ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "category": "photo",
+        "country_code": "AQ",
+        "description": "Recent mostly cloud free Sentinel-2 image of the central and southern part of the Antarctic Peninsula including the eastern part of Alexander Island (true color)",
+        "end_date": "2020-01-19",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
+        "id": "osmim-imagicode-S2B_R095_S6X_20200119T131859",
+        "license_url": "https://imagico.de/map/osmim_tiles.php",
+        "name": "imagico.de: Antarctic Peninsula",
+        "max_zoom": 13,
+        "permission_osm": "explicit",
+        "privacy_policy_url": "http://services.imagico.de/privacy.php",
+        "start_date": "2020-01-19",
+        "type": "tms",
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=S2B_R095_S6X_20200119T131859&z={zoom}&x={x}&y={-y}"
+    },
+    "type": "Feature"
+}

--- a/sources/antarctica/osmim-imagicode-S2B_R129_S67_20200121T222409.geojson
+++ b/sources/antarctica/osmim-imagicode-S2B_R129_S67_20200121T222409.geojson
@@ -2,7 +2,7 @@
     "geometry": {
         "type": "Polygon",
         "coordinates": [
-            [ [ -168.2544, 53.8749 ], [ -168.2544, 54.0213 ], [ -167.8591, 54.0213 ], [ -167.8591, 53.8749 ], [ -168.2544, 53.8749 ] ]
+            [ [ 161.7057, -67.0978 ], [ 161.7057, -65.9895 ], [ 163.9874, -65.9895 ], [ 163.9874, -67.0978 ], [ 161.7057, -67.0978 ] ]
         ]
     },
     "properties": {
@@ -11,20 +11,20 @@
             "text": "imagico.de OSM images for mapping",
             "required": true
         },
-        "category": "historicphoto",
-        "country_code": "US",
-        "description": "Recent image from after the eruption (superseeded by newer image) (true color)",
-        "end_date": "2017-06-05",
+        "category": "photo",
+        "country_code": "AQ",
+        "description": "Cloud free summer image with sea ice (true color)",
+        "end_date": "2020-01-21",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
-        "id": "osmim-imagicode-LC80770232017156LGN00",
+        "id": "osmim-imagicode-S2B_R129_S67_20200121T222409",
         "license_url": "https://imagico.de/map/osmim_tiles.php",
-        "name": "imagico.de: Bogoslof Island",
+        "name": "imagico.de: Young Island/Buckle Island January 2020",
         "max_zoom": 13,
         "permission_osm": "explicit",
         "privacy_policy_url": "http://services.imagico.de/privacy.php",
-        "start_date": "2017-06-05",
+        "start_date": "2020-01-21",
         "type": "tms",
-        "url": "https://imagico.de/map/osmim_tiles.php?layer=LC80770232017156LGN00&z={zoom}&x={x}&y={-y}"
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=S2B_R129_S67_20200121T222409&z={zoom}&x={x}&y={-y}"
     },
     "type": "Feature"
 }

--- a/sources/antarctica/osmim-imagicode-S2B_R129_S67_20200301T222409.geojson
+++ b/sources/antarctica/osmim-imagicode-S2B_R129_S67_20200301T222409.geojson
@@ -2,7 +2,7 @@
     "geometry": {
         "type": "Polygon",
         "coordinates": [
-            [ [ -168.2544, 53.8749 ], [ -168.2544, 54.0213 ], [ -167.8591, 54.0213 ], [ -167.8591, 53.8749 ], [ -168.2544, 53.8749 ] ]
+            [ [ 161.9249, -66.6775 ], [ 161.9249, -66.1208 ], [ 163.0622, -66.1208 ], [ 163.0622, -66.6775 ], [ 161.9249, -66.6775 ] ]
         ]
     },
     "properties": {
@@ -11,20 +11,20 @@
             "text": "imagico.de OSM images for mapping",
             "required": true
         },
-        "category": "historicphoto",
-        "country_code": "US",
-        "description": "Recent image from after the eruption (superseeded by newer image) (true color)",
-        "end_date": "2017-06-05",
+        "category": "photo",
+        "country_code": "AQ",
+        "description": "Almost cloud and sea ice free view of the island (true color)",
+        "end_date": "2020-03-01",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
-        "id": "osmim-imagicode-LC80770232017156LGN00",
+        "id": "osmim-imagicode-S2B_R129_S67_20200301T222409",
         "license_url": "https://imagico.de/map/osmim_tiles.php",
-        "name": "imagico.de: Bogoslof Island",
+        "name": "imagico.de: Young Island March 2020",
         "max_zoom": 13,
         "permission_osm": "explicit",
         "privacy_policy_url": "http://services.imagico.de/privacy.php",
-        "start_date": "2017-06-05",
+        "start_date": "2020-03-01",
         "type": "tms",
-        "url": "https://imagico.de/map/osmim_tiles.php?layer=LC80770232017156LGN00&z={zoom}&x={x}&y={-y}"
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=S2B_R129_S67_20200301T222409&z={zoom}&x={x}&y={-y}"
     },
     "type": "Feature"
 }

--- a/sources/antarctica/osmim-imagicode-S2B_R143_S7X_20200302T215359.geojson
+++ b/sources/antarctica/osmim-imagicode-S2B_R143_S7X_20200302T215359.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ 151.067, -75.7434 ], [ 148.1884, -75.1695 ], [ 147.7709, -75.0735 ], [ 147.683, -75.0509 ], [ 147.683, -74.9371 ], [ 160.7574, -69.4103 ], [ 160.7794, -69.4025 ], [ 164.3611, -69.4025 ], [ 165.262, -69.4103 ], [ 168.0747, -70.281 ], [ 168.0747, -70.4802 ], [ 167.3495, -71.0308 ], [ 166.1849, -71.8423 ], [ 165.0203, -72.5873 ], [ 163.7898, -73.3154 ], [ 162.3615, -74.0863 ], [ 161.087, -74.7127 ], [ 159.7906, -75.2983 ], [ 158.7139, -75.7434 ], [ 151.067, -75.7434 ] ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "category": "photo",
+        "country_code": "AQ",
+        "description": "Recent Sentinel-2 image of the western part of Victoria Land, some clouds at the coast (true color)",
+        "end_date": "2020-03-02",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
+        "id": "osmim-imagicode-S2B_R143_S7X_20200302T215359",
+        "license_url": "https://imagico.de/map/osmim_tiles.php",
+        "name": "imagico.de: Victoria Land west",
+        "max_zoom": 13,
+        "permission_osm": "explicit",
+        "privacy_policy_url": "http://services.imagico.de/privacy.php",
+        "start_date": "2020-03-02",
+        "type": "tms",
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=S2B_R143_S7X_20200302T215359&z={zoom}&x={x}&y={-y}"
+    },
+    "type": "Feature"
+}

--- a/sources/antarctica/osmim-imagicode-aster_anti2.geojson
+++ b/sources/antarctica/osmim-imagicode-aster_anti2.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ -120.615, -85.0511 ], [ -121.0602, -84.7506 ], [ -115.2085, -84.1075 ], [ -93.6269, -84.0855 ], [ -85.4314, -84.0794 ], [ -85.0513, -84.2365 ], [ -87.4598, -85.0511 ], [ -120.615, -85.0511 ] ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "category": "photo",
+        "country_code": "AQ",
+        "description": "ASTER imagery from 2001-2009 from the Ohio Range, positional accuracy in parts is bad (true color with estimated blue)",
+        "end_date": "2009",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
+        "id": "osmim-imagicode-aster_anti2",
+        "license_url": "https://imagico.de/map/osmim_tiles.php",
+        "name": "imagico.de: Ohio Range",
+        "max_zoom": 10,
+        "permission_osm": "explicit",
+        "privacy_policy_url": "http://services.imagico.de/privacy.php",
+        "start_date": "2001",
+        "type": "tms",
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=aster_anti2&z={zoom}&x={x}&y={-y}"
+    },
+    "type": "Feature"
+}

--- a/sources/antarctica/osmim-imagicode-aster_anti3.geojson
+++ b/sources/antarctica/osmim-imagicode-aster_anti3.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ -69.1012, -85.0511 ], [ -71.7929, -84.3003 ], [ -68.4315, -83.9809 ], [ -63.0926, -83.7207 ], [ -56.4886, -84.922 ], [ -58.9149, -85.0511 ], [ -69.1012, -85.0511 ] ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "category": "photo",
+        "country_code": "AQ",
+        "description": "ASTER imagery from 2001-2009 from the Patuxent Range, positional accuracy in parts is bad (true color with estimated blue)",
+        "end_date": "2009",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
+        "id": "osmim-imagicode-aster_anti3",
+        "license_url": "https://imagico.de/map/osmim_tiles.php",
+        "name": "imagico.de: Patuxent Range",
+        "max_zoom": 10,
+        "permission_osm": "explicit",
+        "privacy_policy_url": "http://services.imagico.de/privacy.php",
+        "start_date": "2001",
+        "type": "tms",
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=aster_anti3&z={zoom}&x={x}&y={-y}"
+    },
+    "type": "Feature"
+}

--- a/sources/antarctica/osmim-imagicode-aster_anti_east.geojson
+++ b/sources/antarctica/osmim-imagicode-aster_anti_east.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ 159.6688, -83.1798 ], [ 180.0, -83.8305 ], [ 180.0, -85.0511 ], [ 155.693, -85.0511 ], [ 153.0905, -84.8712 ], [ 159.6688, -83.1798 ] ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "category": "photo",
+        "country_code": "AQ",
+        "description": "ASTER imagery from 2001-2009 from the far southern Transantarctic Mountains - eastern hemisphere, positional accuracy in parts is bad (true color with estimated blue)",
+        "end_date": "2009",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
+        "id": "osmim-imagicode-aster_anti_east",
+        "license_url": "https://imagico.de/map/osmim_tiles.php",
+        "name": "imagico.de: Far southern Transantarctic Mnts. east",
+        "max_zoom": 10,
+        "permission_osm": "explicit",
+        "privacy_policy_url": "http://services.imagico.de/privacy.php",
+        "start_date": "2001",
+        "type": "tms",
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=aster_anti_east&z={zoom}&x={x}&y={-y}"
+    },
+    "type": "Feature"
+}

--- a/sources/antarctica/osmim-imagicode-aster_anti_west.geojson
+++ b/sources/antarctica/osmim-imagicode-aster_anti_west.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ -179.9988, -83.9364 ], [ -165.5249, -84.1526 ], [ -162.7266, -85.0511 ], [ -179.9988, -85.0511 ], [ -179.9988, -83.9364 ] ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "category": "photo",
+        "country_code": "AQ",
+        "description": "ASTER imagery from 2001-2009 from the far southern Transantarctic Mountains - western hemisphere, positional accuracy in parts is bad (true color with estimated blue)",
+        "end_date": "2009",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
+        "id": "osmim-imagicode-aster_anti_west",
+        "license_url": "https://imagico.de/map/osmim_tiles.php",
+        "name": "imagico.de: Far southern Transantarctic Mnts. west",
+        "max_zoom": 10,
+        "permission_osm": "explicit",
+        "privacy_policy_url": "http://services.imagico.de/privacy.php",
+        "start_date": "2001",
+        "type": "tms",
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=aster_anti_west&z={zoom}&x={x}&y={-y}"
+    },
+    "type": "Feature"
+}

--- a/sources/antarctica/osmim-imagicode-usgs_250k_ant.geojson
+++ b/sources/antarctica/osmim-imagicode-usgs_250k_ant.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ -180.0, -85.0511 ], [ -180.0, -83.9976 ], [ -156.0059, -76.9946 ], [ -152.0068, -75.9944 ], [ -141.0205, -73.9947 ], [ -75.52, -70.9947 ], [ 157.9834, -68.9968 ], [ 162.0044, -68.9968 ], [ 168.0249, -69.9971 ], [ 171.5186, -70.9947 ], [ 180.0, -82.9967 ], [ 179.978, -85.0511 ], [ -180.0, -85.0511 ] ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "category": "map",
+        "country_code": "AQ",
+        "description": "USGS Antarctica 1:250k Reconnaissance Series topographic maps",
+        "end_date": "1979",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
+        "id": "osmim-imagicode-usgs_250k_ant",
+        "license_url": "https://imagico.de/map/osmim_tiles.php",
+        "name": "imagico.de: USGS 250k Topos Antarctica",
+        "max_zoom": 11,
+        "permission_osm": "explicit",
+        "privacy_policy_url": "http://services.imagico.de/privacy.php",
+        "start_date": "1950",
+        "type": "tms",
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=usgs_250k_ant&z={zoom}&x={x}&y={-y}"
+    },
+    "type": "Feature"
+}

--- a/sources/antarctica/osmim-imagicode-usgs_500k_ant.geojson
+++ b/sources/antarctica/osmim-imagicode-usgs_500k_ant.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ -180.0, -85.0511 ], [ -180.0, -77.4846 ], [ -179.7144, -77.0979 ], [ -160.0269, -73.4964 ], [ -69.0161, -67.9898 ], [ 97.4927, -63.9935 ], [ 120.0146, -63.9935 ], [ 170.9912, -68.9887 ], [ 179.978, -76.9945 ], [ 180.0, -85.0511 ], [ -180.0, -85.0511 ] ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "category": "map",
+        "country_code": "AQ",
+        "description": "Various USGS 1:500k maps: Antarctia Reconnaissance preliminary base (East Antarctic coast) and Antarctia sketch map (West Antarctic) (gray)",
+        "end_date": "1959",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
+        "id": "osmim-imagicode-usgs_500k_ant",
+        "license_url": "https://imagico.de/map/osmim_tiles.php",
+        "name": "imagico.de: USGS 500k Antarctica maps",
+        "max_zoom": 10,
+        "permission_osm": "explicit",
+        "privacy_policy_url": "http://services.imagico.de/privacy.php",
+        "start_date": "1950",
+        "type": "tms",
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=usgs_500k_ant&z={zoom}&x={x}&y={-y}"
+    },
+    "type": "Feature"
+}

--- a/sources/antarctica/osmim-imagicode-usgs_50k_ant.geojson
+++ b/sources/antarctica/osmim-imagicode-usgs_50k_ant.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ 160.9914, -78.4975 ], [ 160.0011, -77.9962 ], [ 160.0011, -77.2475 ], [ 164.006, -77.2475 ], [ 164.9963, -77.7469 ], [ 164.9963, -78.2495 ], [ 164.006, -78.4975 ], [ 160.9914, -78.4975 ] ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "category": "map",
+        "country_code": "AQ",
+        "description": "1:50k topographic maps of the McMurdo Dry Valleys produced by USGS/LINZ",
+        "end_date": "1989",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
+        "id": "osmim-imagicode-usgs_50k_ant",
+        "license_url": "https://imagico.de/map/osmim_tiles.php",
+        "name": "imagico.de: USGS 50k Topos McMurdo Dry Valleys",
+        "max_zoom": 12,
+        "permission_osm": "explicit",
+        "privacy_policy_url": "http://services.imagico.de/privacy.php",
+        "start_date": "1980",
+        "type": "tms",
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=usgs_50k_ant&z={zoom}&x={x}&y={-y}"
+    },
+    "type": "Feature"
+}

--- a/sources/asia/id/osmim-imagicode-S2B_R032_S07_20200921T025549.geojson
+++ b/sources/asia/id/osmim-imagicode-S2B_R032_S07_20200921T025549.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [ [ 105.3221, -6.1813 ], [ 105.3221, -6.0505 ], [ 105.4972, -6.0505 ], [ 105.4972, -6.1813 ], [ 105.3221, -6.1813 ] ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "url": "http://maps.imagico.de/#osmim",
+            "text": "imagico.de OSM images for mapping",
+            "required": true
+        },
+        "category": "photo",
+        "country_code": "ID",
+        "description": "Recent Sentinel-2 image of the volcanic island (true color)",
+        "end_date": "2020-09-21",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
+        "id": "osmim-imagicode-S2B_R032_S07_20200921T025549",
+        "license_url": "https://imagico.de/map/osmim_tiles.php",
+        "name": "imagico.de: Anak Krakatau",
+        "max_zoom": 14,
+        "permission_osm": "explicit",
+        "privacy_policy_url": "http://services.imagico.de/privacy.php",
+        "start_date": "2020-09-21",
+        "type": "tms",
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=S2B_R032_S07_20200921T025549&z={zoom}&x={x}&y={-y}"
+    },
+    "type": "Feature"
+}

--- a/sources/asia/ru/osmim-imagicode-S2A_R089_N52_20160623T024048.geojson
+++ b/sources/asia/ru/osmim-imagicode-S2A_R089_N52_20160623T024048.geojson
@@ -11,7 +11,7 @@
             "text": "imagico.de OSM images for mapping",
             "required": true
         },
-        "category": "photo",
+        "category": "historicphoto",
         "country_code": "RU",
         "description": "Recent image showing newest features (superseeded by newer image) (true color)",
         "end_date": "2016-06-23",

--- a/sources/europe/de/osmim-imagicode-LC81960222015233LGN00ir.geojson
+++ b/sources/europe/de/osmim-imagicode-LC81960222015233LGN00ir.geojson
@@ -11,7 +11,7 @@
             "text": "imagico.de OSM images for mapping",
             "required": true
         },
-        "category": "photo",
+        "category": "historicphoto",
         "country_code": "DE",
         "description": "Up-to-date low tide imagery of the coast for updating mapping of tidalflats and shoals, superseeded by newer images (false color IR)",
         "end_date": "2015-08-21",

--- a/sources/europe/de/osmim-imagicode-LC81960222015233LGN00vis.geojson
+++ b/sources/europe/de/osmim-imagicode-LC81960222015233LGN00vis.geojson
@@ -11,7 +11,7 @@
             "text": "imagico.de OSM images for mapping",
             "required": true
         },
-        "category": "photo",
+        "category": "historicphoto",
         "country_code": "DE",
         "description": "Up-to-date low tide imagery of the coast for updating mapping of tidalflats and shoals, superseeded by newer images (true color)",
         "end_date": "2015-08-21",

--- a/sources/europe/de/osmim-imagicode-northsea_s2_2016.geojson
+++ b/sources/europe/de/osmim-imagicode-northsea_s2_2016.geojson
@@ -11,7 +11,7 @@
             "text": "imagico.de OSM images for mapping",
             "required": true
         },
-        "category": "photo",
+        "category": "historicphoto",
         "country_code": "DE",
         "description": "Up-to-date low tide imagery of the coast for updating mapping of tidalflats and shoals (superseeded by newer image) (true color)",
         "end_date": "2016-09-25",

--- a/sources/europe/de/osmim-imagicode-northsea_s2_2017.geojson
+++ b/sources/europe/de/osmim-imagicode-northsea_s2_2017.geojson
@@ -11,7 +11,7 @@
             "text": "imagico.de OSM images for mapping",
             "required": true
         },
-        "category": "photo",
+        "category": "historicphoto",
         "country_code": "DE",
         "description": "Up-to-date low tide imagery of the coast for updating mapping of tidalflats and shoals (superseeded by newer image) (true color)",
         "end_date": "2017-06-02",

--- a/sources/europe/ru/osmim-imagicode-S2A_R094_N79_20160812T105622.geojson
+++ b/sources/europe/ru/osmim-imagicode-S2A_R094_N79_20160812T105622.geojson
@@ -11,7 +11,7 @@
             "text": "imagico.de OSM images for mapping",
             "required": true
         },
-        "category": "photo",
+        "category": "historicphoto",
         "country_code": "RU",
         "description": "Late summer imagery with few clouds (superseeded by newer image) (true color)",
         "end_date": "2016-08-12",

--- a/sources/north-america/ca/osmim-imagicode-LC80360072014245LGN00.geojson
+++ b/sources/north-america/ca/osmim-imagicode-LC80360072014245LGN00.geojson
@@ -11,7 +11,7 @@
             "text": "imagico.de OSM images for mapping",
             "required": true
         },
-        "category": "photo",
+        "category": "historicphoto",
         "country_code": "CA",
         "description": "Coastline mostly mapped meanwhile (false color IR)",
         "end_date": "2014-09-02",

--- a/sources/north-america/gl/osmim-imagicode-ls_polar.geojson
+++ b/sources/north-america/gl/osmim-imagicode-ls_polar.geojson
@@ -11,7 +11,7 @@
             "text": "imagico.de OSM images for mapping",
             "required": true
         },
-        "category": "photo",
+        "category": "historicphoto",
         "country_code": "GL",
         "description": "First available image north of the regular Landsat limit, mostly with seasonal snow cover so difficult to interpret, superseeded by newer images (true color)",
         "end_date": "2013-05-17",

--- a/sources/north-america/us/osmim-imagicode-S2B_R015_N52_20190816T222539.geojson
+++ b/sources/north-america/us/osmim-imagicode-S2B_R015_N52_20190816T222539.geojson
@@ -2,7 +2,7 @@
     "geometry": {
         "type": "Polygon",
         "coordinates": [
-            [ [ -168.2544, 53.8749 ], [ -168.2544, 54.0213 ], [ -167.8591, 54.0213 ], [ -167.8591, 53.8749 ], [ -168.2544, 53.8749 ] ]
+            [ [ -168.5059, 53.7714 ], [ -168.5059, 54.0751 ], [ -167.8205, 54.0751 ], [ -167.8205, 53.7714 ], [ -168.5059, 53.7714 ] ]
         ]
     },
     "properties": {
@@ -11,20 +11,20 @@
             "text": "imagico.de OSM images for mapping",
             "required": true
         },
-        "category": "historicphoto",
+        "category": "photo",
         "country_code": "US",
-        "description": "Recent image from after the eruption (superseeded by newer image) (true color)",
-        "end_date": "2017-06-05",
+        "description": "Image update for the small volcanic island (true color)",
+        "end_date": "2019-08-16",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/misc/osmim-imagicode.png",
-        "id": "osmim-imagicode-LC80770232017156LGN00",
+        "id": "osmim-imagicode-S2B_R015_N52_20190816T222539",
         "license_url": "https://imagico.de/map/osmim_tiles.php",
-        "name": "imagico.de: Bogoslof Island",
+        "name": "imagico.de: Bogoslof Island 2019",
         "max_zoom": 13,
         "permission_osm": "explicit",
         "privacy_policy_url": "http://services.imagico.de/privacy.php",
-        "start_date": "2017-06-05",
+        "start_date": "2019-08-16",
         "type": "tms",
-        "url": "https://imagico.de/map/osmim_tiles.php?layer=LC80770232017156LGN00&z={zoom}&x={x}&y={-y}"
+        "url": "https://imagico.de/map/osmim_tiles.php?layer=S2B_R015_N52_20190816T222539&z={zoom}&x={x}&y={-y}"
     },
     "type": "Feature"
 }

--- a/sources/oceania/au/osmim-imagicode-EO1A1350972013086110KF.geojson
+++ b/sources/oceania/au/osmim-imagicode-EO1A1350972013086110KF.geojson
@@ -11,7 +11,7 @@
             "text": "imagico.de OSM images for mapping",
             "required": true
         },
-        "category": "photo",
+        "category": "historicphoto",
         "country_code": "AU",
         "description": "Glaciers of Northwest Heard Island (mapped meanwhile) (false color IR)",
         "end_date": "2013-03-13",

--- a/sources/oceania/pg/osmim-imagicode-LC80940622015159LGN00.geojson
+++ b/sources/oceania/pg/osmim-imagicode-LC80940622015159LGN00.geojson
@@ -11,7 +11,7 @@
             "text": "imagico.de OSM images for mapping",
             "required": true
         },
-        "category": "photo",
+        "category": "historicphoto",
         "country_code": "PG",
         "description": "Many missing islands in OSM (mostly mapped meanwhile) (true color)",
         "end_date": "2015-06-08",

--- a/sources/south-america/pe/osmim-imagicode-S2A_R039_S15_20160510T145731.geojson
+++ b/sources/south-america/pe/osmim-imagicode-S2A_R039_S15_20160510T145731.geojson
@@ -11,7 +11,7 @@
             "text": "imagico.de OSM images for mapping",
             "required": true
         },
-        "category": "photo",
+        "category": "historicphoto",
         "country_code": "PE",
         "description": "Poor and outdated imagery in other sources (true color)",
         "end_date": "2016-05-10",


### PR DESCRIPTION
* adding various new images for the Antarctic (many of them have a variable max_zoom because of the variable scale of the mercator projection).
* changing category of older images from `photo` to `historicphoto`.