### PR TITLE
Remove "best" flag from ALKIS NRW

### DIFF
--- a/sources/europe/de/NRW_alkis.geojson
+++ b/sources/europe/de/NRW_alkis.geojson
@@ -9,7 +9,6 @@
         "id": "nrw_alkis_wms",
         "description": "Amtliches Liegenschaftskatasterinformationssystem (ALKIS). Zeigt Gebäude- und Flurstücksdaten.",
         "country_code": "DE",
-        "best": true,
         "category": "map",
         "available_projections": [
             "EPSG:3034",

--- a/sources/europe/de/NRW_alkis.geojson
+++ b/sources/europe/de/NRW_alkis.geojson
@@ -9,6 +9,7 @@
         "id": "nrw_alkis_wms",
         "description": "Amtliches Liegenschaftskatasterinformationssystem (ALKIS). Zeigt Gebäude- und Flurstücksdaten.",
         "country_code": "DE",
+        "best": false,
         "category": "map",
         "available_projections": [
             "EPSG:3034",


### PR DESCRIPTION
This is a quick fix for https://github.com/osmlab/editor-layer-index/issues/2262#issuecomment-2053627371, https://github.com/osmlab/editor-layer-index/issues/2272

The "best" flag should only be used for aerial imagery because it was introduced as a "best alternative to the default Bing Layer". Editors like iD do not have good handling if two "best" sources are present for multiple categories.