### PR TITLE
update names & URLs

### DIFF
--- a/sources/europe/be/AIV10cm.geojson
+++ b/sources/europe/be/AIV10cm.geojson
@@ -413,7 +413,7 @@
     "properties": {
         "attribution": {
             "required": true,
-            "text": "© agentschap Informatie Vlaanderen"
+            "text": "© Digitaal Vlaanderen"
         },
         "available_projections": [
             "CRS:84",
@@ -434,10 +434,10 @@
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/be/AIV.png",
         "id": "AGIV10cm",
         "license_url": "https://download.agiv.be/Producten/Detail?id=1209&title=Orthofotomozaiek_grootschalig_winteropnamen_kleur_2013_2015_Vlaanderen",
-        "name": "AIV Flanders 2013-2015 aerial imagery 10cm",
+        "name": "Digitaal Vlaanderen 2013-2015 aerial imagery 10cm",
         "start_date": "2013",
         "type": "wms",
-        "url": "https://geoservices.informatievlaanderen.be/raadpleegdiensten/OGW/wms?LAYERS=OGWRGB13_15VL&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
+        "url": "https://geo.api.vlaanderen.be/OGW/wms?LAYERS=OGWRGB13_15VL&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
     },
     "type": "Feature"
 }

--- a/sources/europe/be/AIV10cm.geojson
+++ b/sources/europe/be/AIV10cm.geojson
@@ -434,6 +434,7 @@
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/be/AIV.png",
         "id": "AGIV10cm",
         "license_url": "https://download.agiv.be/Producten/Detail?id=1209&title=Orthofotomozaiek_grootschalig_winteropnamen_kleur_2013_2015_Vlaanderen",
+        "privacy_policy_url": "https://www.vlaanderen.be/over-vlaanderenbe/disclaimer",
         "name": "Digitaal Vlaanderen 2013-2015 aerial imagery 10cm",
         "start_date": "2013",
         "type": "wms",

--- a/sources/europe/be/AIVWegenregister.geojson
+++ b/sources/europe/be/AIVWegenregister.geojson
@@ -413,7 +413,7 @@
     "properties": {
         "attribution": {
             "required": true,
-            "text": "© Agentschap Informatie Vlaanderen"
+            "text": "© Digitaal Vlaanderen"
         },
         "available_projections": [
             "CRS:84",
@@ -434,10 +434,10 @@
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/be/AIV.png",
         "id": "AIV_Wegenregister",
         "license_url": "https://download.vlaanderen.be/Producten/GetGebruiksvoorwaardenPDF?id=7698",
-        "name": "AIV Wegenregister",
+        "name": "Digitaal Vlaanderen Wegenregister",
         "type": "wms",
         "privacy_policy_url": "https://www.vlaanderen.be/over-vlaanderenbe/disclaimer",
-        "url": "http://geoservices.informatievlaanderen.be/raadpleegdiensten/Wegenregister/wms?LAYERS=LABELS,AARDEWEG,WANDFIETS,PLLWEG,VENTWEG,OPAFGGKR,OPAFOGKR,VERKPLEIN,SPECSIT,ROT,DIENSTWEG,WEGEEN,WEGGESCH,AUTOSWEG&STYLES=&CRS={proj}&BBOX={bbox}&FORMAT=image/png&WIDTH={width}&HEIGHT={height}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
+        "url": "https://geo.api.vlaanderen.be/Wegenregister/wms?LAYERS=LABELS,AARDEWEG,WANDFIETS,PLLWEG,VENTWEG,OPAFGGKR,OPAFOGKR,VERKPLEIN,SPECSIT,ROT,DIENSTWEG,WEGEEN,WEGGESCH,AUTOSWEG&STYLES=&CRS={proj}&BBOX={bbox}&FORMAT=image/png&WIDTH={width}&HEIGHT={height}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
     },
     "type": "Feature"
 }

--- a/sources/europe/be/AIV_GRB.geojson
+++ b/sources/europe/be/AIV_GRB.geojson
@@ -469,7 +469,7 @@
     "properties": {
         "attribution": {
             "required": true,
-            "text": "© agentschap Informatie Vlaanderen"
+            "text": "© Digitaal Vlaanderen"
         },
         "best": false,
         "category": "map",
@@ -479,9 +479,9 @@
         "id": "AGIVFlandersGRB",
         "license_url": "https://www.agiv.be/~/media/agiv/producten/grb/documenten/grb%20open%20data%20licentie.pdf",
         "max_zoom": 21,
-        "name": "AIV Flanders GRB",
+        "name": "Digitaal Vlaanderen GRB",
         "type": "tms",
-        "url": "https://tile.informatievlaanderen.be/ws/raadpleegdiensten/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=grb_bsk&STYLE=&FORMAT=image/png&tileMatrixSet=GoogleMapsVL&tileMatrix={zoom}&tileRow={y}&tileCol={x}"
+        "url": "https://geo.api.vlaanderen.be/GRB/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=grb_bsk&STYLE=&FORMAT=image/png&tileMatrixSet=GoogleMapsVL&tileMatrix={zoom}&tileRow={y}&tileCol={x}"
     },
     "type": "Feature"
 }

--- a/sources/europe/be/AIV_GRB.geojson
+++ b/sources/europe/be/AIV_GRB.geojson
@@ -471,6 +471,7 @@
             "required": true,
             "text": "© Digitaal Vlaanderen"
         },
+        "privacy_policy_url": "https://www.vlaanderen.be/over-vlaanderenbe/disclaimer",
         "best": false,
         "category": "map",
         "country_code": "BE",

