### PR TITLE
fix South Tyrol hillshade layers

### DIFF
--- a/sources/europe/it/SouthTyrol-Hillshade_DSM-2006-lowres.geojson
+++ b/sources/europe/it/SouthTyrol-Hillshade_DSM-2006-lowres.geojson
@@ -27,10 +27,10 @@
         "country_code": "IT",
         "type": "wms",
         "category": "elevation",
-        "start_date": "2013",
-        "end_date": "2013",
-        "id": "South-Tyrol-DSM_2013_2_5m",
-        "name": "South Tyrol DSM Hillshade 2013 (2.5 m)"
+        "start_date": "2006",
+        "end_date": "2006",
+        "id": "South-Tyrol-DSM_2006_2_5m",
+        "name": "South Tyrol DSM Hillshade 2006 (2.5 m)"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/it/SouthTyrol-Hillshade_DSM-2006-lowres.geojson
+++ b/sources/europe/it/SouthTyrol-Hillshade_DSM-2006-lowres.geojson
@@ -6,7 +6,7 @@
             "text": "© Autonomen Provinz Bozen/Provincia Autonoma di Bolzano CC0-1.0",
             "required": true
         },
-        "license_url": "https://geoservices.buergernetz.bz.it/geonetwork/srv/ger/pdf?uuid=p_bz:280ef207-6acf-442a-b35b-4477e96ef5db",
+        "license_url": "https://geoservices.buergernetz.bz.it/geonetwork/srv/ger/pdf?uuid=p_bz:Elevation:DigitalElevationModel-2.5m",
         "privacy_policy_url": "https://geoportal.buergernetz.bz.it/privacy.asp",
         "description": "Schummerung errechnet aus dem DSM)",
         "available_projections": [

--- a/sources/europe/it/SouthTyrol-Hillshade_DSM-2006-lowres.geojson
+++ b/sources/europe/it/SouthTyrol-Hillshade_DSM-2006-lowres.geojson
@@ -23,7 +23,7 @@
             "EPSG:31254",
             "EPSG:32632"
         ],
-        "url": "https://geoservices.buergernetz.bz.it/geoserver/p_bz-elevation/ows?LAYERS=DSM-2p5m_Hillshade&STYLES=DSM-2p5m_Hillshade&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "url": "https://geoservices1.civis.bz.it/geoserver/p_bz-Elevation/wms?LAYERS=p_bz-Elevation:DigitalElevationModel-2.5m-Hillshade&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
         "country_code": "IT",
         "type": "wms",
         "category": "elevation",

--- a/sources/europe/it/SouthTyrol-Hillshade_DSM-2013-highres.geojson
+++ b/sources/europe/it/SouthTyrol-Hillshade_DSM-2013-highres.geojson
@@ -23,7 +23,7 @@
             "EPSG:31254",
             "EPSG:32632"
         ],
-        "url": "https://geoservices.buergernetz.bz.it/geoserver/p_bz-elevation/ows?LAYERS=DSM_Hillshade_SolarTirol_3857&STYLES=DSM_Hillshade_SolarTirol_3857&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "url": "https://geoservices1.civis.bz.it/geoserver/p_bz-Elevation/wms?LAYERS=p_bz-Elevation:DigitalElevationModel-0.5m-Hillshade&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
         "country_code": "IT",
         "type": "wms",
         "category": "elevation",

--- a/sources/europe/it/SouthTyrol-Hillshade_DSM-2013-highres.geojson
+++ b/sources/europe/it/SouthTyrol-Hillshade_DSM-2013-highres.geojson
@@ -6,7 +6,7 @@
             "text": "© Autonomen Provinz Bozen/Provincia Autonoma di Bolzano CC0-1.0",
             "required": true
         },
-        "license_url": "https://geoservices.buergernetz.bz.it/geonetwork/srv/ger/pdf?uuid=p_bz:625ee1fc-59f1-4a9d-af62-c6633adb1e4a",
+        "license_url": "https://geoservices.buergernetz.bz.it/geonetwork/srv/ger/pdf?uuid=p_bz:Elevation:DigitalElevationModel-0.5m",
         "privacy_policy_url": "https://geoportal.buergernetz.bz.it/privacy.asp",
         "description": "Schummerung errechnet aus dem DSM)",
         "available_projections": [

--- a/sources/europe/it/SouthTyrol-Hillshade_DTM-2006-lowres.geojson
+++ b/sources/europe/it/SouthTyrol-Hillshade_DTM-2006-lowres.geojson
@@ -6,7 +6,7 @@
             "text": "© Autonomen Provinz Bozen/Provincia Autonoma di Bolzano CC0-1.0",
             "required": true
         },
