### PR TITLE
removed property "best" from outdated layers in Erlangen

### DIFF
--- a/sources/europe/de/Erlangen2018.geojson
+++ b/sources/europe/de/Erlangen2018.geojson
@@ -13,7 +13,6 @@
         "permission_osm": "explicit",
         "privacy_policy_url": "https://osm.rrze.fau.de/datenschutz/",
         "country_code": "DE",
-        "best": true,
         "attribution": {
             "text": "© Stadt Erlangen | © Hansa Luftbild AG",
             "required": true

--- a/sources/europe/de/Erlangen2020.geojson
+++ b/sources/europe/de/Erlangen2020.geojson
@@ -14,7 +14,6 @@
         "permission_osm": "explicit",
         "privacy_policy_url": "https://erlangen.de/datenschutz/",
         "country_code": "DE",
-        "best": true,
         "attribution": {
             "text": "© Stadt Erlangen",
             "url": "https://www.erlangen.de",


### PR DESCRIPTION
removed property "best" from Erlangen2018.geojson and Erlangen2020.geojson