### PR TITLE
Prefer png favicon to reduce the file size

### DIFF
--- a/sources/europe/de/Stuttgart-latest.geojson
+++ b/sources/europe/de/Stuttgart-latest.geojson
@@ -20,7 +20,7 @@
             "EPSG:25832",
             "EPSG:31467"
         ],
-        "icon": "https://www.stuttgart.de/favicon.ico"
+        "icon": "https://www.stuttgart.de/favicon-32x32.png"
     },
     "geometry": {
         "type": "Polygon",


### PR DESCRIPTION
## explain
When i'm in https://www.openstreetmap.org/edit#map=19/48.83238/9.32069 the picture used is a .ico file. It's a old format, i prefer a PNG for download less data.

## sizes
* [favicon-32x32.png](https://www.stuttgart.de/favicon-32x32.png): 1175
* [favicon.ico](https://www.stuttgart.de/favicon.ico): **7406**