### PR TITLE
Fix europe / se / kalmar sources, add 2020 source

### DIFF
--- a/sources/europe/se/kalmar_orto_2014.geojson
+++ b/sources/europe/se/kalmar_orto_2014.geojson
@@ -128,7 +128,7 @@
         "start_date": "2014",
         "type": "wms",
         "url": "https://karta.kalmar.se/ims/services/Ortofoto/Norra_Kalmar_2014/ImageServer/WMSServer?LAYERS=0&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
-        "category": "historicphoto",
+        "category": "photo",
         "privacy_policy_url": "https://kalmar.se/integritetspolicy"
     },
     "type": "Feature"

--- a/sources/europe/se/kalmar_orto_2014.geojson
+++ b/sources/europe/se/kalmar_orto_2014.geojson
@@ -119,7 +119,7 @@
         "description": "Orthophotos for the north coast of the municipality of Kalmar 2014",
         "i18n": true,
         "end_date": "2014",
-        "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/Kalmarvapen_1a.svg/206px-Kalmarvapen_1a.svg.png",
+        "icon": "https://upload.wikimedia.org/wikipedia/commons/c/c8/Kalmar_vapen.svg",
         "id": "kalmar-orto-2014",
         "license_url": "https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/se/Kalmar_permission.pdf",
         "max_zoom": 22,
@@ -127,8 +127,9 @@
         "name": "Kalmar North Orthophoto 2014",
         "start_date": "2014",
         "type": "wms",
-        "url": "https://kartportal.kalmar.se/arcgisserver/services/Ortofoto/Kalmar_2014/ImageServer/WMSServer?LAYERS=0&STYLES=&FORMAT=image/png&TRANSPARENT=TRUE&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
-        "category": "photo"
+        "url": "https://karta.kalmar.se/ims/services/Ortofoto/Norra_Kalmar_2014/ImageServer/WMSServer?LAYERS=0&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "category": "historicphoto",
+        "privacy_policy_url": "https://kalmar.se/integritetspolicy"
     },
     "type": "Feature"
 }

--- a/sources/europe/se/kalmar_orto_2016.geojson
+++ b/sources/europe/se/kalmar_orto_2016.geojson
@@ -112,7 +112,7 @@
         "name": "Kalmar South Orthophoto 2016",
         "start_date": "2016",
         "url": "https://karta.kalmar.se/ims/services/Ortofoto/Kalmar_2016/ImageServer/WMSServer?LAYERS=0&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
-        "category": "historicphoto",
+        "category": "photo",
         "privacy_policy_url": "https://kalmar.se/integritetspolicy"
     },
     "type": "Feature"

--- a/sources/europe/se/kalmar_orto_2016.geojson
+++ b/sources/europe/se/kalmar_orto_2016.geojson
@@ -103,16 +103,17 @@
         "description": "Orthophotos for the south coast of the municipality of Kalmar 2016",
         "i18n": true,
         "end_date": "2016",
-        "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/Kalmarvapen_1a.svg/206px-Kalmarvapen_1a.svg.png",
+        "icon": "https://upload.wikimedia.org/wikipedia/commons/c/c8/Kalmar_vapen.svg",
         "id": "kalmar-orto-2016",
         "license_url": "https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/se/Kalmar_permission.pdf",
         "max_zoom": 22,
         "min_zoom": 9,
+        "type": "wms",
         "name": "Kalmar South Orthophoto 2016",
         "start_date": "2016",
-        "type": "wms",
-        "url": "https://kartportal.kalmar.se/arcgisserver/services/Ortofoto/Kalmar_2016/ImageServer/WMSServer?LAYERS=0&STYLES=&FORMAT=image/png&TRANSPARENT=TRUE&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
-        "category": "photo"
+        "url": "https://karta.kalmar.se/ims/services/Ortofoto/Kalmar_2016/ImageServer/WMSServer?LAYERS=0&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "category": "historicphoto",
+        "privacy_policy_url": "https://kalmar.se/integritetspolicy"
     },
     "type": "Feature"
 }

