### PR TITLE
Fix tile licence

### DIFF
--- a/sources/world/OpenStreetMap-Mapnik.geojson
+++ b/sources/world/OpenStreetMap-Mapnik.geojson
@@ -3,7 +3,7 @@
     "properties": {
         "attribution": {
             "required": true,
-            "text": "\u00a9 OpenStreetMap contributors, CC-BY-SA 2.0",
+            "text": "\u00a9 OpenStreetMap contributors, ODbL 1.0",
             "url": "https://www.openstreetmap.org"
         },
         "default": true,


### PR DESCRIPTION
The OSM standard style tiles haven't been CC BY-SA 2.0 licensed since mid 2020, wit https://blog.openstreetmap.org/2020/06/25/new-licence-for-the-standard-style-tiles-from-openstreetmap-org/