### PR TITLE
europe/ch: remove best flag for imagery older than current swissimage

### DIFF
--- a/sources/europe/ch/Canton_de_Geneve_orthophoto2019_5cm.geojson
+++ b/sources/europe/ch/Canton_de_Geneve_orthophoto2019_5cm.geojson
@@ -12,7 +12,7 @@
             "required": true
         },
         "type": "wms",
-        "best": true,
+        "best": false,
         "category": "photo",
         "available_projections": [
             "CRS:84",

--- a/sources/europe/ch/KantonAargau50cm-AGISHILLSHADE2014.geojson
+++ b/sources/europe/ch/KantonAargau50cm-AGISHILLSHADE2014.geojson
@@ -16,7 +16,7 @@
         "min_zoom": 2,
         "country_code": "CH",
         "type": "tms",
-        "best": true,
+        "best": false,
         "category": "elevation"
     },
     "geometry": {

--- a/sources/europe/ch/KantonBasel-Landschaft12cm-2015.geojson
+++ b/sources/europe/ch/KantonBasel-Landschaft12cm-2015.geojson
@@ -17,7 +17,7 @@
         "min_zoom": 17,
         "country_code": "CH",
         "type": "tms",
-        "best": true,
+        "best": false,
         "category": "photo"
     },
     "geometry": {

--- a/sources/europe/ch/KantonZug2011wms.geojson
+++ b/sources/europe/ch/KantonZug2011wms.geojson
@@ -12,7 +12,7 @@
             "EPSG:21781",
             "EPSG:2056"
         ],
-        "best": true,
+        "best": false,
         "country_code": "CH",
         "start_date": "2011",
         "end_date": "2011",

--- a/sources/europe/ch/KantonZug2016wms.geojson
+++ b/sources/europe/ch/KantonZug2016wms.geojson
@@ -12,7 +12,7 @@
             "EPSG:3857",
             "EPSG:4326"
         ],
-        "best": true,
+        "best": false,
         "country_code": "CH",
         "start_date": "2016",
         "end_date": "2016",

--- a/sources/europe/ch/KantonZug2018wms.geojson
+++ b/sources/europe/ch/KantonZug2018wms.geojson
@@ -12,7 +12,7 @@
             "EPSG:2056",
             "CRS:84"
         ],
-        "best": true,
+        "best": false,
         "country_code": "CH",
         "start_date": "2018",
         "end_date": "2018",

--- a/sources/europe/ch/Kanton_Schaffhausen_ortho_2013.geojson
+++ b/sources/europe/ch/Kanton_Schaffhausen_ortho_2013.geojson
@@ -11,7 +11,7 @@
         "id": "Kanton-Schaffhausen-Luftbild-2013",
         "country_code": "CH",
         "default": false,
-        "best": true,
+        "best": false,
         "start_date": "2013",
         "end_date": "2013",
         "category": "photo",

--- a/sources/europe/ch/Kanton_Solothurn_ortho_2016_wms.geojson
+++ b/sources/europe/ch/Kanton_Solothurn_ortho_2016_wms.geojson
@@ -11,7 +11,7 @@
         "description": "",
         "country_code": "CH",
         "default": false,
-        "best": true,
+        "best": false,
         "start_date": "2016",
         "end_date": "2016",
         "category": "photo",

--- a/sources/europe/ch/Kanton_Solothurn_ortho_2017_wms.geojson
+++ b/sources/europe/ch/Kanton_Solothurn_ortho_2017_wms.geojson
@@ -11,7 +11,7 @@
         "description": "",
         "country_code": "CH",
         "default": false,
-        "best": true,
+        "best": false,
         "start_date": "2017",
         "end_date": "2017",
         "category": "photo",

--- a/sources/europe/ch/Kanton_Thurgau_ortho_2017_wms.geojson
+++ b/sources/europe/ch/Kanton_Thurgau_ortho_2017_wms.geojson
@@ -13,7 +13,7 @@
         "description": "Digitales multispektrales Orthofotomosaik des Kantons Thurgau",
         "country_code": "CH",
         "default": false,
-        "best": true,
+        "best": false,
         "start_date": "2017",
         "end_date": "2017",
         "available_projections": [

--- a/sources/europe/ch/Kanton_Zurich_ortho_2018_wms.geojson
+++ b/sources/europe/ch/Kanton_Zurich_ortho_2018_wms.geojson
@@ -13,7 +13,7 @@
             "EPSG:21780",
             "EPSG:21781"
         ],
-        "best": true,
+        "best": false,
         "country_code": "CH",
         "start_date": "2018",
         "end_date": "2018",

--- a/sources/europe/ch/StadtSanktGallen2018.geojson
+++ b/sources/europe/ch/StadtSanktGallen2018.geojson
@@ -993,7 +993,7 @@
             "EPSG:4326",
             "EPSG:2056"
         ],
-        "best": true,
+        "best": false,
         "country_code": "CH",
         "start_date": "2018",
         "end_date": "2018",


### PR DESCRIPTION
This PR removes the best flag for all sources where the year of the imagery is smaller than the swissimage year: https://map.geo.admin.ch/?lang=en&topic=ech&bgLayer=voidLayer&layers=ch.swisstopo.images-swissimage-dop10.metadata,ch.swisstopo.swissboundaries3d-kanton-flaeche.fill&E=2695532.45&N=1236760.07&zoom=2

CC @simonpoole 