### PR TITLE
Update Budapest-XI-district-ortophoto-2021.geojson

### DIFF
--- a/sources/europe/hu/Budapest-XI-district-ortophoto-2021.geojson
+++ b/sources/europe/hu/Budapest-XI-district-ortophoto-2021.geojson
@@ -19,11 +19,10 @@
         "privacy_policy_url": "https://kozigazgatas.ujbuda.hu/adatvedelem",
         "start_date": "2021-03",
         "end_date": "2021-03",
-        "best": true,
         "country_code": "HU",
         "type": "wms",
         "id": "Budapest_XI_2021",
-        "category": "photo"
+        "category": "historicphoto"
     },
     "geometry": {
         "type": "Polygon",


### PR DESCRIPTION
The 2021 orthophoto is no longer the best, because the 2023 orthophoto is added as well