### PR TITLE
Addition of 2010 Fortaleza Orthophotos

### DIFF
--- a/sources/south-america/br/Fortaleza_2010_Orthophoto.geojson
+++ b/sources/south-america/br/Fortaleza_2010_Orthophoto.geojson
@@ -1,0 +1,31 @@
+{
+  "type" : "Feature",
+  "properties" : {
+    "name" : "Fortaleza Ortofoto 2010",
+    "type" : "wms",
+    "category": "historicphoto",
+    "url" : "https://geoserver.sefin.fortaleza.ce.gov.br/geoserver/IMAGEAMENTO/wms?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=ortofoto_2010&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+    "permission_osm": "explicit",
+    "license_url": "https://wiki.openstreetmap.org/wiki/File:Autoriza%C3%A7%C3%A3o_IDE_SEFIN_Fortaleza.png",
+    "privacy_policy_url": "https://www.sefin.fortaleza.ce.gov.br/Canal/16/Generico/1339/Ler",
+    "id" : "Fortaleza_Ortofoto_2010",
+    "description": "2010 Orthophotos from Fortaleza",
+    "country_code": "BR",
+    "start_date": "2010",
+    "end_date": "2010",
+    "available_projections" : [
+            "EPSG:31984",
+            "EPSG:4326"
+    ],
+    "attribution": {
+      "url": "https://ide.sefin.fortaleza.ce.gov.br/",
+      "text": "Prefeitura Municipal de Fortaleza"
+    },
+    "valid-georeference": true
+
+  },
+  "geometry" : {
+    "type":"Polygon",
+    "coordinates":[[[-38.58817689639,-3.68552318525],[-38.62282869211,-3.71420253888],[-38.65849510732,-3.80814408201],[-38.50982407218,-3.90782293092],[-38.39913154966,-3.8176782637],[-38.46391325286,-3.69670766831],[-38.50176848695,-3.71226679713],[-38.58817689639,-3.68552318525]]]
+  }
+}


### PR DESCRIPTION
Hi there,

Following successful PR #1211 and PR #1227 the local community asked to also add 2010 Orthophotos, from the same source: Spatial Data Infrastructure - Municipality of Fortaleza/Brazil (explicit permission to use in OSM [here](https://wiki.openstreetmap.org/wiki/File:Autoriza%C3%A7%C3%A3o_IDE_SEFIN_Fortaleza.png)).

This layer is already available on [JOSM](https://josm.openstreetmap.de/wiki/Maps/Brazil#FortalezaOrthophoto2010) too.

Thank you for all your support!

Best,
Matheus