--- a/sources/europe/se/kalmar_orto_2018.geojson
+++ b/sources/europe/se/kalmar_orto_2018.geojson
@@ -349,7 +349,7 @@
         "description": "Orthophotos for urban areas of the municipality of Kalmar 2018",
         "i18n": true,
         "end_date": "2018",
-        "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/Kalmarvapen_1a.svg/206px-Kalmarvapen_1a.svg.png",
+        "icon": "https://upload.wikimedia.org/wikipedia/commons/c/c8/Kalmar_vapen.svg",
         "id": "kalmar-orto-2018",
         "license_url": "https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/se/Kalmar_permission.pdf",
         "max_zoom": 22,
@@ -357,8 +357,9 @@
         "name": "Kalmar Urban Orthophoto 2018",
         "start_date": "2018",
         "type": "wms",
-        "url": "https://kartportal.kalmar.se/arcgisserver/services/Ortofoto/Kalmar_2018/ImageServer/WMSServer?LAYERS=0&STYLES=&FORMAT=image/png&TRANSPARENT=TRUE&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
-        "category": "photo"
+        "url": "https://karta.kalmar.se/ims/services/Ortofoto/Kalmar_2018/ImageServer/WMSServer?LAYERS=0&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "category": "historicphoto",
+        "privacy_policy_url": "https://kalmar.se/integritetspolicy"
     },
     "type": "Feature"
 }

--- a/sources/europe/se/kalmar_orto_2018.geojson
+++ b/sources/europe/se/kalmar_orto_2018.geojson
@@ -358,7 +358,7 @@
         "start_date": "2018",
         "type": "wms",
         "url": "https://karta.kalmar.se/ims/services/Ortofoto/Kalmar_2018/ImageServer/WMSServer?LAYERS=0&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
-        "category": "historicphoto",
+        "category": "photo",
         "privacy_policy_url": "https://kalmar.se/integritetspolicy"
     },
     "type": "Feature"

--- a/sources/europe/se/kalmar_orto_2020.geojson
+++ b/sources/europe/se/kalmar_orto_2020.geojson
@@ -1,0 +1,59 @@
+{
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    16.386369,
+                    56.488181
+                ],
+                [
+                    16.386369,
+                    56.7852
+                ],
+                [
+                    16.074626,
+                    56.7852
+                ],
+                [
+                    16.074626,
+                    56.488181
+                ],
+                [
+                    16.386369,
+                    56.488181
+                ]
+            ]
+        ]
+    },
+    "properties": {
+        "attribution": {
+            "required": true,
+            "text": "© Kalmar municipality",
+            "url": "http://data-kalmar.opendata.arcgis.com/"
+        },
+        "available_projections": [
+            "CRS:84",
+            "EPSG:3010",
+            "EPSG:3857",
+            "EPSG:4326"
+        ],
+        "best": true,
+        "country_code": "SE",
+        "description": "Orthophotos for urban areas of the municipality of Kalmar 2020",
+        "i18n": true,
+        "end_date": "2020",
+        "icon": "https://upload.wikimedia.org/wikipedia/commons/c/c8/Kalmar_vapen.svg",
+        "id": "kalmar-orto-2020",
+        "license_url": "https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/se/Kalmar_permission.pdf",
+        "max_zoom": 22,
+        "min_zoom": 9,
+        "name": "Kalmar Urban Orthophoto 2020",
+        "start_date": "2020",
+        "type": "wms",
+        "url": "https://karta.kalmar.se/ims/services/Ortofoto/Kalmar_2020/ImageServer/WMSServer?LAYERS=Kalmar_2020:RGB_2020&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "category": "photo",
+        "privacy_policy_url": "https://kalmar.se/integritetspolicy"
+    },
+    "type": "Feature"
+}


### PR DESCRIPTION
* Fix broken europe / se / kalmar sources thanks to @NKAmapper: https://github.com/osmlab/editor-layer-index/pull/578#issuecomment-741721496
* Add additional source for 2020. 

There is a pdf in Swedish regarding the license/permission to use, but I don't understand Swedish: https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/se/Kalmar_permission.pdf