### PR TITLE
Fix French PCRS WMS layer name

### DIFF
--- a/sources/europe/fr/PCRS.geojson
+++ b/sources/europe/fr/PCRS.geojson
@@ -4,7 +4,7 @@
         "id": "fr.pcrs",
         "name": "PCRS raster",
         "type": "wms",
-        "url": "https://wxs.ign.fr/ortho/geoportail/r/wms?LAYERS=PCRS+LAMB93&STYLES=&CRS={proj}&BBOX={bbox}&FORMAT=image/jpeg&WIDTH={width}&HEIGHT={height}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "url": "https://wxs.ign.fr/ortho/geoportail/r/wms?LAYERS=PCRS.LAMB93&STYLES=&CRS={proj}&BBOX={bbox}&FORMAT=image/jpeg&WIDTH={width}&HEIGHT={height}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
         "available_projections": ["EPSG:3857","EPSG:4326"],
         "best": true,
         "country_code": "FR",


### PR DESCRIPTION
Hi,

The recently added WMS source for french PCRS (#1696) looks broken when used in iD editor and in the imagery tester (https://rapideditor.github.io/imagery-index/index.html). Querying images fail with a http 403 error.

```
<ExceptionReport><Exception exceptionCode="MissingRights">No rights for this ressource or ressource does not exist</Exception></ExceptionReport>
```

Looking at the [capabilities](https://wxs.ign.fr/ortho/geoportail/r/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities) I found the layer name must be `PCRS.LAMB93` instead of `PCRS+LAMB93`.