### PR TITLE
Standardize LINZ Basemaps URLs

### DIFF
--- a/sources/oceania/nz/LINZ-Hawkes-Bay-Cyclone-Gabrielle.geojson
+++ b/sources/oceania/nz/LINZ-Hawkes-Bay-Cyclone-Gabrielle.geojson
@@ -11,7 +11,7 @@
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "photo",
         "best": true,
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/hawkes-bay-cyclone-gabrielle-2023-0.1m/WebMercatorQuad/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/hawkes-bay-cyclone-gabrielle-2023-0.1m/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-Hawkes-Bay-Cyclone-Gabrielle.geojson
+++ b/sources/oceania/nz/LINZ-Hawkes-Bay-Cyclone-Gabrielle.geojson
@@ -11,7 +11,7 @@
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "photo",
         "best": true,
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/hawkes-bay-cyclone-gabrielle-2023-0.1m/EPSG:3857/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/hawkes-bay-cyclone-gabrielle-2023-0.1m/WebMercatorQuad/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-NZ-Aerial-Imagery.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Aerial-Imagery.geojson
@@ -10,7 +10,7 @@
         "name": "LINZ NZ Aerial Imagery",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "photo",
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial/WebMercatorQuad/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-NZ-Aerial-Imagery.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Aerial-Imagery.geojson
@@ -10,7 +10,7 @@
         "name": "LINZ NZ Aerial Imagery",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "photo",
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial/EPSG:3857/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial/WebMercatorQuad/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-NZ-Auckland-2010.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Auckland-2010.geojson
@@ -10,7 +10,7 @@
         "name": "LINZ Auckland 2010-2012",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "historicphoto",
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:auckland_rural_2010-2012_0-50m_RGBA/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/auckland-rural-2010-2012-0.5m/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-NZ-Auckland-2010.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Auckland-2010.geojson
@@ -10,7 +10,7 @@
         "name": "LINZ Auckland 2010-2012",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "historicphoto",
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:auckland_rural_2010-2012_0-50m_RGBA/EPSG:3857/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:auckland_rural_2010-2012_0-50m_RGBA/WebMercatorQuad/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-NZ-Auckland-2010.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Auckland-2010.geojson
@@ -10,7 +10,7 @@
         "name": "LINZ Auckland 2010-2012",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "historicphoto",
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:auckland_rural_2010-2012_0-50m_RGBA/WebMercatorQuad/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:auckland_rural_2010-2012_0-50m_RGBA/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-NZ-Bay-of-Plenty-2014.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Bay-of-Plenty-2014.geojson
@@ -10,7 +10,7 @@
         "name": "LINZ Bay of Plenty 2014-2015",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "historicphoto",
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:bay-of-plenty_urban_2014-15_0-125m/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/bay-of-plenty-urban-2014-2015-0.125m/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-NZ-Bay-of-Plenty-2014.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Bay-of-Plenty-2014.geojson
@@ -10,7 +10,7 @@
         "name": "LINZ Bay of Plenty 2014-2015",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "historicphoto",
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:bay-of-plenty_urban_2014-15_0-125m/EPSG:3857/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:bay-of-plenty_urban_2014-15_0-125m/WebMercatorQuad/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-NZ-Bay-of-Plenty-2014.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Bay-of-Plenty-2014.geojson
@@ -10,7 +10,7 @@
         "name": "LINZ Bay of Plenty 2014-2015",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "historicphoto",
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:bay-of-plenty_urban_2014-15_0-125m/WebMercatorQuad/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:bay-of-plenty_urban_2014-15_0-125m/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-NZ-Christchurch-2015.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Christchurch-2015.geojson
@@ -10,7 +10,7 @@
         "name": "LINZ Christchurch 2015-2016",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "historicphoto",
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:christchurch_urban_2015-2016_0-075m_RGBA/EPSG:3857/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:christchurch_urban_2015-2016_0-075m_RGBA/WebMercatorQuad/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-NZ-Christchurch-2015.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Christchurch-2015.geojson
@@ -10,7 +10,7 @@
         "name": "LINZ Christchurch 2015-2016",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "historicphoto",
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:christchurch_urban_2015-2016_0-075m_RGBA/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/christchurch-urban-2015-2016-0.075m/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-NZ-Christchurch-2015.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Christchurch-2015.geojson
@@ -10,7 +10,7 @@
         "name": "LINZ Christchurch 2015-2016",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "historicphoto",
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:christchurch_urban_2015-2016_0-075m_RGBA/WebMercatorQuad/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:christchurch_urban_2015-2016_0-075m_RGBA/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-NZ-Hamilton-2016.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Hamilton-2016.geojson
@@ -10,7 +10,7 @@
         "name": "LINZ Hamilton 2016-2017",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "historicphoto",
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:hamilton_urban_2016-17_0-1m/WebMercatorQuad/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:hamilton_urban_2016-17_0-1m/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-NZ-Hamilton-2016.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Hamilton-2016.geojson
@@ -10,7 +10,7 @@
         "name": "LINZ Hamilton 2016-2017",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "historicphoto",
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:hamilton_urban_2016-17_0-1m/EPSG:3857/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:hamilton_urban_2016-17_0-1m/WebMercatorQuad/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-NZ-Hamilton-2016.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Hamilton-2016.geojson
@@ -10,7 +10,7 @@
         "name": "LINZ Hamilton 2016-2017",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "historicphoto",
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:hamilton_urban_2016-17_0-1m/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/hamilton-urban-2016-2017-0.1m/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-NZ-Wellington-2017.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Wellington-2017.geojson
@@ -10,7 +10,7 @@
         "name": "LINZ Wellington 2017",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "historicphoto",
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:wellington_urban_2017_0-10m/EPSG:3857/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:wellington_urban_2017_0-10m/WebMercatorQuad/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-NZ-Wellington-2017.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Wellington-2017.geojson
@@ -10,7 +10,7 @@
         "name": "LINZ Wellington 2017",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "historicphoto",
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:wellington_urban_2017_0-10m/WebMercatorQuad/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:wellington_urban_2017_0-10m/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",