--- a/sources/europe/be/AIV_OrthoPhoto.geojson
+++ b/sources/europe/be/AIV_OrthoPhoto.geojson
@@ -621,7 +621,7 @@
     "properties": {
         "attribution": {
             "required": true,
-            "text": "\u00a9 agentschap Informatie Vlaanderen"
+            "text": "© Digitaal Vlaanderen"
         },
         "best": true,
         "category": "photo",
@@ -631,9 +631,9 @@
         "id": "AGIV",
         "license_url": "https://download.agiv.be/Producten/Detail?id=1545&title=Orthofotomozaiek_middenschalig_winteropnamen_kleur_meest_recent_Vlaanderen_2016_04",
         "max_zoom": 21,
-        "name": "AIV Flanders most recent aerial imagery",
+        "name": "Digitaal Vlaanderen most recent aerial imagery",
         "type": "tms",
-        "url": "https://tile.informatievlaanderen.be/ws/raadpleegdiensten/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=omwrgbmrvl&STYLE=&FORMAT=image/png&tileMatrixSet=GoogleMapsVL&tileMatrix={zoom}&tileRow={y}&tileCol={x}"
+        "url": "https://geo.api.vlaanderen.be/OFW/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=omwrgbmrvl&STYLE=&FORMAT=image/png&tileMatrixSet=GoogleMapsVL&tileMatrix={zoom}&tileRow={y}&tileCol={x}"
     },
     "type": "Feature"
 }

--- a/sources/europe/be/AIV_OrthoPhoto_Preliminary.geojson
+++ b/sources/europe/be/AIV_OrthoPhoto_Preliminary.geojson
@@ -621,7 +621,7 @@
     "properties": {
         "attribution": {
             "required": true,
-            "text": "© agentschap Informatie Vlaanderen"
+            "text": "© Digitaal Vlaanderen"
         },
         "category": "photo",
         "country_code": "BE",
@@ -630,9 +630,9 @@
         "id": "AGIVwerkbestand",
         "license_url": "https://metadata.vlaanderen.be/srv/dut/catalog.search#/metadata/711f82cf-1b68-238c-ae04-4cda-d1cf-deb1-66f6d3d7",
         "privacy_policy_url": "https://overheid.vlaanderen.be/Webdiensten-Gebruiksrecht",
-        "name": "AIV Flanders preliminary aerial imagery",
+        "name": "Digitaal Vlaanderen preliminary aerial imagery",
         "type": "wms",
-        "url": "https://geoservices.informatievlaanderen.be/raadpleegdiensten/ofw/wms?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=OFW&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://geo.api.vlaanderen.be/ofw/wms?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=OFW&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "available_projections": [
             "CRS:84",
             "EPSG:3035",

--- a/sources/europe/be/AIVhillshade25cm.geojson
+++ b/sources/europe/be/AIVhillshade25cm.geojson
@@ -413,7 +413,7 @@
     "properties": {
         "attribution": {
             "required": true,
-            "text": "© agentschap Informatie Vlaanderen"
+            "text": "© Digitaal Vlaanderen"
         },
         "available_projections": [
             "CRS:84",
@@ -434,10 +434,10 @@
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/be/AIV.png",
         "id": "AIV_DHMV_II_HILL_25cm",
         "license_url": "https://www.geopunt.be/catalogus/datasetfolder/be2276f8-21fa-4e51-b4bc-c79eaf8bab81",
-        "name": "AIV Digitaal Hoogtemodel Vlaanderen II, multidirectionale hillshade 0,25 m",
+        "name": "Digitaal Vlaanderen DHV II, multidirectional hillshade 0,25 m",
         "start_date": "2013",
         "type": "wms",
-        "url": "https://geoservices.informatievlaanderen.be/raadpleegdiensten/dhmv/wms?LAYERS=DHMV_II_HILL_25cm&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
+        "url": "https://geo.api.vlaanderen.be/DHMV/wms?LAYERS=DHMV_II_HILL_25cm&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
     },
     "type": "Feature"
 }

--- a/sources/europe/be/AIVskyview25cm.geojson
+++ b/sources/europe/be/AIVskyview25cm.geojson
@@ -413,7 +413,7 @@
     "properties": {
         "attribution": {
             "required": true,
-            "text": "© agentschap Informatie Vlaanderen"
+            "text": "© Digitaal Vlaanderen"
         },
         "available_projections": [
             "CRS:84",
@@ -434,10 +434,10 @@
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/be/AIV.png",
         "id": "AIV_DHMV_II_SVF_25cm",
         "license_url": "https://www.geopunt.be/catalogus/datasetfolder/07dcd02f-eb0a-4247-95d1-155bb1129b3b",
-        "name": "AIV Digitaal Hoogtemodel Vlaanderen II, Skyview factor 0,25 m",
+        "name": "Digitaal Vlaanderen DHV II, Skyview factor 0,25 m",
         "start_date": "2013",
         "type": "wms",
-        "url": "https://geoservices.informatievlaanderen.be/raadpleegdiensten/dhmv/wms?LAYERS=DHMV_II_SVF_25cm&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
+        "url": "https://geo.api.vlaanderen.be/DHMV/wms?LAYERS=DHMV_II_SVF_25cm&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
     },
     "type": "Feature"
 }


### PR DESCRIPTION
* AIV (Agentschap Informatie Vlaanderen) has been called Digitaal Vlaanderen for a while now! The update did make me replace "AIV Flanders" with "Digitaal Vlaanderen" for the sake of brevity, especially since Digitaal Vlaanderen is never abreviated. I'm not sure how translators will deal with that.
* Digitaal Vlaanderen is migrating all services, the current URLs will stop working on June 30th! See https://feedback.informatievlaanderen.be/t/nieuwe-url-voor-alle-geografische-webdiensten/363