### PR TITLE
Add Putnam Ortho 2023

### DIFF
--- a/sources/north-america/us/oh/Putnam_OH_2023.geojson
+++ b/sources/north-america/us/oh/Putnam_OH_2023.geojson
@@ -1,0 +1,96 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "Putnam_OH_2023",
+        "attribution": {
+            "url": "https://putnamcountyohio.gov/",
+            "text": "Putnam County, State of Ohio",
+            "required": false
+        },
+        "name": "Putnam County Orthoimagery (2023)",
+        "icon": "https://putnamcountyohio.gov/favicon-32x32.png",
+        "url": "https://putnamcountygis.com/arcgis/services/Aerials/2023_Aerial/MapServer/WMSServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "max_zoom": 23,
+        "license_url": "https://gis1.oit.ohio.gov/OGRIPWeb/WebContent/OSIP/OSIP%20III%20RFP%200A1177.pdf#page=26",
+        "country_code": "US",
+        "type": "wms",
+        "available_projections": [
+            "CRS:84",
+            "EPSG:3857",
+            "EPSG:4326"
+        ],
+        "start_date": "2023",
+        "end_date": "2023",
+        "description": "Spring 2023 orthoimagery for Putnam County in the State of Ohio",
+        "category": "photo",
+        "valid-georeference": true,
+        "privacy_policy_url": "https://putnamcountygis.com/"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -84.347079283338488,
+                    41.168426745829109
+                ],
+                [
+                    -84.346778653445,
+                    40.99325501212568
+                ],
+                [
+                    -84.401019359875249,
+                    40.992434469357562
+                ],
+                [
+                    -84.399222654158862,
+                    40.930723994279603
+                ],
+                [
+                    -84.403806375829021,
+                    40.930695699701388
+                ],
+                [
+                    -84.40294339119356,
+                    40.899798020295179
+                ],
+                [
+                    -84.344118963093194,
+                    40.900731741376113
+                ],
+                [
+                    -84.342874001651907,
+                    40.856139486115779
+                ],
+                [
+                    -84.107915824188893,
+                    40.859690455681246
+                ],
+                [
+                    -84.108906134426263,
+                    40.900802477821621
+                ],
+                [
+                    -83.991398751116577,
+                    40.902415268779627
+                ],
+                [
+                    -83.99173828605511,
+                    40.916166433790103
+                ],
+                [
+                    -83.878651930590834,
+                    40.917582931111859
+                ],
+                [
+                    -83.879458326069866,
+                    41.171484328687022
+                ],
+                [
+                    -84.347079283338488,
+                    41.168426745829109
+                ]
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
Putnam County's 2023 imagery was captured under OSIP III (as listed on [OGRIP's download portal](https://gis1.oit.ohio.gov/geodatadownload/)), which is public domain.