### PR TITLE
Updates to NYSDOP_Latest

### DIFF
--- a/sources/north-america/us/ny/NYSDOP_Latest.geojson
+++ b/sources/north-america/us/ny/NYSDOP_Latest.geojson
@@ -1379,7 +1379,7 @@
         "max_zoom": 19,
         "name": "NYSDOP Orthoimagery - Latest",
         "type": "wms",
-        "url": "https://orthos.its.ny.gov/arcgis/services/wms/Latest/MapServer/WmsServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0,1,2,3&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://orthos.its.ny.gov/arcgis/services/wms/Latest/MapServer/WmsServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0,1,2,3,4&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "privacy_policy_url": "https://its.ny.gov/its-internet-security-and-privacy-policy",
         "category": "photo",
         "valid-georeference": true


### PR DESCRIPTION
The 2021 imagery batch is now live, and these changes will enable it.

Additionally, I noticed that this repository requests tiles as JPEGs, whereas JOSM requests PNGs with transparency (see [here](https://josm.openstreetmap.de/wiki/Maps/USA%20States)). I went ahead and switched this to the transparent PNGs, which should be advantageous.