### PR TITLE
Fix NYS Orthos to accomodate for new layer IDs.

### DIFF
--- a/sources/north-america/us/ny/NYSDOP_Latest.geojson
+++ b/sources/north-america/us/ny/NYSDOP_Latest.geojson
@@ -1379,7 +1379,7 @@
         "max_zoom": 19,
         "name": "NYSDOP Orthoimagery - Latest",
         "type": "wms",
-        "url": "https://orthos.its.ny.gov/arcgis/services/wms/Latest/MapServer/WmsServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0,1,2,3,4&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://orthos.its.ny.gov/arcgis/services/wms/Latest/MapServer/WmsServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0,1,2,3&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "privacy_policy_url": "https://its.ny.gov/its-internet-security-and-privacy-policy",
         "category": "photo",
         "valid-georeference": true


### PR DESCRIPTION
Currently, this imagery source will error if you make a tile request, since the current URL asks for a layer that no longer exists. This fixes the issue.