### PR TITLE
Check if source intersect country of country_code

### DIFF
--- a/scripts/data/simplify_geometries.py
+++ b/scripts/data/simplify_geometries.py
@@ -1,0 +1,42 @@
+import glob
+import gzip
+import json
+import os
+from collections import defaultdict
+import fiona
+from pyproj import Transformer
+from shapely.geometry import shape, mapping
+from shapely.ops import transform, cascaded_union
+
+transformer = Transformer.from_crs("epsg:4326", "epsg:3857", always_xy=True)
+transformer_back = Transformer.from_crs("epsg:3857", "epsg:4326", always_xy=True)
+
+countries = defaultdict(list)
+
+for file_name in glob.glob(os.path.join("download_osm_boundaries_com", "*.geojson.gz")):
+    with gzip.open(file_name) as f:
+        data = json.load(f)
+
+    for feature in data["features"]:
+        if "ISO3166-1" in feature["properties"]["all_tags"]:
+            isocode = feature["properties"]["all_tags"]["ISO3166-1"]
+            geom = shape(feature["geometry"])
+            geom_3857 = transform(transformer.transform, geom)
+            geom_3857_simplified = geom_3857.buffer(1000).simplify(250).buffer(-1000)
+            geom_simplified = transform(
+                transformer_back.transform, geom_3857_simplified
+            )
+            countries[isocode].append(geom_simplified)
+
+schema = {"geometry": "Any", "properties": {"ISO3166-1": "str"}}
+with fiona.open(
+    "countries.geojson",
+    mode="w",
+    driver="GeoJSON",
+    schema=schema,
+    COORDINATE_PRECISION=5,
+) as sink:
+    for isocode, shapes in countries.items():
+        geom = cascaded_union(shapes)
+        feature = {"geometry": mapping(geom), "properties": {"ISO3166-1": isocode}}
+        sink.write(feature)


### PR DESCRIPTION
Currently, there is no test for the country_code attribute. 

This PR adds a check that the source geometry intersects the geometry of the country with the same ISO3166-1 country code. This check requires a dataset with the country geometries. "scripts/data/simplify_geometries.py" is a script to extract a dataset out of downloads from https://osm-boundaries.com. This dataset currently does not include countries for "AQ", "ZZ", "PS", "XN", "EU", "BV". While this dataset is based on osm data, I'm not sure if osm-boundaries.com data can be used. If not, https://github.com/ideditor/country-coder/blob/master/src/data/borders.json might be an alternative. 

```
License
Unless otherwise stated, Ground Zero Communications AB and/or its licensors own the intellectual property rights for all material on OSM-Boundaries. All intellectual property rights are reserved. You may access this from OSM-Boundaries for your own personal use subjected to restrictions set in these terms and conditions.

You must not:

Republish material from OSM-Boundaries
Sell, rent or sub-license material from OSM-Boundaries
Reproduce, duplicate or copy material from OSM-Boundaries
Redistribute content from OSM-Boundaries
```
