### PR TITLE
Add Massachusetts MassGIS 2023 aerial imagery

### DIFF
--- a/sources/north-america/us/ma/MassGIS_2021_Aerial.geojson
+++ b/sources/north-america/us/ma/MassGIS_2021_Aerial.geojson
@@ -19,7 +19,6 @@
         "description": "15cm Spring 2021 true color aerial imagery for the state of Massachusetts",
         "category": "photo",
         "valid-georeference": true,
-        "best": true,
         "privacy_policy_url": "https://www.esri.com/en-us/privacy/overview"
     },
     "geometry": {

--- a/sources/north-america/us/ma/MassGIS_2023_Aerial.geojson
+++ b/sources/north-america/us/ma/MassGIS_2023_Aerial.geojson
@@ -1,24 +1,25 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "MassGIS-2019-Orthos",
-        "name": "MassGIS 2019 Orthos",
-        "icon": "https://www.mass.gov/files/styles/organization_logo/public/2017-05/massgis_logo_401x300.png",
-        "category": "photo",
-        "type": "tms",
-        "url": "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/USGS_Orthos_2019/MapServer/tile/{zoom}/{y}/{x}",
-        "country_code": "US",
-        "min_zoom": 7,
-        "max_zoom": 20,
+        "id": "MassGIS_2023_Aerial",
         "attribution": {
-            "url": "https://www.mass.gov/info-details/massgis-data-2019-aerial-imagery",
+            "url": "https://www.mass.gov/info-details/massgis-data-2023-aerial-imagery",
             "text": "MassGIS",
             "required": false
         },
+        "name": "MassGIS 2023 Aerial Imagery",
+        "icon": "https://www.mass.gov/files/styles/organization_logo/public/2017-05/massgis_logo_401x300.png",
+        "url": "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/orthos2023/MapServer/tile/{zoom}/{y}/{x}",
+        "max_zoom": 20,
+        "license_url": "https://www.mass.gov/service-details/massgis-frequently-asked-questions",
+        "country_code": "US",
+        "type": "tms",
+        "start_date": "2023-03-20",
+        "end_date": "2023-04-28",
+        "description": "15cm Spring 2023 true color aerial imagery for the state of Massachusetts",
+        "category": "photo",
         "valid-georeference": true,
-        "start_date": "2019-03-24",
-        "end_date": "2019-04-25",
-        "license_url": "https://wiki.openstreetmap.org/wiki/MassGIS#Right_to_Use",
+        "best": true,
         "privacy_policy_url": "https://www.esri.com/en-us/privacy/overview"
     },
     "geometry": {


### PR DESCRIPTION
(And removing 2019, since the standard seems to be to keep the most recent two sets of imagery.)