### PR TITLE
Add europe / ch / Kanton Zug 2020 and 2021 imagery

### DIFF
--- a/sources/europe/ch/KantonZug2020wms.geojson
+++ b/sources/europe/ch/KantonZug2020wms.geojson
@@ -1,0 +1,56 @@
+{
+    "type": "Feature",
+    "properties": {
+        "attribution": {
+            "text": "GIS Kanton Zug",
+            "required": true
+        },
+        "available_projections": [
+            "CRS:84",
+            "EPSG:2056",
+            "EPSG:3857",
+            "EPSG:4326",
+            "EPSG:21781"
+        ],
+        "best": true,
+        "country_code": "CH",
+        "start_date": "2020",
+        "end_date": "2020",
+        "id": "Zug-2020-wms",
+        "name": "Kanton Zug Neuheim 2020 3.5 cm",
+        "license_url": "https://www.zg.ch/behoerden/direktion-des-innern/geoportal/geodaten-einbinden/wms",
+        "privacy_policy_url": "https://www.zg.ch/datenschutzerklaerung",
+        "type": "wms",
+        "description": "Orthofoto der Gemeinde Neuheim.",
+        "category": "photo",
+        "url": "https://services.geo.zg.ch/ows/Orthofotos?LAYERS=zg.orthofoto_2020_kt_zg&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "min_zoom": 6
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    8.611838,
+                    47.184806
+                ],
+                [
+                    8.611838,
+                    47.218916
+                ],
+                [
+                    8.557491,
+                    47.218916
+                ],
+                [
+                    8.557491,
+                    47.184806
+                ],
+                [
+                    8.611838,
+                    47.184806
+                ]
+            ]
+        ]
+    }
+}

--- a/sources/europe/ch/KantonZug2021wms.geojson
+++ b/sources/europe/ch/KantonZug2021wms.geojson
@@ -1,0 +1,56 @@
+{
+    "type": "Feature",
+    "properties": {
+        "attribution": {
+            "text": "GIS Kanton Zug",
+            "required": true
+        },
+        "available_projections": [
+            "CRS:84",
+            "EPSG:2056",
+            "EPSG:3857",
+            "EPSG:4326",
+            "EPSG:21781"
+        ],
+        "best": true,
+        "country_code": "CH",
+        "start_date": "2021",
+        "end_date": "2021",
+        "id": "Zug-2021-wms",
+        "name": "Kanton Zug Menzingen 2021 6.5 cm",
+        "license_url": "https://www.zg.ch/behoerden/direktion-des-innern/geoportal/geodaten-einbinden/wms",
+        "privacy_policy_url": "https://www.zg.ch/datenschutzerklaerung",
+        "type": "wms",
+        "description": "Orthofoto der Gemeinde Menzingen.",
+        "category": "photo",
+        "url": "https://services.geo.zg.ch/ows/Orthofotos?LAYERS=zg.orthofoto_2021_kt_zg&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "min_zoom": 6
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    8.666816,
+                    47.147032
+                ],
+                [
+                    8.666816,
+                    47.205748
+                ],
+                [
+                    8.553708,
+                    47.205748
+                ],
+                [
+                    8.553708,
+                    47.147032
+                ],
+                [
+                    8.666816,
+                    47.147032
+                ]
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
Add aerial imagery for the municipalities Neuheim (2020) and Menzingen (2021). 

The data can be sued freely but attribution is required:

> Die hier bereitgestellten Geodatendienste stehen zur freien Nutzung zur Verfügung. Für die Nutzenden bedeutet dies
> 
> Sie dürfen diesen Datensatz sowohl für nicht-​kommerzielle wie auch kommerzielle Zwecke nutzen.
> Eine Quellenangabe ist Pflicht ("Quelle: GIS Kanton Zug").
https://www.zg.ch/behoerden/direktion-des-innern/geoportal/geodaten-einbinden/wms

There is an entry for the corresponding WMS server in https://wiki.openstreetmap.org/wiki/Contributors#Switzerland

CC @simonpoole  