### PR TITLE
Add tracestrack topo imagery

### DIFF
--- a/sources/world/TracestrackTopo.geojson
+++ b/sources/world/TracestrackTopo.geojson
@@ -1,0 +1,19 @@
+{
+    "properties": {
+        "attribution": {
+            "required": true,
+            "text": "Data: © OpenStreetMap contributors, SRTM, GEBCO, SONNY's LiDAR DTM, NASADEM, ESA WorldCover; Maps © Tracestrack",
+            "url": "https://www.tracestrack.com/tos/"
+        },
+        "icon": "https://www.tracestrack.com/img/logo_white.png",
+        "id": "TracestrackTopo",
+        "max_zoom": 19,
+        "min_zoom": 3,
+        "name": "Tracestrack Topo Universal",
+        "type": "tms",
+        "category": "osmbasedmap",
+        "url": "https://tile.tracestrack.com/topo__/{zoom}/{x}/{y}@1x.png?key=7e1b3f4d479cfb3ccfef83f4e4fe6b4f"
+    },
+    "type": "Feature",
+    "geometry": null
+}

--- a/sources/world/TracestrackTopo.geojson
+++ b/sources/world/TracestrackTopo.geojson
@@ -3,8 +3,9 @@
         "attribution": {
             "required": true,
             "text": "Data: © OpenStreetMap contributors, SRTM, GEBCO, SONNY's LiDAR DTM, NASADEM, ESA WorldCover; Maps © Tracestrack",
-            "url": "https://www.tracestrack.com/tos/"
+            "url": "https://www.tracestrack.com/information/"
         },
+        "license_url": "https://www.tracestrack.com/tos/",
         "icon": "https://www.tracestrack.com/img/logo_white.png",
         "id": "TracestrackTopo",
         "max_zoom": 19,
@@ -12,7 +13,7 @@
         "name": "Tracestrack Topo Universal",
         "type": "tms",
         "category": "osmbasedmap",
-        "url": "https://tile.tracestrack.com/topo__/{zoom}/{x}/{y}@1x.png?key=7e1b3f4d479cfb3ccfef83f4e4fe6b4f"
+        "url": "https://tile.tracestrack.com/topo__/{zoom}/{x}/{y}.png?key=7e1b3f4d479cfb3ccfef83f4e4fe6b4f"
     },
     "type": "Feature",
     "geometry": null


### PR DESCRIPTION
Hi,

I'm from Tracestrack Maps and I'd like to provide the Topo map as an imagery to help mappers.

The API key is embedded and has a limited quota at 900 requests per minute. It might be adjusted later if necessary.