### PR TITLE
WMS Sync: check if projections return an image

### DIFF
--- a/requirements-wms_sync.txt
+++ b/requirements-wms_sync.txt
@@ -1,4 +1,4 @@
-pillow==8.0.1
+pillow==8.1.0
 aiohttp==3.7.3
 aiofiles==0.6.0
 imagehash==4.2.0
@@ -6,5 +6,6 @@ mercantile==1.1.6
 shapely==1.7.1
 pyproj==3.0.0.post1
 jsonschema==3.2.0
-colorlog==4.6.2
+colorlog==4.7.2
 pyproj==3.0.0.post1
+python-magic==0.4.18


### PR DESCRIPTION
Some WMS servers advertise projections but do not actually support them. This PR sends a GetMap request for each projection and checks if an image is returned. 


The updated script modifies locally the following sources, but there are always some server/network issues, thus more WMS servers could be affected. 

```
        modified:   sources/europe/ee/EstoniaBasemap-Maaamet.geojson
        modified:   sources/europe/ee/EstoniaCIR-Maaamet.geojson
        modified:   sources/europe/ee/EstoniaCadastre(Maaamet).geojson
        modified:   sources/europe/it/PCN2012-Italy.geojson
        modified:   sources/europe/no/KartverketAviationObstructionsoverlay.geojson
        modified:   sources/europe/no/KartverketContourLinesoverlay.geojson
        modified:   sources/europe/se/SollentunaOrthophoto.geojson
        modified:   sources/north-america/ca/Canvec-French.geojson
        modified:   sources/north-america/ca/Canvec.geojson
        modified:   sources/north-america/us/USDA-NAIP.geojson
```