### PR TITLE
Update Hennepin Co imagery

### DIFF
--- a/sources/north-america/us/mn/Hennepin_Ortho_2022.geojson
+++ b/sources/north-america/us/mn/Hennepin_Ortho_2022.geojson
@@ -1,29 +1,28 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "Hennepin_Ortho_2021",
+        "id": "Hennepin_Ortho_2022",
         "attribution": {
             "url": "https://gis-hennepin.hub.arcgis.com/",
             "text": "Hennepin County GIS",
             "required": false
         },
-        "name": "Hennepin County Orthoimagery (2021)",
+        "name": "Hennepin County Orthoimagery (2022)",
         "icon": "https://www.hennepin.us/branding-assets/img/h-logo-blue.png",
-        "url": "https://gis.hennepin.us/arcgis/services/Imagery/UTM_Aerial_2021/MapServer/WMSServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=1&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://gis.hennepin.us/arcgis/services/Imagery/UTM_Aerial_2022/MapServer/WMSServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=1&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "max_zoom": 19,
         "license_url": "https://metrogis.org/getmedia/3847b6d1-9609-4223-8f1c-591a7780fabb/HennepinCountyResolution_2014_02_11.pdf.aspx",
         "country_code": "US",
         "type": "wms",
         "available_projections": [
             "CRS:84",
-            "EPSG:3857",
             "EPSG:4326",
             "EPSG:26915"
         ],
-        "start_date": "2021-03",
-        "end_date": "2021-03",
-        "description": "True color orthoimagery for Hennepin County of the State of Minnesota captured in 2021 Spring",
-        "category": "historicphoto",
+        "start_date": "2022-03",
+        "end_date": "2022-03",
+        "description": "True color, leaf-off orthoimagery for Hennepin County of the State of Minnesota captured in 2022 Spring",
+        "category": "photo",
         "valid-georeference": true,
         "privacy_policy_url": "https://www.hennepin.us/your-government/open-government/accessibility-privacy-security"
     },


### PR DESCRIPTION
Adds 2022 orthorectified true color, leaf-off imagery, changes 2021 category from photo to historicphoto