### PR TITLE
Berlin: Update two sources to include additional information

### DIFF
--- a/sources/europe/de/BerlinBaeumeAlkis.geojson
+++ b/sources/europe/de/BerlinBaeumeAlkis.geojson
@@ -1,17 +1,17 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "Berlin-Baumbestand",
-        "name": "Berlin/Geoportal Baumbestand",
+        "id": "Berlin-Baumbestand_Alkis",
+        "name": "Berlin/Geoportal Baumbestand, Alkis s/w",
         "type": "tms",
         "category": "other",
-        "url": "https://mapproxy.codefor.de/tiles/1.0.0/baumbestand_0_1_3_4_merged/mercator/{zoom}/{x}/{y}.png",
-        "start_date": "2014",
-        "end_date": "2015",
+        "url": "https://mapproxy.codefor.de/tiles/1.0.0/baumbestand_0_1_3_4_alkis/mercator/{zoom}/{x}/{y}.png",
+        "start_date": "2024",
+        "end_date": "2024",
         "country_code": "DE",
         "best": false,
         "attribution": {
-            "text": "Geoportal Berlin/Straßen- und Anlagenbaumbestand Berlin (codefor.de proxy)",
+            "text": "Geoportal Berlin/Straßen- und Anlagenbaumbestand Berlin, ALKIS s/w (codefor.de proxy)",
             "required": true
         },
         "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf",

--- a/sources/europe/de/BerlinStrassenbefahrungAlkis.geojson
+++ b/sources/europe/de/BerlinStrassenbefahrungAlkis.geojson
@@ -1,17 +1,17 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "Berlin-Strassenbefahrung-2014",
-        "name": "Berlin/Geoportal Straßenbefahrung 2014",
+        "id": "Berlin-Strassenbefahrung-2014-Alkis",
+        "name": "Berlin/Geoportal Straßenbefahrung 2014, Alkis",
         "type": "tms",
         "category": "other",
-        "url": "https://mapproxy.codefor.de/tiles/1.0.0/strassenbefahrung/mercator/{zoom}/{x}/{y}.png",
+        "url": "https://mapproxy.codefor.de/tiles/1.0.0/strassenbefahrung_alkis/mercator/{zoom}/{x}/{y}.png",
         "start_date": "2014",
         "end_date": "2015",
         "country_code": "DE",
         "best": false,
         "attribution": {
-            "text": "Geoportal Berlin/Straßenbefahrung 2014 (codefor.de proxy)",
+            "text": "Geoportal Berlin/Straßenbefahrung 2014; ALKIS s/w (codefor.de proxy)",
             "required": true
         },
         "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf",


### PR DESCRIPTION
**BerlinStrassenbefahrungAlkis**

This replaces the existing BerlinStrassenbefahrung layer with a new layer BerlinStrassenbefahrungAlkis that includes ALKIS data for those areas which where white in the previous version. 

This is a new file and layer ID because the attribution changes and we need to keep a clean record of attribution <> layer id.

**BerlinBaumeAlkis**

Some thing, same reason.