### PR TITLE
Updated URL for DK imagery 

### DIFF
--- a/sources/europe/dk/SDFECadastralParcelsINSPIREView.geojson
+++ b/sources/europe/dk/SDFECadastralParcelsINSPIREView.geojson
@@ -656,10 +656,12 @@
         "country_code": "DK",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/dk/SDFESkrmkort.png",
         "id": "Geodatastyrelsen_Cadastral_Parcels_INSPIRE_View",
-        "max_zoom": 20,
+        "max_zoom": 19,
         "name": "SDFE Cadastral Parcels INSPIRE View",
         "type": "wms",
         "url": "https://services.datafordeler.dk/DKskaermkort/topo_skaermkort/1.0.0/Wms?username=OPFFZDPOAS&password=tRmWsq8p9LW2-pf&FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=dtk_skaermkort&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "license_url": "https://download.kortforsyningen.dk/content/om-kortforsyningendownload",
+        "privacy_policy_url": "https://dataforsyningen.dk/Persondata",
         "category": "other"
     },
     "type": "Feature"

--- a/sources/europe/dk/SDFECadastralParcelsINSPIREView.geojson
+++ b/sources/europe/dk/SDFECadastralParcelsINSPIREView.geojson
@@ -659,7 +659,7 @@
         "max_zoom": 20,
         "name": "SDFE Cadastral Parcels INSPIRE View",
         "type": "wms",
-        "url": "https://kortforsyningen.kms.dk/cp_inspire?LAYERS=CP.CadastralParcel&STYLES=&FORMAT=image/png&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LOGIN=OpenStreetMapDK2015&PASSWORD=Gall4Peters",
+        "url": "https://services.datafordeler.dk/DKskaermkort/topo_skaermkort/1.0.0/Wms?username=OPFFZDPOAS&password=tRmWsq8p9LW2-pf&FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=dtk_skaermkort&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "category": "other"
     },
     "type": "Feature"

--- a/sources/europe/dk/SDFEDTKKort25.geojson
+++ b/sources/europe/dk/SDFEDTKKort25.geojson
@@ -659,7 +659,7 @@
         "max_zoom": 19,
         "name": "SDFE DTK Kort25",
         "type": "wms",
-        "url": "https://api.dataforsyningen.dk/dtk_25_DAF?service=WMS&request=GetMap&token=52065b2ec5fda5a46a50b451f3f24473&FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&Layers=dkt25&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://api.dataforsyningen.dk/dtk_25_DAF?service=WMS&request=GetMap&token=52065b2ec5fda5a46a50b451f3f24473&FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&Layers=dtk25&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "license_url": "https://download.kortforsyningen.dk/content/om-kortforsyningendownload",
         "privacy_policy_url": "https://dataforsyningen.dk/Persondata",
         "category": "map"

--- a/sources/europe/dk/SDFEDTKKort25.geojson
+++ b/sources/europe/dk/SDFEDTKKort25.geojson
@@ -659,7 +659,7 @@
         "max_zoom": 19,
         "name": "SDFE DTK Kort25",
         "type": "wms",
-        "url": "https://kortforsyningen.kms.dk/topo25?FORMAT=image/png&VERSION=1.1.1&login=OpenStreetMapDK2015&password=Gall4Peters&SERVICE=WMS&REQUEST=GetMap&Layers=topo25_klassisk&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://api.dataforsyningen.dk/dtk_25_DAF?service=WMS&request=GetMap&token=52065b2ec5fda5a46a50b451f3f24473&FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&Layers=DTK25&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "category": "map"
     },
     "type": "Feature"

--- a/sources/europe/dk/SDFEDTKKort25.geojson
+++ b/sources/europe/dk/SDFEDTKKort25.geojson
@@ -660,6 +660,8 @@
         "name": "SDFE DTK Kort25",
         "type": "wms",
         "url": "https://api.dataforsyningen.dk/dtk_25_DAF?service=WMS&request=GetMap&token=52065b2ec5fda5a46a50b451f3f24473&FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&Layers=DTK25&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "license_url": "https://download.kortforsyningen.dk/content/om-kortforsyningendownload",
+        "privacy_policy_url": "https://dataforsyningen.dk/Persondata",
         "category": "map"
     },
     "type": "Feature"

--- a/sources/europe/dk/SDFEDTKKort25.geojson
+++ b/sources/europe/dk/SDFEDTKKort25.geojson
@@ -659,7 +659,7 @@
         "max_zoom": 19,
         "name": "SDFE DTK Kort25",
         "type": "wms",
-        "url": "https://api.dataforsyningen.dk/dtk_25_DAF?service=WMS&request=GetMap&token=52065b2ec5fda5a46a50b451f3f24473&FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&Layers=DTK25&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://api.dataforsyningen.dk/dtk_25_DAF?service=WMS&request=GetMap&token=52065b2ec5fda5a46a50b451f3f24473&FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&Layers=dkt25&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "license_url": "https://download.kortforsyningen.dk/content/om-kortforsyningendownload",
         "privacy_policy_url": "https://dataforsyningen.dk/Persondata",
         "category": "map"

