### PR TITLE
Update Spain PNOA TMS URL

### DIFF
--- a/sources/europe/es/PNOASpain-TMS.geojson
+++ b/sources/europe/es/PNOASpain-TMS.geojson
@@ -6,7 +6,7 @@
             "required": true
         },
         "name": "PNOA Spain",
-        "url": "https://www.ign.es/wmts/pnoa-ma?request=GetTile&service=WMTS&VERSION=1.0.0&Layer=OI.OrthoimageCoverage&Style=default&Format=image/jpeg&TileMatrixSet=GoogleMapsCompatible&TileMatrix={zoom}&TileRow={y}&TileCol={x}",
+        "url": "https://tms-pnoa-ma.idee.es/1.0.0/pnoa-ma/{z}/{x}/{-y}.jpeg",
         "country_code": "ES",
         "type": "tms",
         "id": "PNOA-Spain-TMS",

--- a/sources/europe/es/PNOASpain-TMS.geojson
+++ b/sources/europe/es/PNOASpain-TMS.geojson
@@ -6,7 +6,7 @@
             "required": true
         },
         "name": "PNOA Spain",
-        "url": "https://tms-pnoa-ma.idee.es/1.0.0/pnoa-ma/{z}/{x}/{-y}.jpeg",
+        "url": "https://tms-pnoa-ma.idee.es/1.0.0/pnoa-ma/{zoom}/{x}/{-y}.jpeg",
         "country_code": "ES",
         "type": "tms",
         "id": "PNOA-Spain-TMS",


### PR DESCRIPTION
As a follow-up from #1121, I got again contacted by IGN/CNIG (Spanish NMA) representatives to request an update on the TMS URL being used in OSM editors to `https://tms-pnoa-ma.idee.es/1.0.0/pnoa-ma/{z}/{x}/{-y}.jpeg`.

cc. @msevilla00