### PR TITLE
Add USDA high resolution imagery

### DIFF
--- a/sources/north-america/us/ak/USDA_Delta_Junction_2021.geojson
+++ b/sources/north-america/us/ak/USDA_Delta_Junction_2021.geojson
@@ -1,0 +1,112 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "USDA_Delta_Junction_2021",
+        "attribution": {
+            "url": "https://datagateway.nrcs.usda.gov/",
+            "text": "U.S. Department of Agriculture",
+            "required": false
+        },
+        "name": "USDA Delta Junction Orthoimagery (2021)",
+        "type": "wms",
+        "url": "https://nrcsgeoservices.sc.egov.usda.gov/arcgis/services/ortho_imagery/alaska_delta_junction_2021/ImageServer/WMSServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=alaska_delta_junction_2021:NaturalColor_4Band_Vivid_NoStretch&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "start_date": "2021",
+        "end_date": "2021",
+        "max_zoom": 20,
+        "min_zoom": 12,
+        "license_url": "https://www.usda.gov/policies-and-links/",
+        "country_code": "US",
+        "available_projections": [
+            "CRS:84",
+            "EPSG:4326",
+            "EPSG:3857"
+        ],
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/north-america/us/USDA.png",
+        "category": "photo",
+        "privacy_policy_url": "https://www.usda.gov/privacy-policy",
+        "valid-georeference": true
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -144.74911337007418,
+                    64.11792103233867
+                ],
+                [
+                    -145.50001036857506,
+                    64.12594287417905
+                ],
+                [
+                    -145.49895832374352,
+                    64.24903211946743
+                ],
+                [
+                    -145.74934499364645,
+                    64.25008416429895
+                ],
+                [
+                    -145.74881897123075,
+                    64.37448846562684
+                ],
+                [
+                    -146.2516964006997,
+                    64.37475147683469
+                ],
+                [
+                    -146.2511703782839,
+                    64.12489082934752
+                ],
+                [
+                    -145.99973166354943,
+                    64.12173469485295
+                ],
+                [
+                    -146.00078370838096,
+                    63.99969749439605
+                ],
+                [
+                    -145.75039703847804,
+                    63.99969749439605
+                ],
+                [
+                    -145.7525011281411,
+                    63.875556204276116
+                ],
+                [
+                    -145.5000103685751,
+                    63.873452114613066
+                ],
+                [
+                    -145.5010624134066,
+                    63.75246695898769
+                ],
+                [
+                    -144.74885035886626,
+                    63.74615468999854
+                ],
+                [
+                    -144.7509544485293,
+                    63.624117489541646
+                ],
+                [
+                    -144.49846368896334,
+                    63.62306544471012
+                ],
+                [
+                    -144.49846368896334,
+                    63.87555620427611
+                ],
+                [
+                    -144.7499024036978,
+                    63.870295980118485
+                ],
+                [
+                    -144.74911337007418,
+                    64.11792103233867
+                ]
+            ]
+        ]
+    }
+}

--- a/sources/north-america/us/hi/USDA_Hawaii_2022.geojson
+++ b/sources/north-america/us/hi/USDA_Hawaii_2022.geojson
@@ -1,0 +1,56 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "USDA_Hawaii_2022",
+        "attribution": {
+            "url": "https://datagateway.nrcs.usda.gov/",
+            "text": "U.S. Department of Agriculture",
+            "required": false
+        },
+        "name": "USDA Hawaii Imagery (2022)",
+        "type": "wms",
+        "url": "https://nrcsgeoservices.sc.egov.usda.gov/arcgis/services/ortho_imagery/hawaii_vivid_2022_30cm/ImageServer/WMSServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=hawaii_vivid_2022_30cm:Natural Color No Stretch&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "start_date": "2014-12-06",
+        "end_date": "2020-10-11",
+        "max_zoom": 20,
+        "min_zoom": 12,
+        "license_url": "https://www.usda.gov/policies-and-links/",
+        "country_code": "US",
+        "available_projections": [
+            "CRS:84",
+            "EPSG:4326",
+            "EPSG:3857"
+        ],
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/north-america/us/USDA.png",
+        "category": "photo",
+        "privacy_policy_url": "https://www.usda.gov/privacy-policy",
+        "valid-georeference": true
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -160.33912875649403,
+                    22.31879602313053
+                ],
+                [
+                    -160.33912875649403,
+                    18.845042487146173
+                ],
+                [
+                    -154.73744714701988,
+                    18.845042487146173
+                ],
+                [
+                    -154.73744714701988,
+                    22.31879602313053
+                ],
+                [
+                    -160.33912875649403,
+                    22.31879602313053
+                ]
+            ]
+        ]
+    }
+}

