### PR TITLE
Add AGIS 2022 imagery

### DIFF
--- a/sources/europe/ch/KantonAargau20cm-AGIS2022.geojson
+++ b/sources/europe/ch/KantonAargau20cm-AGIS2022.geojson
@@ -2,23 +2,23 @@
     "type": "Feature",
     "properties": {
         "license_url": "https://wiki.openstreetmap.org/wiki/Switzerland/AGIS",
-        "description": "This imagery is provided via a proxy operated by https://sosm.ch/, it was recorded early in the year with minimum foilage",
+        "description": "This imagery is provided via a proxy operated by https://sosm.ch/",
         "privacy_policy_url": "https://sosm.ch/about/terms-of-service/",
-        "id": "Aargau-AGIS-2021",
+        "id": "Aargau-AGIS-2022",
         "attribution": {
-            "text": "AGIS OF2021",
+            "text": "AGIS OF2022",
             "required": false
         },
-        "name": "Kanton Aargau 20cm (AGIS 2021)",
-        "url": "https://mapproxy.osm.ch/tiles/AGIS2021/EPSG900913/{zoom}/{x}/{y}.png?origin=nw",
-        "start_date": "2021",
-        "end_date": "2021",
+        "name": "Kanton Aargau 20cm (AGIS 2022)",
+        "url": "https://mapproxy.osm.ch/tiles/AGIS2022/EPSG900913/{zoom}/{x}/{y}.png?origin=nw",
+        "start_date": "2022",
+        "end_date": "2022",
         "max_zoom": 20,
         "min_zoom": 4,
         "country_code": "CH",
         "type": "tms",
         "category": "photo",
-        "best": false
+        "best": true
     },
     "geometry": {
         "type": "Polygon",


### PR DESCRIPTION
This adds 20cm nominal resolution imagery from mid 2022 for the Canton Aargau.

Thanks to @rbuffat for pointing the update out.