### PR TITLE
remove "best" from au/nsw imagery

### DIFF
--- a/sources/oceania/au/nsw/NSW-WebServices-Imagery.geojson
+++ b/sources/oceania/au/nsw/NSW-WebServices-Imagery.geojson
@@ -15,7 +15,6 @@
         "country_code": "AU",
         "type": "tms",
         "id": "NSW_LPI_Imagery",
-        "best": true,
         "icon": "https://www.spatial.nsw.gov.au/__data/assets/file/0017/224801/favicon.ico",
         "category": "photo"
     },


### PR DESCRIPTION
The community has voted at
https://discord.com/channels/413070382636072960/471231032645910529/958215360232960020
5 to 0 that the DCS Imagery is no longer the best compared to Bing