### PR TITLE
Add Fairfield Ortho 2023

### DIFF
--- a/sources/north-america/us/oh/City_of_Fairfield_OH_2023.geojson
+++ b/sources/north-america/us/oh/City_of_Fairfield_OH_2023.geojson
@@ -1,28 +1,24 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "City_of_Fairfield_OH_2020",
+        "id": "City_of_Fairfield_OH_2023",
         "attribution": {
             "url": "https://www.fairfield-city.org/",
             "text": "City of Fairfield, State of Ohio",
             "required": false
         },
-        "name": "City of Fairfield Orthoimagery (2020)",
+        "name": "City of Fairfield Orthoimagery (2023)",
         "icon": "https://www.fairfield-city.org/ImageRepository/Document?documentID=6061",
-        "url": "https://gis.fairfield-city.org/cofgis/services/Imagery_2020_WGS/MapServer/WMSServer?LAYERS=0&STYLES=&CRS={proj}&BBOX={bbox}&FORMAT=image/jpeg&WIDTH={width}&HEIGHT={height}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "url": "https://gis.fairfield-city.org/cofgis/rest/services/2023_Imagery_WGS/MapServer/tile/{zoom}/{y}/{x}",
         "max_zoom": 21,
         "min_zoom": 12,
         "license_url": "https://gis1.oit.ohio.gov/OGRIPWeb/WebContent/OSIP/OSIP%20III%20RFP%200A1177.pdf#page=26",
         "country_code": "US",
-        "type": "wms",
-        "available_projections": [
-            "CRS:84",
-            "EPSG:3857"
-        ],
-        "start_date": "2020",
-        "end_date": "2020",
-        "description": "Spring 2020 orthoimagery for City of Fairfield in the State of Ohio",
-        "category": "historicphoto",
+        "type": "tms",
+        "start_date": "2023",
+        "end_date": "2023",
+        "description": "3-inch resolution spring 2023 orthoimagery for City of Fairfield in the State of Ohio",
+        "category": "photo",
         "valid-georeference": true,
         "privacy_policy_url": "https://www.fairfield-city.org/privacy"
     },


### PR DESCRIPTION
Fairfield's 2023 imagery was captured under OSIP III (Butler County's partial 3IN 2023 imagery as listed on [OGRIP's download portal](https://gis1.oit.ohio.gov/geodatadownload/)), which is in the public domain. This is different than the countywide mosaic being added in #2207, which is only 6IN