### PR TITLE
Fix ewidencja budynków geoportal

### DIFF
--- a/sources/europe/pl/Geoportal2EwidencjabudynkówWMS.geojson
+++ b/sources/europe/pl/Geoportal2EwidencjabudynkówWMS.geojson
@@ -6,7 +6,6 @@
         "description": "Usługa Krajowa Integracja Ewidencji Gruntów jest usługą zbiorczą prezentacji danych ewidencyjnych pochodzących bezpośrednio z jednostek szczebla powiatowego. Usługa zawiera jedynie dane tych jednostek, które dysponują usługą WMS o odpowiednich parametrach i zdecydowały się włączyć swoją usługę WMS do usługi zbiorczej KrajowaIntegracjaEwidencjiGruntow.",
         "type": "wms",
         "url": "https://integracja.gugik.gov.pl/cgi-bin/KrajowaIntegracjaEwidencjiGruntow?LAYERS=budynki&STYLES=default&FORMAT=image/png&TRANSPARENT=TRUE&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
-        "best": true,
         "country_code": "PL",
         "available_projections": [
             "EPSG:2176",

--- a/sources/europe/pl/Geoportal2Nazwyulic.geojson
+++ b/sources/europe/pl/Geoportal2Nazwyulic.geojson
@@ -6,7 +6,6 @@
         "description": "Usługa przeglądania WMS Krajowa Integracja Numeracji Adresowej umożliwiająca pobieranie obrazów mapowych utworzonych na podstawie danych przestrzennych z Państwowego Rejestru Granic w zakresie ewidencji ulic i adresów.",
         "type": "wms",
         "url": "https://integracja.gugik.gov.pl/cgi-bin/KrajowaIntegracjaNumeracjiAdresowej?LAYERS=prg-ulice&STYLES=default&FORMAT=image/png&TRANSPARENT=TRUE&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
-        "best": true,
         "country_code": "PL",
         "available_projections": [
             "EPSG:2176",

--- a/sources/europe/pl/Geoportal2Punktyadresowe.geojson
+++ b/sources/europe/pl/Geoportal2Punktyadresowe.geojson
@@ -6,7 +6,6 @@
         "description": "Usługa przeglądania WMS Krajowa Integracja Numeracji Adresowej umożliwiająca pobieranie obrazów mapowych utworzonych na podstawie danych przestrzennych z Państwowego Rejestru Granic w zakresie ewidencji ulic i adresów.",
         "type": "wms",
         "url": "https://integracja.gugik.gov.pl/cgi-bin/KrajowaIntegracjaNumeracjiAdresowej?LAYERS=prg-adresy&STYLES=default&FORMAT=image/png&TRANSPARENT=TRUE&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
-        "best": true,
         "country_code": "PL",
         "available_projections": [
             "EPSG:2176",


### PR DESCRIPTION
It's that time of the year when I contribute to open source projects, meaning its Hacktoberfest time! Thus it would be great if this PR can be given the 'hacktoberfest-accepted' label.

Basically since there has been no change on the iD side I have removed the attribute best from the overlays as this makes them the default layer for Poland and because of that the first thing one sees when opening the editor is this:

![image](https://user-images.githubusercontent.com/62251475/135744314-5a439a2d-202e-45f8-b5e5-e88f903fb957.png)

Instead of something like this: 
![image](https://user-images.githubusercontent.com/62251475/135744320-59769141-5d0a-4668-b666-3209f760a2a3.png)
