### PR TITLE
NYSDOP_Latest: Do not request layer 4 (2017 batch)

### DIFF
--- a/sources/north-america/us/ny/NYSDOP_Latest.geojson
+++ b/sources/north-america/us/ny/NYSDOP_Latest.geojson
@@ -1379,7 +1379,7 @@
         "max_zoom": 19,
         "name": "NYSDOP Orthoimagery - Latest",
         "type": "wms",
-        "url": "https://orthos.its.ny.gov/arcgis/services/wms/Latest/MapServer/WmsServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0,1,2,3,4&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://orthos.its.ny.gov/arcgis/services/wms/Latest/MapServer/WmsServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0,1,2,3&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "privacy_policy_url": "https://its.ny.gov/its-internet-security-and-privacy-policy",
         "category": "photo",
         "valid-georeference": true


### PR DESCRIPTION
With the addition of the 2022 imagery batch, it seems that the 2017 batch (previously layer 4) has been removed. This change stops requesting that layer, which solves the error that has been occurring.