### PR TITLE
Fix wms url for europe / at / GeoimageatMaxRes

### DIFF
--- a/sources/europe/at/GeoimageatMaxRes.geojson
+++ b/sources/europe/at/GeoimageatMaxRes.geojson
@@ -808,7 +808,7 @@
         "permission_osm": "explicit",
         "type": "wms",
         "category": "photo",
-        "url": "https://gis.bmlfuw.gv.at/wmsgw/?key=4d80de696cd562a63ce463a58a61488d&service=WMS&LAYERS=Luftbild&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
+        "url": "https://gis.lfrz.gv.at/wmsgw/?key=4d80de696cd562a63ce463a58a61488d&FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&Layers=Luftbild&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&STYLES="
     },
     "type": "Feature"
 }


### PR DESCRIPTION
It looks like the domain of the server has changed. This PR includes the updated URL taken from [JOSM](https://josm.openstreetmap.de/wiki/Maps/Austria#Geoimage.atMaxRes) .

The WMS server reports the following AccessConstraints:

> INFO:root:AccessConstraints: Das angebotene elektronische Service (WMS) wird in weiterer Folge als 'Dienst' bezeichnet. Die Inhalte der angebotenen Dienste sind urheberrechtlich geschützt und unterliegen dem Markenschutz von GEOIMAGE-AUSTRIA®. Die Dienste und deren Inhalte können für folgende nicht kommerzielle Zwecke (jeweils und ausschließlich) verwendet werden: 1. Private Nutzung, 2. Forschung, 3. Bildung, 4. Schulische Nutzung / Unterricht, 5. Erzeugung von Open Data Folgeprodukten, 6. Nutzung für Vereinszwecke, 7. Nutzung innerhalb von Blaulichtorganisationen, 8. Nutzung innerhalb von Behörden, jedoch nur zur Erfüllung gesetz-licher Aufgaben und ohne Darstellung im Internet. Für die Verwendung des Dienstes ist eine Selbstregistrierung erforderlich, die hierbei dem Benutzer zur Verfügung gestellten Zugangsdaten dürfen nicht an Dritte weitergegeben werden. Alle auf Basis des Dienstes und seiner Inhalte erzeugten Werke müssen folgenden Copyrighthinweis enthalten: 'Orthophoto: www.geoimage.at (c)'. Die Nutzung des Dienstes für die Erzeugung von Folgeprodukten (siehe 5. oben) ist unter der Voraussetzung gestattet, dass die erzeugten Folgeprodukte der Creative Common Lizenz 'Namensnennung-Weitergabe unter gleichen Bedingungen 2.0 Österreich (CC BY-SA 2.0)', siehe http://creativecommons.org/licenses/by-sa/2.0/at/ oder 'Namensnennung-Weitergabe unter gleichen Bedingungen 3.0 Österreich (CC BY-SA 3.0)', siehe http://creativecommons.org/licenses/by-sa/3.0/at/ oder der 'Open Database License (ODbL) v1.0', siehe http://opendatacommons.org/licenses/odbl/1.0/, unterliegen. [WICHTIGER HINWEIS: der hier angebotene Dienst und die darin enthaltenen Daten unterliegen NICHT der oben angegebenen CC BY-SA 2.0 bzw. CC BY-SA 3.0 bzw. ODbL v1.0 !]. Die erstellten Folgeprodukte dürfen keine Orthophotos oder Orthophotoausschnitte aus dem Geoimage Dienst beinhalten. Das Einbinden dieses Dienstes in andere Anwendungen (Cascading) ist nicht erlaubt. Innerbetriebliche und/oder kommerzielle Nutzung in Unternehmen ist ausnahmslos NICHT erlaubt. Das systematische permanente Abspeichern der Daten des Dienstes zur Generierung eines Paralleldatensatzes (Tiling, permanent Caching) ist ausnahmslos NICHT erlaubt, das gewöhnliche Browsercaching ist von diesen Verbot ausgenommen. Der Benutzer ist verpflichtet gegenüber den Mitarbeitern von GEOIMAGE AUSTRIA bei Anfrage Auskunft über die Verwendung des Dienstes und der darin eingebunden Daten zu geben. Ein Verstoß gegen die Nutzungsbedingungen hat einen Entzug der Nutzungsberechtigung sowie rechtliche Schritte gegen den Verstoßenden zur Folge. Darüber hinaus behält sich das LFRZ das Recht vor, jederzeit die Nutzungsberechtigung des Dienstes von einzelnen Nutzern ohne Angabe von Gründen zu entziehen. Im Katastrophenfall kann der Dienst sofort von allen Stellen, welche bei der Bewältigung der Katastrophe mitarbeiten, für die Dauer der Katastrophenbewältigung verwendet werden. Danach ist eine kurze Mitteilung über die Verwendung des Dienstes an office@geoimage.at zu richten. Für den Dienst wird keine Verfügbarkeit und/oder Performance garantiert. Für Daten und Datenqualität wird keinerlei Gewähr gegeben. Für Schäden oder Folgeschäden aus der Verwendung des Dienstes und der darin enthaltenen Daten wird keinerlei Haftung übernommen. Dieser Dienst wird derzeit angeboten, es besteht jedoch kein Anspruch auf spätere Verfügbarkeit des Dienstes. Für jede von den oben beschriebenen Nutzungsbedingungen abweichende Nutzung (z.B. kommerzielle Nutzung oder innerbetriebliche Nutzung) des Dienstes und der darin enthaltenen Daten kontaktieren Sie bitte office@geoimage.at oder besuchen die Webseite www.geoimage.at für unser Angebot an garantierten kommerziellen Diensten.