### PR TITLE
Slovenia: GURS DOF025 orthophoto updated up to 2021

### DIFF
--- a/sources/europe/si/gurs-dof025.geojson
+++ b/sources/europe/si/gurs-dof025.geojson
@@ -773,12 +773,12 @@
     "properties": {
         "attribution": {
             "required": true,
-            "text": "CC-BY Geodetska uprava Republike Slovenije, DOF025, 2018-2020; Level2.si 2021",
+            "text": "CC-BY Geodetska uprava Republike Slovenije, DOF025, 2018-2021; Level2.si 2022",
             "url": "https://level2.si/sl/pogoji-uporabe-spletnih-servisov/"
         },
         "country_code": "SI",
         "start_date": "2018",
-        "end_date": "2020",
+        "end_date": "2021",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/si/level2.png",
         "id": "GURS-DOF025",
         "license_url": "https://wiki.openstreetmap.org/wiki/GURS",
@@ -787,7 +787,7 @@
         "min_zoom": 8,
         "best": true,
         "name": "GURS: Slovenia orthophoto 25cm (DOF025)",
-        "description": "Slovenia orthophoto 25cm/pixel (GURS DOF050), hosted by Level2.si",
+        "description": "Slovenia orthophoto 25cm/pixel (GURS DOF025), hosted by Level2.si",
         "overlay": false,
         "type": "tms",
         "url": "https://gis.level2.si/geoserver/gwc/service/tms/1.0.0/level2%3ADOF025_latest@EPSG%3A3857@jpeg/{zoom}/{x}/{-y}.jpeg",


### PR DESCRIPTION
In August 2022 orthophoto in central part of Slovenia was updated by @uprel with 2021 recordings, see https://site.geo-portal.si/2022-08-17-vkljucitev-dof-21.html
