### PR TITLE
Correct NYS Orthos URL

### DIFF
--- a/sources/north-america/us/ny/NYS_Orthos_Online.geojson
+++ b/sources/north-america/us/ny/NYS_Orthos_Online.geojson
@@ -1322,7 +1322,7 @@
         "name": "NYS Orthos Online",
         "start_date": "2013",
         "type": "wms",
-        "url": "https://orthos.dhses.ny.gov/arcgis/services/Latest/MapServer/WmsServer?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=0,1,2,3,4&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://orthos.its.ny.gov/arcgis/services/wms/Latest/MapServer/WmsServer?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=0,1,2,3&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "category": "photo"
     },
     "type": "Feature"


### PR DESCRIPTION
Updated URLs to reflect changes in server names, as reflected in https://gis.ny.gov/gateway/mg/webserv/webserv.html

Removed `LAYER 4` since it was causing errors.