### PR TITLE
de/NRW: Orthophoto is best, vDOP is not

### DIFF
--- a/sources/europe/de/NRW_ortho_wms.geojson
+++ b/sources/europe/de/NRW_ortho_wms.geojson
@@ -9,7 +9,7 @@
         "id": "nrw_ortho_wms",
         "description": "RGB-/Colorbild - Normale farbliche Darstellung.",
         "country_code": "DE",
-        "best": false,
+        "best": true,
         "category": "photo",
         "available_projections": [
             "EPSG:3034",

--- a/sources/europe/de/NRW_vdop_wms.geojson
+++ b/sources/europe/de/NRW_vdop_wms.geojson
@@ -9,7 +9,7 @@
         "id": "nrw_vdop_wms",
         "description": "10cm Bodenauflösung, Zwischenergebnisse aus dem Herstellungsprozess der Digitalen Orthophotos (DOP)",
         "country_code": "DE",
-        "best": true,
+        "best": false,
         "category": "photo",
         "available_projections": [
             "EPSG:3034",


### PR DESCRIPTION
resolves #2262

might not address #2273 because the outcome of that issue *could* be to remove the vDOP entry entirely