--- a/sources/europe/dk/SDFESkrmkort.geojson
+++ b/sources/europe/dk/SDFESkrmkort.geojson
@@ -660,6 +660,8 @@
         "name": "SDFE Skærmkort",
         "type": "wms",
         "url": "https://services.datafordeler.dk/DKskaermkort/topo_skaermkort/1.0.0/Wms?username=OPFFZDPOAS&password=tRmWsq8p9LW2-pf&FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=dtk_skaermkort&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "license_url": "https://download.kortforsyningen.dk/content/om-kortforsyningendownload",
+        "privacy_policy_url": "https://dataforsyningen.dk/Persondata",
         "category": "map"
     },
     "type": "Feature"

--- a/sources/europe/dk/SDFESkrmkort.geojson
+++ b/sources/europe/dk/SDFESkrmkort.geojson
@@ -659,7 +659,7 @@
         "max_zoom": 19,
         "name": "SDFE Skærmkort",
         "type": "wms",
-        "url": "https://kortforsyningen.kms.dk/topo_skaermkort?FORMAT=image/png&VERSION=1.1.1&login=OpenStreetMapDK2015&password=Gall4Peters&SERVICE=WMS&REQUEST=GetMap&Layers=dtk_skaermkort&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://services.datafordeler.dk/DKskaermkort/topo_skaermkort/1.0.0/Wms?username=OPFFZDPOAS&password=tRmWsq8p9LW2-pf&FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=dtk_skaermkort&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "category": "map"
     },
     "type": "Feature"

--- a/sources/europe/dk/SDFESurfaceShadowMap(40cm).geojson
+++ b/sources/europe/dk/SDFESurfaceShadowMap(40cm).geojson
@@ -660,6 +660,8 @@
         "name": "SDFE Surface Shadow Map (40 cm)",
         "type": "wms",
         "url": "https://api.dataforsyningen.dk/dhm_DAF?service=WMS&request=GetMap&token=52065b2ec5fda5a46a50b451f3f24473&FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&Layers=dhm_overflade_skyggekort&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "license_url": "https://download.kortforsyningen.dk/content/om-kortforsyningendownload",
+        "privacy_policy_url": "https://dataforsyningen.dk/Persondata",
         "category": "elevation"
     },
     "type": "Feature"

--- a/sources/europe/dk/SDFESurfaceShadowMap(40cm).geojson
+++ b/sources/europe/dk/SDFESurfaceShadowMap(40cm).geojson
@@ -659,7 +659,7 @@
         "max_zoom": 20,
         "name": "SDFE Surface Shadow Map (40 cm)",
         "type": "wms",
-        "url": "https://kortforsyningen.kms.dk/dhm?login=OpenStreetMapDK2015&password=Gall4Peters&FORMAT=image/png&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&Layers=dhm_overflade_skyggekort&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://api.dataforsyningen.dk/dhm_DAF?service=WMS&request=GetMap&token=52065b2ec5fda5a46a50b451f3f24473&FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&Layers=dhm_overflade_skyggekort&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "category": "elevation"
     },
     "type": "Feature"

--- a/sources/europe/dk/SDFETerrainShadowMap(40cm).geojson
+++ b/sources/europe/dk/SDFETerrainShadowMap(40cm).geojson
@@ -659,7 +659,7 @@
         "max_zoom": 20,
         "name": "SDFE Terrain Shadow Map (40 cm)",
         "type": "wms",
-        "url": "https://kortforsyningen.kms.dk/dhm?login=OpenStreetMapDK2015&password=Gall4Peters&FORMAT=image/png&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&Layers=dhm_terraen_skyggekort&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://api.dataforsyningen.dk/dhm_DAF?service=WMS&request=GetMap&token=52065b2ec5fda5a46a50b451f3f24473&FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&Layers=dhm_terraen_skyggekort&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "category": "elevation"
     },
     "type": "Feature"

--- a/sources/europe/dk/SDFETerrainShadowMap(40cm).geojson
+++ b/sources/europe/dk/SDFETerrainShadowMap(40cm).geojson
@@ -660,6 +660,8 @@
         "name": "SDFE Terrain Shadow Map (40 cm)",
         "type": "wms",
         "url": "https://api.dataforsyningen.dk/dhm_DAF?service=WMS&request=GetMap&token=52065b2ec5fda5a46a50b451f3f24473&FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&Layers=dhm_terraen_skyggekort&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "license_url": "https://download.kortforsyningen.dk/content/om-kortforsyningendownload",
+        "privacy_policy_url": "https://dataforsyningen.dk/Persondata",
         "category": "elevation"
     },
     "type": "Feature"


### PR DESCRIPTION
Most of the Danish imagery is broken due to changes in the credentials. 
I don't know why it was changed, but I was told by a well known mapper in the Danish community told me, that the updated 
 URLs and credentials [can be found here](https://josm.openstreetmap.de/wiki/Maps/Denmark).

So here's my pull request trying to implement the updated URLs :)

Fixes #1416, Fixes #1405, Fixes #1415