### PR TITLE
Replaced map layer from Norwegian Mapping Authority

### DIFF
--- a/sources/europe/no/Kartverket-N50.geojson
+++ b/sources/europe/no/Kartverket-N50.geojson
@@ -2,11 +2,11 @@
     "type": "Feature",
     "properties": {
         "type": "tms",
-        "name": "Kartverket N50 topo",
-        "id": "kartverket-topo4",
+        "name": "Kartverket N50",
+        "id": "kartverket-kartdata3",
         "country_code": "NO",
         "description": "Topographic map N50, equivalent to Norway 1:50.000 paper map series.",
-        "url": "https://opencache{switch:,2,3}.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=topo4&zoom={zoom}&x={x}&y={y}",
+        "url": "https://opencache{switch:,2,3}.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=kartdata3&zoom={zoom}&x={x}&y={y}",
         "privacy_policy_url": "https://www.kartverket.no/en/about-kartverket/data-protection-policy",
         "icon": "https://kartverket.no/dist/favicons/publicsite/favicon-32x32.png",
         "min_zoom": 3,
@@ -16,7 +16,7 @@
             "text": "© Kartverket",
             "url": "https://www.kartverket.no/"
         },
-        "license_url": "https://lists.nuug.no/pipermail/kart/2014-August/004831.html",
+        "license_url": "https://community.openstreetmap.org/t/fornyet-tillatelse-fra-kartverket/92410",
         "category": "map"
     },
     "geometry": {


### PR DESCRIPTION
Replace layer with id "kartverket-topo4", with a similar new layer which don't contain unlicensed data.
See #1790