### PR TITLE
Add property 'support_cors' and set it to false for ESRI Clarity & Mapnik BlackWhite

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -252,7 +252,11 @@
                 "minimum-tile-expire": {
                     "description": "minimum expiry time for tiles in seconds. The larger the value, the longer entry in cache will be considered valid",
                     "type": "integer"
-                }                            
+                },
+                "support_cors": {
+                    "description": "Whether the imagery server support CORS or not",
+                    "type": "boolean"
+                }
             }
         }
     }

--- a/sources/world/EsriImageryClarity.geojson
+++ b/sources/world/EsriImageryClarity.geojson
@@ -10,6 +10,7 @@
         "permission_osm": "explicit",
         "description": "Esri archive imagery that may be clearer and more accurate than the default layer.",
         "i18n": true,
+        "support_cors": false,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/world/EsriImageryClarity.png",
         "id": "EsriWorldImageryClarity",
         "license_url": "https://github.com/osmlab/editor-layer-index/pull/358#issuecomment-361416110",

--- a/sources/world/OpenStreetMap-MapnikBlackWhite.geojson
+++ b/sources/world/OpenStreetMap-MapnikBlackWhite.geojson
@@ -8,6 +8,7 @@
         },
         "default": true,
         "i18n": true,
+        "support_cors": false,
         "icon": "https://osmlab.github.io/editor-layer-index/sources/world/OpenStreetMap-MapnikBlackWhite.png",
         "id": "osm-mapnik-black_and_white",
         "max_zoom": 18,


### PR DESCRIPTION
Hi,

This is a simple PR that add a new property "support_cors". It indicates wether the imagery tile server support CORS or not.

I set this property to false for:
- ESRI Clarity
- Mapnik Black & White

In fact, those 2 tiles server to not send the header "Access-Control-Allow-Origin: *" and  because of that tools using those imagery will get a CORS error.