### PR TITLE
set category of all OpenRailwayMap overlays to "osmbasedmap"

### DIFF
--- a/sources/world/OpenRailwayMapMaxspeeds.geojson
+++ b/sources/world/OpenRailwayMapMaxspeeds.geojson
@@ -4,6 +4,7 @@
     "id": "openrailwaymap-maxspeeds",
     "name": "OpenRailwayMap Maxspeeds",
     "type": "tms",
+    "category": "osmbasedmap",
     "url": "https://{switch:a,b,c}.tiles.openrailwaymap.org/maxspeed/{zoom}/{x}/{y}.png",
     "overlay": true,
     "attribution": {

--- a/sources/world/OpenRailwayMapSignalling.geojson
+++ b/sources/world/OpenRailwayMapSignalling.geojson
@@ -4,6 +4,7 @@
     "id": "openrailwaymap-signalling",
     "name": "OpenRailwayMap Signalling",
     "type": "tms",
+    "category": "osmbasedmap",
     "url": "https://{switch:a,b,c}.tiles.openrailwaymap.org/signals/{zoom}/{x}/{y}.png",
     "overlay": true,
     "attribution": {


### PR DESCRIPTION
To be in line with the [main OpenRailwayMap layer](https://github.com/osmlab/editor-layer-index/blob/4617927a28777fd65611f5a3c231b73c42af4a96/sources/world/OpenRailwayMap.geojson?short_path=8120ea5#L7) and [JOSM's imagery index](https://josm.openstreetmap.de/wiki/Maps/Worldwide#OpenRailwayMap-MaxSpeed) (small addition to #720).