### PR TITLE
Fix category of USGS 3DEP

### DIFF
--- a/sources/north-america/us/USGS3DEP.geojson
+++ b/sources/north-america/us/USGS3DEP.geojson
@@ -578,7 +578,7 @@
         ],
         "privacy_policy_url": "https://www.usgs.gov/privacy-policies",
         "url": "https://elevation.nationalmap.gov/arcgis/services/3DEPElevation/ImageServer/WMSServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=3DEPElevation:Hillshade%20Gray&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
-        "category": "photo",
+        "category": "elevation",
         "valid-georeference": true
     },
     "type": "Feature"


### PR DESCRIPTION
Changes the category of 3DEP to `elevation` to match that of [MassGIS LiDAR Shaded Relief](https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/north-america/us/ma/MassGISLIDARShadedRelief.geojson) and [VCGI LiDAR DEM Hillshade](https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/north-america/us/vt/VCGI_LiDAR_DEM_Hillshade.geojson)