### PR TITLE
Update PDOK-Luchtfoto-Beeldmateriaal-25cm-latest.geojson

### DIFF
--- a/sources/europe/nl/PDOK-Luchtfoto-Beeldmateriaal-25cm-latest.geojson
+++ b/sources/europe/nl/PDOK-Luchtfoto-Beeldmateriaal-25cm-latest.geojson
@@ -241,7 +241,7 @@
         "max_zoom": 19,
         "name": "PDOK aerial imagery Beeldmateriaal.nl 25cm latest",
         "type": "tms",
-        "url": "https://geodata.nationaalgeoregister.nl/luchtfoto/rgb/wmts?FORMAT=image/jpeg&SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=Actueel_ortho25&STYLE=&FORMAT=image/jpeg&tileMatrixSet=OGC:1.0:GoogleMapsCompatible&tileMatrix={zoom}&tileRow={y}&tileCol={x}",
+        "url": "https://service.pdok.nl/hwh/luchtfotorgb/wmts/v1_0?FORMAT=image/jpeg&SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=Actueel_ortho25&STYLE=&FORMAT=image/jpeg&tileMatrixSet=OGC:1.0:GoogleMapsCompatible&tileMatrix={zoom}&tileRow={y}&tileCol={x}",
         "category": "photo"
     },
     "type": "Feature"

--- a/sources/europe/nl/PDOK-Luchtfoto-Beeldmateriaal-25cm-latest.geojson
+++ b/sources/europe/nl/PDOK-Luchtfoto-Beeldmateriaal-25cm-latest.geojson
@@ -238,6 +238,7 @@
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/nl/PDOK-Luchtfoto-Beeldmateriaal-25cm-latest.png",
         "id": "Actueel_ortho25_WMS",
         "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=630995#p630995",
+        "privacy_policy_url": "https://www.pdok.nl/privacy",
         "max_zoom": 19,
         "name": "PDOK aerial imagery Beeldmateriaal.nl 25cm latest",
         "type": "tms",


### PR DESCRIPTION
Old url is after 1 juni 2021 out of production.
New:
https://service.pdok.nl/hwh/luchtfotorgb/wmts/v1_0?&request=GetCapabilities&service=wmts

https://geoforum.nl/t/oude-url-s-van-pdok-luchtfoto-definitief-uit-productie/5829