--- a/sources/north-america/us/hi/USDA_Northwest_Hawaiian_Islands_2022.geojson
+++ b/sources/north-america/us/hi/USDA_Northwest_Hawaiian_Islands_2022.geojson
@@ -1,0 +1,56 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "USDA_Northwest_Hawaiian_Islands_2022",
+        "attribution": {
+            "url": "https://datagateway.nrcs.usda.gov/",
+            "text": "U.S. Department of Agriculture",
+            "required": false
+        },
+        "name": "USDA Northwest Hawaiian Islands Imagery (2022)",
+        "type": "wms",
+        "url": "https://nrcsgeoservices.sc.egov.usda.gov/arcgis/services/ortho_imagery/northwest_hawaiian_islands_2022_30cm/ImageServer/WMSServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=northwest_hawaiian_islands_2022_30cm:Natural Color No Stretch&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "start_date": "2020-05-29",
+        "end_date": "2022-06-30",
+        "max_zoom": 20,
+        "min_zoom": 12,
+        "license_url": "https://www.usda.gov/policies-and-links/",
+        "country_code": "US",
+        "available_projections": [
+            "CRS:84",
+            "EPSG:4326",
+            "EPSG:3857"
+        ],
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/north-america/us/USDA.png",
+        "category": "photo",
+        "privacy_policy_url": "https://www.usda.gov/privacy-policy",
+        "valid-georeference": true
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -178.79629342259264,
+                    27.39866602007675
+                ],
+                [
+                    -162.1411202500087,
+                    21.87262404328549
+                ],
+                [
+                    -161.47491332310534,
+                    23.210214682340474
+                ],
+                [
+                    -178.6297416908668,
+                    29.171296555558747
+                ],
+                [
+                    -178.79629342259264,
+                    27.39866602007675
+                ]
+            ]
+        ]
+    }
+}

--- a/sources/oceania/as/USDA_American_Samoa_2022.geojson
+++ b/sources/oceania/as/USDA_American_Samoa_2022.geojson
@@ -1,0 +1,56 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "USDA_American_Samoa_2022",
+        "attribution": {
+            "url": "https://datagateway.nrcs.usda.gov/",
+            "text": "U.S. Department of Agriculture",
+            "required": false
+        },
+        "name": "USDA American Samoa Imagery (2022)",
+        "type": "wms",
+        "url": "https://nrcsgeoservices.sc.egov.usda.gov/arcgis/services/ortho_imagery/american_samoa_vivid_2022_30cm/ImageServer/WMSServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=american_samoa_vivid_2022_30cm:Natural Color No Stretch&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "start_date": "2018-04-07",
+        "end_date": "2022-06-10",
+        "max_zoom": 20,
+        "min_zoom": 12,
+        "license_url": "https://www.usda.gov/policies-and-links/",
+        "country_code": "AS",
+        "available_projections": [
+            "CRS:84",
+            "EPSG:4326",
+            "EPSG:3857"
+        ],
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/north-america/us/USDA.png",
+        "category": "photo",
+        "privacy_policy_url": "https://www.usda.gov/privacy-policy",
+        "valid-georeference": true
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -171.01724134405018,
+                    -14.734243505717942
+                ],
+                [
+                    -167.94045959468005,
+                    -14.771590987059534
+                ],
+                [
+                    -167.8632182118507,
+                    -10.805330809160186
+                ],
+                [
+                    -171.33908043917253,
+                    -10.855907794031241
+                ],
+                [
+                    -171.01724134405018,
+                    -14.734243505717942
+                ]
+            ]
+        ]
+    }
+}

