### PR TITLE
Update Cape Town sources

### DIFF
--- a/sources/africa/za/SouthAfricaCoCT2017Aerial.geojson
+++ b/sources/africa/za/SouthAfricaCoCT2017Aerial.geojson
@@ -458,19 +458,22 @@
         },
         "country_code": "ZA",
         "description": "City of Cape Town Aerial ortho-photography of the municipal area. 8cm ground sample distance",
-        "end_date": "2017",
+        "end_date": "2017-01",
         "id": "South_Africa-CapeTown-Aerial-2017",
-        "name": "2017 Aerial Imagery from the City of Cape Town",
+        "name": "City of Cape Town Aerial Imagery (2017)",
         "permission_osm": "explicit",
         "license_url": "https://osmlab.github.io/editor-layer-index/sources/africa/za/South_Africa_CapeTown_2017_2018_Aerial_Imagery.pdf",
-        "start_date": "2017",
-        "type": "wmts",
-        "available_projections": ["EPSG:3857"],
+        "start_date": "2017-01",
+        "type": "wms",
+        "available_projections": [
+            "EPSG:3857",
+            "EPSG:4326",
+            "EPSG:20482"
+        ],
         "privacy_policy_url": "https://www.capetown.gov.za/General/Privacy",
-        "url": "https://citymaps.capetown.gov.za/agsext1/rest/services/Aerial_Photography_Cached/AP_2017_Jan/MapServer/WMTS/1.0.0/WMTSCapabilities.xml",
-        "category": "historicphoto"
+        "url": "https://cityimg.capetown.gov.za:443/erdas-iws/ogc/wms/GeoSpatial%20Datasets?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=Aerial%20Imagery_Aerial%20Imagery%202017Jan&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "category": "historicphoto",
+        "min_zoom": 3
     },
     "type": "Feature"
 }
-
-

--- a/sources/africa/za/SouthAfricaCoCT2018Aerial.geojson
+++ b/sources/africa/za/SouthAfricaCoCT2018Aerial.geojson
@@ -456,20 +456,24 @@
             "text": "City of Cape Town Aerial",
             "url": "https://www.arcgis.com/sharing/rest/content/items/739759d8127f4d1f9ba8ef9019878147/info/metadata/metadata.xml?format=default&output=html"
         },
-        "best": true,
         "country_code": "ZA",
         "description": "City of Cape Town Aerial ortho-photography of the municipal area. 8cm ground sample distance.",
-        "end_date": "2018",
+        "end_date": "2018-02",
         "id": "South_Africa-CapeTown-Aerial-2018",
-        "name": "2018 Aerial Imagery from the City of Cape Town",
+        "name": "City of Cape Town Aerial Imagery (2018)",
         "permission_osm": "explicit",
         "license_url": "https://osmlab.github.io/editor-layer-index/sources/africa/za/South_Africa_CapeTown_2017_2018_Aerial_Imagery.pdf",
-        "start_date": "2018",
-        "type": "wmts",
-        "available_projections": ["EPSG:3857"],
+        "start_date": "2018-02",
+        "type": "wms",
+        "available_projections": [
+            "EPSG:3857",
+            "EPSG:4326",
+            "EPSG:20482"
+        ],
         "privacy_policy_url": "https://www.capetown.gov.za/General/Privacy",
-        "url": "https://citymaps.capetown.gov.za/agsext1/rest/services/Aerial_Photography_Cached/AP_2018_Feb/MapServer/WMTS/1.0.0/WMTSCapabilities.xml",
-        "category": "photo"
+        "url": "https://cityimg.capetown.gov.za:443/erdas-iws/ogc/wms/GeoSpatial&20Datasets?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=Aerial%20Imagery_Aerial&20Imagery%202018Feb&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "category": "historicphoto",
+        "min_zoom": 4
     },
     "type": "Feature"
 }

--- a/sources/africa/za/SouthAfricaCoCT2021Aerial.geojson
+++ b/sources/africa/za/SouthAfricaCoCT2021Aerial.geojson
@@ -456,22 +456,18 @@
             "text": "City of Cape Town Aerial",
             "url": "https://www.arcgis.com/sharing/rest/content/items/739759d8127f4d1f9ba8ef9019878147/info/metadata/metadata.xml?format=default&output=html"
         },
