### PR TITLE
Switch WMS sync back to weekly

### DIFF
--- a/.github/workflows/sync_wms.yml
+++ b/.github/workflows/sync_wms.yml
@@ -2,8 +2,8 @@ name: ELI WMS sync
 
 on:
   schedule:
-    - cron: "0 0 * * *" # daily
-    # - cron: '0 0 * * 0' # weekly
+    #- cron: "0 0 * * *" # daily
+    - cron: '0 0 * * 0' # weekly
 
 jobs:
   wms_sync:


### PR DESCRIPTION
The last few weeks the wms sync script run daily and it seemed to behave as expected. Thus, it is ok to switch back to weekly runs. 