### PR TITLE
Run WMS sync bot again only weekly

### DIFF
--- a/.github/workflows/sync_wms.yml
+++ b/.github/workflows/sync_wms.yml
@@ -2,8 +2,8 @@ name: ELI WMS sync
 
 on:
   schedule:
-  - cron: '0 0 * * *' # daily
-    # - cron: '0 0 * * 0' # weekly
+  # - cron: '0 0 * * *' # daily
+    - cron: '0 0 * * 0' # weekly
 
 jobs:
   wms_sync:


### PR DESCRIPTION
The projection check of the WMS bot seems to be stable thus the bot should again only run weekly and not daily.