### PR TITLE
migrate to new transifex "v3" CLI client

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,9 +1,9 @@
 [main]
 host = https://www.transifex.com
-minimum_perc = 1
 
-[id-editor.imagery]
+[o:openstreetmap:p:id-editor:r:imagery]
 file_filter = i18n/<lang>.yaml
 source_file = i18n/en.yaml
 source_lang = en
-type = YAML
+type        = YAML
+

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SOURCES := $(shell find sources -type f -name '*.geojson')
 SOURCES_QUOTED := $(shell find sources -type f -name '*.geojson' -exec echo "\"{}"\" \; | LC_ALL="C" sort)
 PYTHON = python
 TX := $(shell which tx)
+TXVERSION := $(shell tx --version | cut -c1-1)
 
 all: $(ALL)
 
@@ -27,6 +28,8 @@ i18n/en.yaml: scripts/extract_i18n.py $(SOURCES)
 txpush: i18n/en.yaml
 ifeq (, $(TX))
 	@echo "Transifex not installed"
+else ifeq (0, $(TXVERSION))
+	@echo "Installed Transifex CLI client too old: Upgrade to https://github.com/transifex/cli"
 else
 	$(TX) push -s
 endif
@@ -34,6 +37,8 @@ endif
 txpull:
 ifeq (, $(TX))
 	@echo "Transifex not installed"
+else ifeq (0, $(TXVERSION))
+	@echo "Installed Transifex CLI client too old: Upgrade to https://github.com/transifex/cli"
 else
 	$(TX) pull -a
 endif


### PR DESCRIPTION
The old (v0.*, python based) CLI client from Transifex will not work [anymore](https://github.com/transifex/transifex-client#the-new-client-) [soon](https://community.transifex.com/t/reminder-deprecated-transifex-apis-and-transifex-client-to-be-discontinued-on-nov-30-2022/3079) (Nov 30).

The [new client](https://github.com/transifex/cli) (v1.*, implemented in go) uses a slightly different config file, but should be otherwise a drop-in replacement for ELI's uses.

This PR upgrades the config file and adds a check and error message to the txpull/txpush `make` commands if the old version of the `tx` client is used.