### PR TITLE
Update Etag value for ESRI imagery

### DIFF
--- a/sources/world/EsriImagery.geojson
+++ b/sources/world/EsriImagery.geojson
@@ -15,7 +15,7 @@
         "max_zoom": 22,
         "no_tile_header": {
             "Etag": [
-                "\"10i954m13i2\""
+                "\"vvvvvvvvvvvvf\""
             ]
         },
         "name": "Esri World Imagery",


### PR DESCRIPTION
Seem as if ESRI is setting a different header value now. At least in my testing this new value seems to work to stop getting the dreaded error tiles.