### PR TITLE
Fix europe / ch / Kanton Zurch 2014 elevation

### DIFF
--- a/sources/europe/ch/Kanton_Zurich_dom_hillshade_2014_wms.geojson
+++ b/sources/europe/ch/Kanton_Zurich_dom_hillshade_2014_wms.geojson
@@ -7,24 +7,24 @@
         },
         "available_projections": [
             "EPSG:2056",
-            "EPSG:21781",
-            "EPSG:21780",
-            "EPSG:21782",
-            "EPSG:4326",
+            "EPSG:3857",
             "EPSG:4258",
-            "EPSG:3857"
+            "EPSG:4326",
+            "EPSG:21780",
+            "EPSG:21781",
+            "EPSG:21782"
         ],
         "country_code": "CH",
         "start_date": "2014",
         "end_date": "2014",
         "min_zoom": 10,
         "id": "OGDLidarZH-DOM",
-        "name": "Kanton Zurich, Oberflächenschummerung 50cm",
+        "name": "Kanton Zurich, Oberflächenschummerung 2014 50cm",
         "license_url": "https://opendata.swiss/de/dataset/wms-digitales-hohenmodell-ogd1",
         "privacy_policy_url": "https://www.zh.ch/internet/de/service/nav/footer/nutzungsregelungen.html",
         "type": "wms",
         "category": "elevation",
-        "url": "https://wms.zh.ch/OGDLidarZH?FORMAT=image/jpeg&STYLES=&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=dom2014hillshade&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
+        "url": "https://wms.zh.ch/OGDLidarZH?LAYERS=dom2014_relief&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/ch/Kanton_Zurich_dtm_hillshade_2014_wms.geojson
+++ b/sources/europe/ch/Kanton_Zurich_dtm_hillshade_2014_wms.geojson
@@ -7,24 +7,24 @@
         },
         "available_projections": [
             "EPSG:2056",
-            "EPSG:21781",
-            "EPSG:21780",
-            "EPSG:21782",
-            "EPSG:4326",
+            "EPSG:3857",
             "EPSG:4258",
-            "EPSG:3857"
+            "EPSG:4326",
+            "EPSG:21780",
+            "EPSG:21781",
+            "EPSG:21782"
         ],
         "country_code": "CH",
         "start_date": "2014",
         "end_date": "2014",
         "min_zoom": 10,
         "id": "OGDLidarZH-DTM",
-        "name": "Kanton Zurich, Terrainschummerung 50cm",
+        "name": "Kanton Zurich, Terrainschummerung 2014 50cm",
         "license_url": "https://opendata.swiss/de/dataset/wms-digitales-hohenmodell-ogd1",
         "privacy_policy_url": "https://www.zh.ch/internet/de/service/nav/footer/nutzungsregelungen.html",
         "type": "wms",
         "category": "elevation",
-        "url": "https://wms.zh.ch/OGDLidarZH?FORMAT=image/jpeg&STYLES=&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=dtm2014hillshade&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}"
+        "url": "https://wms.zh.ch/OGDLidarZH?LAYERS=dtm2014_relief&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
     },
     "geometry": {
         "type": "Polygon",


### PR DESCRIPTION
The Kanton Zürich added new elevation data and changed the layer names of the existing ones.

