### PR TITLE
Update NAIP imagery based on watchdog result

### DIFF
--- a/sources/north-america/us/USDA-NAIP.geojson
+++ b/sources/north-america/us/USDA-NAIP.geojson
@@ -2,6 +2,11 @@
     "type": "Feature",
     "properties": {
         "id": "USDA-NAIP",
+        "attribution": {
+            "url": "https://naip-usdaonline.hub.arcgis.com/",
+            "text": "U.S. Department of Agriculture",
+            "required": false
+        },
         "name": "National Agriculture Imagery Program",
         "type": "wms",
         "url": "https://gis.apfo.usda.gov/arcgis/services/NAIP/USDA_CONUS_PRIME/ImageServer/WMSServer?LAYERS=0&STYLES=&FORMAT=image/jpeg&TRANSPARENT=TRUE&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
@@ -10,13 +15,18 @@
             "EPSG:3857",
             "EPSG:4326"
         ],
+        "start_date": "2018",
+        "end_date": "2020",
         "max_zoom": 20,
         "min_zoom": 12,
+        "license_url": "https://www.usda.gov/policies-and-links/",
         "country_code": "US",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/north-america/us/USDA.png",
-        "description": "The most recent year of DOQQs from the National Agriculture Imagery Program (NAIP) for each state in the contiguous United States.",
+        "description": "The most recent year of 60cm 4-band DOQQs from the National Agriculture Imagery Program (NAIP) for each state in the contiguous United States.",
         "i18n": true,
-        "category": "photo"
+        "category": "photo",
+        "privacy_policy_url": "https://www.usda.gov/privacy-policy",
+        "valid-georeference": true
     },
     "geometry": {
         "type": "Polygon",
@@ -4157,6 +4167,64 @@
                     49.0645144
                 ]
             ],
+			[
+				[
+              -117.1142578125,
+              37.920367835943516
+				],
+				[
+				-117.10464477539061,
+				37.39443683148101
+				],
+				[
+				-116.79908752441406,
+				37.10968165142563
+				],
+				[
+				-116.40375137329103,
+				36.630406976495614
+				],
+				[
+				-115.98987579345702,
+				36.62455202137101
+				],
+				[
+				-115.99021911621094,
+				36.52950186333475
+				],
+				[
+				-115.56793212890625,
+				36.520259426268346
+				],
+				[
+				-115.4498291015625,
+				36.4477991295848
+				],
+				[
+				-115.25207519531249,
+				36.4477991295848
+				],
+				[
+				-115.257568359375,
+				37.42252593456307
+				],
+				[
+				-115.80825805664062,
+				37.8271414168374
+				],
+				[
+				-116.23672485351564,
+				37.83039548690152
+				],
+				[
+				-116.23535156249999,
+				37.920367835943516
+				],
+				[
+				-117.1142578125,
+				37.920367835943516
+				]
+			],
             [
                 [
                     -82.9407144,


### PR DESCRIPTION
This PR:

1. Exclude Nevada Test and Training Range from the boundary.
2. Add license and privacy fields.
3. Specifies start and end dates. Note that these two may need to be updated in the future upon new image acquisition is complete.
![AREA 51](https://user-images.githubusercontent.com/686438/131759934-5099840b-8255-4430-ae74-146c88981fb4.png)