--- a/sources/oceania/fm/USDA_Micronesia_2023.geojson
+++ b/sources/oceania/fm/USDA_Micronesia_2023.geojson
@@ -1,0 +1,56 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "USDA_Micronesia_2023",
+        "attribution": {
+            "url": "https://datagateway.nrcs.usda.gov/",
+            "text": "U.S. Department of Agriculture",
+            "required": false
+        },
+        "name": "USDA Micronesia Imagery (2023)",
+        "type": "wms",
+        "url": "https://nrcsgeoservices.sc.egov.usda.gov/arcgis/services/ortho_imagery/micronesia_vivid_2023_30cm/ImageServer/WMSServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=micronesia_vivid_2023_30cm:Natural Color No Stretch&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "start_date": "2016-11-11",
+        "end_date": "2023-08-03",
+        "max_zoom": 20,
+        "min_zoom": 12,
+        "license_url": "https://www.usda.gov/policies-and-links/",
+        "country_code": "FM",
+        "available_projections": [
+            "CRS:84",
+            "EPSG:4326",
+            "EPSG:3857"
+        ],
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/north-america/us/USDA.png",
+        "category": "photo",
+        "privacy_policy_url": "https://www.usda.gov/privacy-policy",
+        "valid-georeference": true
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    163.373429275922462,
+                    5.98505344128734
+                ],
+                [
+                    136.569223497932114,
+                    13.303997896401635
+                ],
+                [
+                    136.774521388045969,
+                    7.552230748292314
+                ],
+                [
+                    163.514571575375726,
+                    -2.535897507641291
+                ],
+                [
+                    163.373429275922462,
+                    5.98505344128734
+                ]
+            ]
+        ]
+    }
+}

--- a/sources/oceania/gu/USDA_Guam_2022.geojson
+++ b/sources/oceania/gu/USDA_Guam_2022.geojson
@@ -1,0 +1,56 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "USDA_Guam_2022",
+        "attribution": {
+            "url": "https://datagateway.nrcs.usda.gov/",
+            "text": "U.S. Department of Agriculture",
+            "required": false
+        },
+        "name": "USDA Guam Imagery (2022)",
+        "type": "wms",
+        "url": "https://nrcsgeoservices.sc.egov.usda.gov/arcgis/services/ortho_imagery/guam_vivid_2022_30cm/ImageServer/WMSServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=guam_vivid_2022_30cm:Natural Color No Stretch&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "start_date": "2020-09-19",
+        "end_date": "2022-07-19",
+        "max_zoom": 20,
+        "min_zoom": 12,
+        "license_url": "https://www.usda.gov/policies-and-links/",
+        "country_code": "GU",
+        "available_projections": [
+            "CRS:84",
+            "EPSG:4326",
+            "EPSG:3857"
+        ],
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/north-america/us/USDA.png",
+        "category": "photo",
+        "privacy_policy_url": "https://www.usda.gov/privacy-policy",
+        "valid-georeference": true
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    144.7917960323581,
+                    13.109039173492937
+                ],
+                [
+                    145.16311788835557,
+                    13.606917193761905
+                ],
+                [
+                    144.80265810181848,
+                    13.847654534343988
+                ],
+                [
+                    144.43254314242773,
+                    13.372197118943856
+                ],
+                [
+                    144.7917960323581,
+                    13.109039173492937
+                ]
+            ]
+        ]
+    }
+}

--- a/sources/oceania/mh/USDA_Marshall_Islands_2023.geojson
+++ b/sources/oceania/mh/USDA_Marshall_Islands_2023.geojson
@@ -1,0 +1,56 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "USDA_Marshall_Islands_2023",
+        "attribution": {
+            "url": "https://datagateway.nrcs.usda.gov/",
+            "text": "U.S. Department of Agriculture",
+            "required": false
+        },
+        "name": "USDA Marshall Islands Imagery (2023)",
+        "type": "wms",
+        "url": "https://nrcsgeoservices.sc.egov.usda.gov/arcgis/services/ortho_imagery/marshall_islands_vivid_2023_30cm/ImageServer/WMSServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=marshall_islands_vivid_2023_30cm:Natural Color No Stretch&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "start_date": "2018-04-11",
+        "end_date": "2023-08-08",
+        "max_zoom": 20,
+        "min_zoom": 12,
+        "license_url": "https://www.usda.gov/policies-and-links/",
+        "country_code": "MH",
+        "available_projections": [
+            "CRS:84",
+            "EPSG:4326",
+            "EPSG:3857"
+        ],
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/north-america/us/USDA.png",
+        "category": "photo",
+        "privacy_policy_url": "https://www.usda.gov/privacy-policy",
+        "valid-georeference": true
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    168.6983433007506,
+                    4.336607017637928
+                ],
+                [
+                    172.58617209478174,
+                    5.806368042469353
+                ],
+                [
+                    169.36556144362055,
+                    15.454101704619514
+                ],
+                [
+                    159.42144489123066,
+                    10.542344580796188
+                ],
+                [
+                    168.6983433007506,
+                    4.336607017637928
+                ]
+            ]
+        ]
+    }
+}

