### PR TITLE
WMS bot: make proj check more resilient against network errors

### DIFF
--- a/.github/workflows/sync_wms.yml
+++ b/.github/workflows/sync_wms.yml
@@ -2,7 +2,8 @@ name: ELI WMS sync
 
 on:
   schedule:
-    - cron: '0 0 * * 0'
+  - cron: '0 0 * * *' # daily
+    # - cron: '0 0 * * 0' # weekly
 
 jobs:
   wms_sync:


### PR DESCRIPTION
- When downloading an image, check if there is a network error, image parsing error or other error and return the status. 
- Temporarily enable the WMS bot daily to check if the changes make the script more resilient against network errors. 