### PR TITLE
Revert Orange County ortho back to original URL

### DIFF
--- a/sources/north-america/us/ca/Orange_CA_2022.geojson
+++ b/sources/north-america/us/ca/Orange_CA_2022.geojson
@@ -9,7 +9,7 @@
         },
         "name": "Orange County Orthoimagery (2022)",
         "icon": "https://www.ocgov.com/sites/ocgov/files/ocseal_0.png",
-        "url": "https://www.ocgis.com/survey/rest/services/Basemaps/Eagle_2022_3in_Aerial_Cached/ImageServer/exportImage?f=image&format=jpg&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&foo={proj}",
+        "url": "https://ocgis.com/arcpub/rest/services/Aerial_Imagery_Countywide/22_OC_3IN_SP6/ImageServer/exportImage?f=image&format=jpg&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&foo={proj}",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/California#Publicly_Available_Data",
         "country_code": "US",


### PR DESCRIPTION
URL was originally switched as the previous ImageServer was down. Switching back to the original ImageServer as it's better aligned