--- a/sources/oceania/mp/USDA_CNMI_2022.geojson
+++ b/sources/oceania/mp/USDA_CNMI_2022.geojson
@@ -1,0 +1,56 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "USDA_CNMI_2022",
+        "attribution": {
+            "url": "https://datagateway.nrcs.usda.gov/",
+            "text": "U.S. Department of Agriculture",
+            "required": false
+        },
+        "name": "USDA Northern Mariana Islands Imagery (2022)",
+        "type": "wms",
+        "url": "https://nrcsgeoservices.sc.egov.usda.gov/arcgis/services/ortho_imagery/cnmi_vivid_2022_30cm/ImageServer/WMSServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=cnmi_vivid_2022_30cm:Natural Color No Stretch&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "start_date": "2012-03-12",
+        "end_date": "2022-06-03",
+        "max_zoom": 20,
+        "min_zoom": 12,
+        "license_url": "https://www.usda.gov/policies-and-links/",
+        "country_code": "MP",
+        "available_projections": [
+            "CRS:84",
+            "EPSG:4326",
+            "EPSG:3857"
+        ],
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/north-america/us/USDA.png",
+        "category": "photo",
+        "privacy_policy_url": "https://www.usda.gov/privacy-policy",
+        "valid-georeference": true
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    146.12702597824722,
+                    13.778116234735766
+                ],
+                [
+                    146.56472714761364,
+                    20.72551025530249
+                ],
+                [
+                    144.6658764863915,
+                    20.755608440209258
+                ],
+                [
+                    144.8750718982211,
+                    13.946847306335261
+                ],
+                [
+                    146.12702597824722,
+                    13.778116234735766
+                ]
+            ]
+        ]
+    }
+}

--- a/sources/oceania/pw/USDA_Palau_2022.geojson
+++ b/sources/oceania/pw/USDA_Palau_2022.geojson
@@ -1,0 +1,56 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "USDA_Palau_2022",
+        "attribution": {
+            "url": "https://datagateway.nrcs.usda.gov/",
+            "text": "U.S. Department of Agriculture",
+            "required": false
+        },
+        "name": "USDA Palau Imagery (2022)",
+        "type": "wms",
+        "url": "https://nrcsgeoservices.sc.egov.usda.gov/arcgis/rest/services/ortho_imagery/palau_vivid_2022_30cm/ImageServer/exportImage?f=image&format=jpg&bbox={bbox}&imageSR={wkid}&bboxSR={wkid}&size={width},{height}&f={proj}",
+        "start_date": "2019-03-06",
+        "end_date": "2022-06-18",
+        "max_zoom": 20,
+        "min_zoom": 12,
+        "license_url": "https://www.usda.gov/policies-and-links/",
+        "country_code": "PW",
+        "available_projections": [
+            "CRS:84",
+            "EPSG:4326",
+            "EPSG:3857"
+        ],
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/north-america/us/USDA.png",
+        "category": "photo",
+        "privacy_policy_url": "https://www.usda.gov/privacy-policy",
+        "valid-georeference": true
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    130.1638068601765,
+                    3.134514351724011
+                ],
+                [
+                    132.50035869076507,
+                    2.305112123054847
+                ],
+                [
+                    135.35828985545194,
+                    8.43509824667162
+                ],
+                [
+                    134.43863464113969,
+                    8.456586790104325
+                ],
+                [
+                    130.1638068601765,
+                    3.134514351724011
+                ]
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
Adds imagery for territories and freely associated states of the US as well as imagery for Alaska/Hawaii.

Edit: coverage area errors are because imagery of spread out archipelagos only cover the islands themselves and not the ocean in between them