### PR TITLE
Add Montgomery Ortho 2022

### DIFF
--- a/sources/north-america/us/oh/Montgomery_OH_2022.geojson
+++ b/sources/north-america/us/oh/Montgomery_OH_2022.geojson
@@ -1,29 +1,29 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "Montgomery_OH_2019",
+        "id": "Montgomery_OH_2022",
         "attribution": {
             "url": "https://www.mcohio.org/",
             "text": "Montgomery County, State of Ohio",
             "required": false
         },
-        "name": "Montgomery County Orthoimagery (2019)",
-        "icon": "https://www.mcohio.org/_assets_/images/logo.png",
-        "url": "https://portal.ketteringoh.org/arcgis/rest/services/GISData/MontCoAerial2019/MapServer/export?f=image&format=jpg&layers=&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&foo={proj}",
+        "name": "Montgomery County Orthoimagery (2022)",
+        "icon": "https://www.mcohio.org/ImageRepository/Document?documentId=88",
+        "url": "https://gis.mcohio.org/arcgis/rest/services/AUDGIS_MrSID/MapServer/export?f=image&format=jpg&layers=show:0&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&foo={proj}",
         "max_zoom": 21,
-        "license_url": "https://portal.ketteringoh.org/arcgis/rest/services/GISData/MontCoAerial2019/MapServer/info/metadata",
+        "license_url": "https://gis1.oit.ohio.gov/OGRIPWeb/WebContent/OSIP/OSIP%20III%20RFP%200A1177.pdf#page=26",
         "country_code": "US",
         "type": "wms",
         "available_projections": [
             "CRS:84",
             "EPSG:3857"
         ],
-        "start_date": "2019",
-        "end_date": "2019",
-        "description": "Spring 2019 orthoimagery for Montgomery County in the State of Ohio",
+        "start_date": "2022",
+        "end_date": "2022",
+        "description": "3-inch resolution 2022 orthoimagery for Montgomery County in the State of Ohio",
         "category": "photo",
         "valid-georeference": true,
-        "privacy_policy_url": "https://www.ketteringoh.org/privacy-policy/"
+        "privacy_policy_url": "https://www.mcohio.org/privacy"
     },
     "geometry": {
         "type": "Polygon",


### PR DESCRIPTION
Montgomery County's 2022 imagery was captured under OSIP III (as listed on [OGRIP's download portal](https://gis1.oit.ohio.gov/geodatadownload/)), which is in the public domain.