### PR TITLE
Docs: Add link to JOSM imagery sources wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ For any other usage, use https://osmlab.github.io/editor-layer-index/imagery.geo
 
 An interactive list of all layers (with a live map preview for most of them) is available at
 https://osmlab.github.io/editor-layer-index.
+
+## Similar Projects
+
+- The [JOSM Imagery souces wiki](https://josm.openstreetmap.de/wiki/Maps) is a similar project to ELI


### PR DESCRIPTION
I find myself lookin for this link again and again when looking at adding ELI layer. It is common to link to similar projects from the readme, so how about we do the same here.