### PR TITLE
Fix pull request action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get file changes
         id: get_file_changes
-        uses: trilom/file-changes-action@v1.2.3
+        uses: trilom/file-changes-action@v1.2.4
         with:
           output: ' '
 


### PR DESCRIPTION
In https://github.com/osmlab/editor-layer-index/pull/1023 the action to detect changed files fails with "There was an issue sorting changed files from Github." 

In https://github.com/trilom/file-changes-action/issues/104 it was reported that upgrading from trilom/file-changes-action@v1.2.3 to trilom/file-changes-action@v1.2.4 could help.