-        "best": true,
         "country_code": "ZA",
         "description": "City of Cape Town Aerial ortho-photography of the municipal area. 8cm ground sample distance.",
-        "end_date": "2018",
-        "id": "South_Africa-CapeTown-Aerial-2018-rest",
-        "name": "City of Cape Town 2018 Aerial",
+        "end_date": "2021-03",
+        "id": "South_Africa-CapeTown-Aerial-2021",
+        "name": "City of Cape Town Aerial Imagery (2021)",
         "permission_osm": "explicit",
         "license_url": "https://osmlab.github.io/editor-layer-index/sources/africa/za/South_Africa_CapeTown_2017_2018_Aerial_Imagery.pdf",
-        "start_date": "2018",
-        "type": "wms",
-        "available_projections": [
-            "EPSG:3857"
-        ],
+        "start_date": "2021-03",
+        "type": "tms",
         "privacy_policy_url": "https://www.capetown.gov.za/General/Privacy",
-        "url": "https://citymaps.capetown.gov.za/agsext1/rest/services/Aerial_Photography_Cached/AP_2018_Feb/MapServer/export?f=image&format=jpeg&imageSR=3857&bboxSR=3857&bbox={bbox}&size={width},{height}&foo={proj}",
-        "category": "photo",
+        "url": "https://cityimg.capetown.gov.za/erdas-iws/esri/GeoSpatial%20Datasets/rest/services/Aerial%20Imagery_Aerial%20Imagery%202021Mar%20Cache/MapServer/tile/{zoom}/{y}/{x}",
+        "category": "historicphoto",
         "min_zoom": 4
     },
     "type": "Feature"

--- a/sources/africa/za/SouthAfricaCoCT2023Aerial.geojson
+++ b/sources/africa/za/SouthAfricaCoCT2023Aerial.geojson
@@ -456,22 +456,25 @@
             "text": "City of Cape Town Aerial",
             "url": "https://www.arcgis.com/sharing/rest/content/items/739759d8127f4d1f9ba8ef9019878147/info/metadata/metadata.xml?format=default&output=html"
         },
+        "best": true,
         "country_code": "ZA",
-        "description": "City of Cape Town Aerial ortho-photography of the municipal area. 8cm ground sample distance",
-        "end_date": "2017",
-        "id": "South_Africa-CapeTown-Aerial-2017-rest",
-        "name": "City of Cape Town 2017 Aerial",
+        "description": "City of Cape Town Aerial ortho-photography of the municipal area. 8cm ground sample distance.",
+        "end_date": "2023-01",
+        "id": "South_Africa-CapeTown-Aerial-2023",
+        "name": "City of Cape Town Aerial Imagery (2023)",
         "permission_osm": "explicit",
         "license_url": "https://osmlab.github.io/editor-layer-index/sources/africa/za/South_Africa_CapeTown_2017_2018_Aerial_Imagery.pdf",
-        "start_date": "2017",
+        "start_date": "2023-01",
         "type": "wms",
         "available_projections": [
-            "EPSG:3857"
+            "EPSG:3857",
+            "EPSG:4326",
+            "EPSG:20482"
         ],
         "privacy_policy_url": "https://www.capetown.gov.za/General/Privacy",
-        "url": "https://citymaps.capetown.gov.za/agsext1/rest/services/Aerial_Photography_Cached/AP_2017_Jan/MapServer/export?f=image&format=jpeg&imageSR=3857&bboxSR=3857&bbox={bbox}&size={width},{height}&foo={proj}",
-        "category": "historicphoto",
-        "min_zoom": 3
+        "url": "https://cityimg.capetown.gov.za:443/erdas-iws/ogc/wms/GeoSpatial&20Datasets?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=Aerial%20Imagery_Aerial&20Imagery%202023Jan&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "category": "photo",
+        "min_zoom": 4
     },
     "type": "Feature"
 }


### PR DESCRIPTION
* Updated City of Cape Town 2017/18 Aerials
  * Removed best attribute from 2018 and changed category to historicphoto
  * Replaced old WMTS endpoints with the new WMS endpoints
* Added City of Cape Town 2021/2023 Aerials

Closes #1616, closes #1617