### PR TITLE
Update PNOA Spain TMS to use JPEG format

### DIFF
--- a/sources/europe/es/PNOASpain-TMS.geojson
+++ b/sources/europe/es/PNOASpain-TMS.geojson
@@ -6,7 +6,7 @@
             "required": true
         },
         "name": "PNOA Spain",
-        "url": "https://www.ign.es/wmts/pnoa-ma?request=GetTile&service=WMTS&VERSION=1.0.0&Layer=OI.OrthoimageCoverage&Style=default&Format=image/png&TileMatrixSet=GoogleMapsCompatible&TileMatrix={zoom}&TileRow={y}&TileCol={x}",
+        "url": "https://www.ign.es/wmts/pnoa-ma?request=GetTile&service=WMTS&VERSION=1.0.0&Layer=OI.OrthoimageCoverage&Style=default&Format=image/jpeg&TileMatrixSet=GoogleMapsCompatible&TileMatrix={zoom}&TileRow={y}&TileCol={x}",
         "country_code": "ES",
         "type": "tms",
         "id": "PNOA-Spain-TMS",


### PR DESCRIPTION
I'm submitting this change in the format of the images requested to the PNOA TMS service for Spain as a request by the Spanish NMA (IGN/CNIG). `image/jpeg` requests are cached by their CDN as opposed to the current `image/png`, making the editing experience slower for everyone.