-        "license_url": "https://geoservices.buergernetz.bz.it/geonetwork/srv/ger/pdf?uuid=p_bz:280ef207-6acf-442a-b35b-4477e96ef5db",
+        "license_url": "https://geoservices.buergernetz.bz.it/geonetwork/srv/ger/pdf?uuid=p_bz:Elevation:DigitalTerrainModel-2.5m",
         "privacy_policy_url": "https://geoportal.buergernetz.bz.it/privacy.asp",
         "description": "Schummerung errechnet aus dem DTM",
         "available_projections": [

--- a/sources/europe/it/SouthTyrol-Hillshade_DTM-2006-lowres.geojson
+++ b/sources/europe/it/SouthTyrol-Hillshade_DTM-2006-lowres.geojson
@@ -23,7 +23,7 @@
             "EPSG:31254",
             "EPSG:32632"
         ],
-        "url": "https://geoservices.buergernetz.bz.it/geoserver/p_bz-elevation/ows?LAYERS=DTM-2p5m_Hillshade&STYLES=DTM-2p5m_Hillshade&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "url": "https://geoservices1.civis.bz.it/geoserver/p_bz-Elevation/wms?LAYERS=p_bz-Elevation:DigitalTerrainModel-2.5m-Hillshade&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
         "country_code": "IT",
         "type": "wms",
         "category": "elevation",

--- a/sources/europe/it/SouthTyrol-Hillshade_DTM-2006-lowres.geojson
+++ b/sources/europe/it/SouthTyrol-Hillshade_DTM-2006-lowres.geojson
@@ -27,10 +27,10 @@
         "country_code": "IT",
         "type": "wms",
         "category": "elevation",
-        "start_date": "2013",
-        "end_date": "2013",
-        "id": "South-Tyrol-DTM_2013_2_5m",
-        "name": "South Tyrol DTM Hillshade 2013 (2.5 m)"
+        "start_date": "2006",
+        "end_date": "2006",
+        "id": "South-Tyrol-DTM_2006_2_5m",
+        "name": "South Tyrol DTM Hillshade 2006 (2.5 m)"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/it/SouthTyrol-Hillshade_DTM-2013-highres.geojson
+++ b/sources/europe/it/SouthTyrol-Hillshade_DTM-2013-highres.geojson
@@ -6,7 +6,7 @@
             "text": "© Autonomen Provinz Bozen/Provincia Autonoma di Bolzano CC0-1.0",
             "required": true
         },
-        "license_url": "https://geoservices.buergernetz.bz.it/geonetwork/srv/ger/pdf?uuid=p_bz:a060f1bf-1149-4c57-bdb7-400464e112d5",
+        "license_url": "https://geoservices.buergernetz.bz.it/geonetwork/srv/ger/pdf?uuid=p_bz:Elevation:DigitalTerrainModel-0.5m",
         "privacy_policy_url": "https://geoportal.buergernetz.bz.it/privacy.asp",
         "description": "Schummerung errechnet aus dem DTM",
         "available_projections": [

--- a/sources/europe/it/SouthTyrol-Hillshade_DTM-2013-highres.geojson
+++ b/sources/europe/it/SouthTyrol-Hillshade_DTM-2013-highres.geojson
@@ -23,7 +23,7 @@
             "EPSG:31254",
             "EPSG:32632"
         ],
-        "url": "https://geoservices.buergernetz.bz.it/geoserver/p_bz-elevation/ows?LAYERS=DTM_Hillshade_SolarTirol_3857&STYLES=DTM_Hillshade_SolarTirol_3857&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "url": "https://geoservices1.civis.bz.it/geoserver/p_bz-Elevation/wms?LAYERS=p_bz-Elevation:DigitalTerrainModel-0.5m-Hillshade&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
         "country_code": "IT",
         "type": "wms",
         "category": "elevation",


### PR DESCRIPTION
Apparently the WMS endpoint was changed to a new URL and the layers were renamed.

This also fixes the incorrect vintage of the 2.5m resolution "lowers" DTM/DSM layers, which has data from 2006 (not 2013).