### PR TITLE
Add GeoScribble WMS overlay

### DIFF
--- a/sources/world/GeoScribbles.geojson
+++ b/sources/world/GeoScribbles.geojson
@@ -7,7 +7,7 @@
             "url": "https://wiki.openstreetmap.org/wiki/GeoScribble"
         },
         "description": "Geometric survey notes from Every Door editor, aged three weeks at most",
-        "i18n": false,
+        "i18n": true,
         "id": "geoscribble-latest",
         "available_projections": [
             "EPSG:3857",

--- a/sources/world/GeoScribbles.geojson
+++ b/sources/world/GeoScribbles.geojson
@@ -6,7 +6,7 @@
             "text": "GeoScribble contributors",
             "url": "https://wiki.openstreetmap.org/wiki/GeoScribble"
         },
-        "description": "Post-processed Sentinel Satellite imagery.",
+        "description": "Geometric survey notes, aged three weeks at most",
         "i18n": false,
         "id": "geoscribble-latest",
         "available_projections": [

--- a/sources/world/GeoScribbles.geojson
+++ b/sources/world/GeoScribbles.geojson
@@ -1,0 +1,29 @@
+{
+    "geometry": null,
+    "properties": {
+        "attribution": {
+            "required": false,
+            "text": "GeoScribble contributors",
+            "url": "https://wiki.openstreetmap.org/wiki/GeoScribble"
+        },
+        "description": "Post-processed Sentinel Satellite imagery.",
+        "i18n": false,
+        "id": "geoscribble-latest",
+        "available_projections": [
+            "EPSG:3857",
+            "EPSG:4326"
+        ],
+        "max_zoom": 22,
+        "name": "GeoScribble latest notes",
+        "type": "wms",
+        "default": false,
+        "overlay": true,
+        "transparent": true,
+        "category": "other",
+        "valid-georeference": true,
+        "url": "https://geoscribble.osmz.ru/?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=latest&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "license_url": "https://wiki.openstreetmap.org/wiki/GeoScribble",
+        "privacy_policy_url": false
+    },
+    "type": "Feature"
+}

--- a/sources/world/GeoScribbles.geojson
+++ b/sources/world/GeoScribbles.geojson
@@ -6,7 +6,7 @@
             "text": "GeoScribble contributors",
             "url": "https://wiki.openstreetmap.org/wiki/GeoScribble"
         },
-        "description": "Geometric survey notes, aged three weeks at most",
+        "description": "Geometric survey notes from Every Door editor, aged three weeks at most",
         "i18n": false,
         "id": "geoscribble-latest",
         "available_projections": [

--- a/sources/world/GeoScribbles.geojson
+++ b/sources/world/GeoScribbles.geojson
@@ -22,7 +22,7 @@
         "category": "other",
         "valid-georeference": true,
         "url": "https://geoscribble.osmz.ru/?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=latest&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
-        "license_url": "https://wiki.openstreetmap.org/wiki/GeoScribble",
+        "license_url": "https://wiki.openstreetmap.org/wiki/GeoScribble#License",
         "privacy_policy_url": false
     },
     "type": "Feature"


### PR DESCRIPTION
See https://wiki.openstreetmap.org/wiki/GeoScribble — for editors that don't support the geometric notes yet.

Things to discuss:

* There is no explicit license mention, but the wiki page states it's PDDL. Should I put this license note somewhere else?
* There are two layers: limited to 3 months and 3 weeks of notes. Does 3 weeks work?
* `default=true`?
* `i18n=true`?