--- a/sources/oceania/nz/LINZ-NZ-Wellington-2017.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Wellington-2017.geojson
@@ -10,7 +10,7 @@
         "name": "LINZ Wellington 2017",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "historicphoto",
-        "url": "https://basemaps.linz.govt.nz/v1/tiles/aerial:wellington_urban_2017_0-10m/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/wellington-urban-2017-0.1m/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",
         "type": "tms",


### PR DESCRIPTION
LINZ is trying to move it's users to more standard URLs as we have a collection of similar URLs for the same imagery.

I have split this into three commits 

Move from EPSG code to TileMatrix ID, [Standardise LINZ urls](https://github.com/osmlab/editor-layer-index/commit/aaa5acab04e6b57cd8a39a49d89b8083ceb5fc89) We have multiple tile matrices for the same EPSG code so using just a EPSG code can be possibly give users different tile matrix. so we are recommending people to use the TileMatrixId `WebMercatorQuad` over `EPSG:3857` 

Remove "aerial:" [Remove all "aerial:" prefixed imagery as it is a deprecated URL](https://github.com/osmlab/editor-layer-index/commit/c1e70c5e6b2272f17c9d14cd8face2985c6ab3db) Accessing imagery from "aerial:..." is deprecated and is going away "soon" all imagery can be access directly with via it's name. Names can be found in the drop down list on https://basemaps.linz.govt.nz or in https://github.com/linz/basemaps-config

[Convert LINZ imagery to webp](https://github.com/osmlab/editor-layer-index/commit/7e91a8134702c3968d258eef67c366dcff0f476f) This one is optional, webp has much more usage in our system which provides a better experience for most users. Fixes: #1890 

