### PR TITLE
formal updates on Berlin DOP 2019 and older

### DIFF
--- a/sources/europe/de/Berlinaerialphotograph2011.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2011.geojson
@@ -2,7 +2,7 @@
     "type": "Feature",
     "properties": {
         "id": "Berlin-2011",
-        "name": "Berlin aerial photography 2011",
+        "name": "Berlin/Geoportal DOP20RGB (2011)",
         "type": "wms",
         "category": "historicphoto",
         "url": "https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_luftbild2011_20?LAYERS=0&STYLES=default&FORMAT=image/png&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
@@ -18,10 +18,11 @@
             "EPSG:4258"
         ],
         "attribution": {
-            "text": "Geoportal Berlin/Digitale farbige Orthophotos 2011",
+            "text": "Geoportal Berlin/Digitale farbige Orthophotos 2011 (DOP20RGB)",
             "required": true
         },
-        "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=367583#p367583"
+        "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf", 
+    "privacy_policy_url": "https://www.stadtentwicklung.berlin.de/geoinformation/fis-broker/datenschutz/index.shtml",
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/de/Berlinaerialphotograph2011.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2011.geojson
@@ -22,7 +22,7 @@
             "required": true
         },
         "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf", 
-    "privacy_policy_url": "https://www.stadtentwicklung.berlin.de/geoinformation/fis-broker/datenschutz/index.shtml",
+    "privacy_policy_url": "https://www.stadtentwicklung.berlin.de/geoinformation/fis-broker/datenschutz/index.shtml"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/de/Berlinaerialphotograph2014.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2014.geojson
@@ -2,7 +2,7 @@
   "type": "Feature",
   "properties": {
     "id": "Berlin-2014",
-    "name": "Berlin aerial photography 2014",
+    "name": "Berlin/Geoportal DOP20RGB (2014)",
     "type": "tms",
     "category": "historicphoto",
     "url": "https://tiles.codefor.de/berlin-2014/{zoom}/{x}/{y}.png",
@@ -10,10 +10,11 @@
     "end_date": "2014",
     "country_code": "DE",
     "attribution": {
-      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2014",
+      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2014 (DOP20RGB) (codefor.de mirror)",
       "required": true
     },
-    "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=367583#p367583",
+    "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf", 
+    "privacy_policy_url": "https://codefor.de/datenschutz/",
     "max_zoom": 18
   },
   "geometry": {

--- a/sources/europe/de/Berlinaerialphotograph2015.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2015.geojson
@@ -2,7 +2,7 @@
   "type": "Feature",
   "properties": {
     "id": "Berlin-2015",
-    "name": "Berlin aerial photography 2015",
+    "name": "Berlin/Geoportal DOP20RGB (2015)",
     "type": "tms",
     "category": "historicphoto",
     "url": "https://tiles.codefor.de/berlin-2015/{zoom}/{x}/{y}.png",
@@ -10,10 +10,11 @@
     "end_date": "2015-08-03",
     "country_code": "DE",
     "attribution": {
-      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2015",
+      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2015 (DOP20RGB) (codefor.de mirror)",
       "required": true
     },
-    "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=367583#p367583",
+    "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf", 
+    "privacy_policy_url": "https://codefor.de/datenschutz/",
     "max_zoom": 18
   },
   "geometry": {

--- a/sources/europe/de/Berlinaerialphotograph2016.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2016.geojson
@@ -2,7 +2,7 @@
   "type": "Feature",
   "properties": {
     "id": "Berlin-2016",
-    "name": "Berlin aerial photography 2016",
+    "name": "Berlin/Geoportal DOP20RGB (2016)",
     "type": "tms",
     "category": "historicphoto",
     "url": "https://tiles.codefor.de/berlin-2016/{zoom}/{x}/{y}.png",
@@ -10,10 +10,11 @@
     "end_date": "2016-04-03",
     "country_code": "DE",
     "attribution": {
-      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2016",
+      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2016 (DOP20RGB) (codefor.de mirror)",
       "required": true
     },
-    "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=367583#p367583",
+    "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf", 
+    "privacy_policy_url": "https://codefor.de/datenschutz/",
     "max_zoom": 18
   },
   "geometry": {

--- a/sources/europe/de/Berlinaerialphotograph2016infrared.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2016infrared.geojson
@@ -2,7 +2,7 @@
   "type": "Feature",
   "properties": {
     "id": "Berlin-2016-infrared",
-    "name": "Berlin aerial photography 2016 (infrared)",
+    "name": "Berlin/Geoportal DOP20CIR (2016 infrared)",
     "type": "tms",
     "category": "historicphoto",
     "url": "https://tiles.codefor.de/berlin-2016i/{zoom}/{x}/{y}.png",
@@ -10,10 +10,11 @@
     "end_date": "2016-04-03",
     "country_code": "DE",
     "attribution": {
-      "text": "Geoportal Berlin/Digitale Color-Infrarot-Orthophotos 2016",
+      "text": "Geoportal Berlin/Digitale Color-Infrarot-Orthophotos 2016 (DOP20CIR) (codefor.de mirror)",
       "required": true
     },
-    "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=367583#p367583",
+    "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf", 
+    "privacy_policy_url": "https://codefor.de/datenschutz/",
     "max_zoom": 18
   },
   "geometry": {

--- a/sources/europe/de/Berlinaerialphotograph2017.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2017.geojson
@@ -2,7 +2,7 @@
   "type": "Feature",
   "properties": {
     "id": "Berlin-2017",
-    "name": "Berlin aerial photography 2017",
+    "name": "Berlin/Geoportal DOP20RGB (2017)",
     "type": "tms",
     "category": "historicphoto",
     "url": "https://tiles.codefor.de/berlin-2017/{zoom}/{x}/{y}.png",
@@ -10,10 +10,11 @@
     "end_date": "2017-03-28",
     "country_code": "DE",
     "attribution": {
-      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2017",
+      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2017 (DOP20RGB) (codefor.de mirror)",
       "required": true
     },
-    "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=367583#p367583",
+    "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf", 
+    "privacy_policy_url": "https://codefor.de/datenschutz/",
     "max_zoom": 18
   },
   "geometry": {

--- a/sources/europe/de/Berlinaerialphotograph2018.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2018.geojson
@@ -2,7 +2,7 @@
   "type": "Feature",
   "properties": {
     "id": "Berlin-2018",
-    "name": "Berlin aerial photography 2018",
+    "name": "Berlin/Geoportal DOP20RGB (2018)",
     "type": "tms",
     "category": "historicphoto",
     "url": "https://tiles.codefor.de/berlin-2018/{zoom}/{x}/{y}.png",
@@ -10,10 +10,11 @@
     "end_date": "2018-04-07",
     "country_code": "DE",
     "attribution": {
-      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2018",
+      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2018 (DOP20RGB) (codefor.de mirror)",
       "required": true
     },
-    "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=367583#p367583",
+    "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf", 
+    "privacy_policy_url": "https://codefor.de/datenschutz/",
     "max_zoom": 18
   },
   "geometry": {

--- a/sources/europe/de/Berlinaerialphotograph2019.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2019.geojson
@@ -2,19 +2,20 @@
   "type": "Feature",
   "properties": {
     "id": "Berlin-2019",
-    "name": "Berlin aerial photography 2019",
+    "name": "Berlin/Geoportal DOP20RGB (2019)",
     "type": "tms",
-    "category": "photo",
+    "category": "historicphoto",
     "url": "https://tiles.codefor.de/berlin-2019/{zoom}/{x}/{y}.png",
     "start_date": "2019-04-01",
     "end_date": "2019-04-06",
     "country_code": "DE",
-    "best": true,
+    "best": false,
     "attribution": {
-      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2019 (DOP20RGB)",
+      "text": "Geoportal Berlin/Digitale farbige Orthophotos 2019 (DOP20RGB) (codefor.de mirror)",
       "required": true
     },
     "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf",
+    "privacy_policy_url": "https://codefor.de/datenschutz/",
     "max_zoom": 18
   },
   "geometry": {


### PR DESCRIPTION
name-> more precise
category->historicphoto
best->false
attribution-> add codefor.de as mirror
license_url->update
privacy-> add

followup to #1054 