### PR TITLE
Update St Johns County sources

### DIFF
--- a/sources/north-america/us/fl/Saint_Johns_Basemap.geojson
+++ b/sources/north-america/us/fl/Saint_Johns_Basemap.geojson
@@ -1,22 +1,19 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "Saint_Johns_Ortho_CIR_2021",
+        "id": "Saint_Johns_Basemap",
         "attribution": {
             "url": "https://www.sjcfl.us/GIS/index.aspx",
             "text": "Saint Johns County GIS",
             "required": false
         },
-        "name": "Saint Johns County Infrared Orthoimagery (2021)",
-        "url": "https://www.gis.sjcfl.us/portal_sjcgis/rest/services/Imagery_2021_cir/MapServer/tile/{zoom}/{y}/{x}",
-        "max_zoom": 20,
+        "name": "Saint Johns County Basemap",
+        "url": "https://www.gis.sjcfl.us/portal_sjcgis/rest/services/Basemap/MapServer/tile/{zoom}/{y}/{x}",
+        "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Florida#Publicly_Available_Data",
         "country_code": "US",
         "type": "tms",
-        "start_date": "2021",
-        "end_date": "2021",
-        "description": "The 2021 color infrared orthoimagery for Saint Johns County in the State of Florida",
-        "category": "historicphoto",
+        "category": "map",
         "valid-georeference": true,
         "privacy_policy_url": "https://sjcfl.us/county/SiteTools/privacy.aspx"
     },

--- a/sources/north-america/us/fl/Saint_Johns_Ortho_2021.geojson
+++ b/sources/north-america/us/fl/Saint_Johns_Ortho_2021.geojson
@@ -16,7 +16,7 @@
         "start_date": "2021",
         "end_date": "2021",
         "description": "The 2021 natural color orthoimagery for Saint Johns County in the State of Florida",
-        "category": "photo",
+        "category": "historicphoto",
         "valid-georeference": true,
         "privacy_policy_url": "https://sjcfl.us/county/SiteTools/privacy.aspx"
     },

--- a/sources/north-america/us/fl/Saint_Johns_Ortho_CIR_2023.geojson
+++ b/sources/north-america/us/fl/Saint_Johns_Ortho_CIR_2023.geojson
@@ -1,22 +1,22 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "Saint_Johns_Ortho_CIR_2021",
+        "id": "Saint_Johns_Ortho_CIR_2023",
         "attribution": {
             "url": "https://www.sjcfl.us/GIS/index.aspx",
             "text": "Saint Johns County GIS",
             "required": false
         },
-        "name": "Saint Johns County Infrared Orthoimagery (2021)",
-        "url": "https://www.gis.sjcfl.us/portal_sjcgis/rest/services/Imagery_2021_cir/MapServer/tile/{zoom}/{y}/{x}",
+        "name": "Saint Johns County Infrared Orthoimagery (2023)",
+        "url": "https://www.gis.sjcfl.us/portal_sjcgis/rest/services/Imagery_2023_cir/MapServer/tile/{zoom}/{y}/{x}",
         "max_zoom": 20,
         "license_url": "https://wiki.openstreetmap.org/wiki/Florida#Publicly_Available_Data",
         "country_code": "US",
         "type": "tms",
-        "start_date": "2021",
-        "end_date": "2021",
-        "description": "The 2021 color infrared orthoimagery for Saint Johns County in the State of Florida",
-        "category": "historicphoto",
+        "start_date": "2023",
+        "end_date": "2023",
+        "description": "The 2023 color infrared orthoimagery for Saint Johns County in the State of Florida",
+        "category": "photo",
         "valid-georeference": true,
         "privacy_policy_url": "https://sjcfl.us/county/SiteTools/privacy.aspx"
     },


### PR DESCRIPTION
This PR adds 2023 CIR imagery for St. Johns County. The 2023 natural color imagery can already be viewed via Esri World Imagery, so I thought it would be redundant to add it again.

Also adds St. Johns County Basemap, which can be useful to add new street names within the county (unfortunately TIGER doesn't seem to be up to date in the area) as well as mapping new parks, schools, etc.