### PR TITLE
Added eox.at cloudless Sentinel-2 2022

### DIFF
--- a/sources/world/eox.at-2022-cloudless.geojson
+++ b/sources/world/eox.at-2022-cloudless.geojson
@@ -1,0 +1,30 @@
+{
+    "geometry": null,
+    "properties": {
+        "attribution": {
+            "required": true,
+            "text": "Sentinel-2 cloudless - https://s2maps.eu by EOX IT Services GmbH (Contains modified Copernicus Sentinel data 2022)",
+            "url": "https://s2maps.eu/"
+        },
+        "default": false,
+        "permission_osm": "explicit",
+        "description": "Post-processed Sentinel Satellite imagery.",
+        "i18n": true,
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/world/eox.png",
+        "id": "EOXAT2022CLOUDLESS",
+        "license_url": "https://wiki.openstreetmap.org/wiki/Eox.at",
+        "available_projections": [
+            "EPSG:3857",
+            "EPSG:4326"
+        ],
+        "start_date": "2022",
+        "end_date": "2022",
+        "max_zoom": 18,
+        "name": "eox.at 2022 cloudless",
+        "type": "wms",
+        "category": "photo",
+        "url": "https://s2maps-tiles.eu/?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=s2cloudless-2022_3857&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "privacy_policy_url": "https://eox.at/impressum/"
+    },
+    "type": "Feature"
+}


### PR DESCRIPTION
Released 2023-10-18, Blog entry https://www.eox.at/2023/10/sentinel-2-cloudless-2022/