### PR TITLE
change category of Waymarked Trails layers to "osmbasedmap"

### DIFF
--- a/sources/world/WMT-cycling.geojson
+++ b/sources/world/WMT-cycling.geojson
@@ -13,7 +13,7 @@
         "url": "https://tile.waymarkedtrails.org/cycling/{zoom}/{x}/{y}.png",
         "max_zoom": 17,
         "type": "tms",
-        "category": "other",
+        "category": "osmbasedmap",
         "icon": "https://static.waymarkedtrails.org/img/map_cycling.png"
     },
     "geometry": null

--- a/sources/world/WMT-hiking.geojson
+++ b/sources/world/WMT-hiking.geojson
@@ -13,7 +13,7 @@
         "url": "https://tile.waymarkedtrails.org/hiking/{zoom}/{x}/{y}.png",
         "max_zoom": 17,
         "type": "tms",
-        "category": "other",
+        "category": "osmbasedmap",
         "icon": "https://static.waymarkedtrails.org/img/map_hiking.png"
     },
     "geometry": null

--- a/sources/world/WMT-horseriding.geojson
+++ b/sources/world/WMT-horseriding.geojson
@@ -4,7 +4,7 @@
     "id": "Waymarked_Trails-Horse_Riding",
     "name": "Waymarked Trails: Horse Riding",
     "type": "tms",
-    "category": "other",
+    "category": "osmbasedmap",
     "url": "https://tile.waymarkedtrails.org/riding/{zoom}/{x}/{y}.png",
     "overlay": true,
     "attribution": {

--- a/sources/world/WMT-mtb.geojson
+++ b/sources/world/WMT-mtb.geojson
@@ -13,7 +13,7 @@
         "url": "https://tile.waymarkedtrails.org/mtb/{zoom}/{x}/{y}.png",
         "max_zoom": 17,
         "type": "tms",
-        "category": "other",
+        "category": "osmbasedmap",
         "icon": "https://static.waymarkedtrails.org/img/map_mtb.png"
     },
     "geometry": null

--- a/sources/world/WMT-skating.geojson
+++ b/sources/world/WMT-skating.geojson
@@ -13,7 +13,7 @@
         "url": "https://tile.waymarkedtrails.org/skating/{zoom}/{x}/{y}.png",
         "max_zoom": 17,
         "type": "tms",
-        "category": "other",
+        "category": "osmbasedmap",
         "icon": "https://static.waymarkedtrails.org/img/map_skating.png"
     },
     "geometry": null

--- a/sources/world/WMT-slopemap.geojson
+++ b/sources/world/WMT-slopemap.geojson
@@ -13,7 +13,7 @@
         "url": "https://tile.waymarkedtrails.org/slopes/{zoom}/{x}/{y}.png",
         "max_zoom": 17,
         "type": "tms",
-        "category": "other",
+        "category": "osmbasedmap",
         "icon": "https://static.waymarkedtrails.org/img/map_slopes.png"
     },
     "geometry": null


### PR DESCRIPTION
I'm not sure why the Waymarked Trails overlays got categorized as `other` in #761, but I think `osmbasedmap` fits better.

@lonvia @simonpoole @grischard @Klumbumbus – what do you think?