### PR TITLE
NRW_alkis, NRW_alkis_buildings: Fix category to "other"

### DIFF
--- a/sources/europe/de/NRW_alkis.geojson
+++ b/sources/europe/de/NRW_alkis.geojson
@@ -10,7 +10,7 @@
         "description": "Amtliches Liegenschaftskatasterinformationssystem (ALKIS). Zeigt Gebäude- und Flurstücksdaten.",
         "country_code": "DE",
         "best": false,
-        "category": "map",
+        "category": "other",
         "available_projections": [
             "EPSG:3034",
             "EPSG:3035",

--- a/sources/europe/de/NRW_alkis_buildings.geojson
+++ b/sources/europe/de/NRW_alkis_buildings.geojson
@@ -10,7 +10,7 @@
         "description": "Amtliche Gebäudeumrisse, Hausnummern und Etagen (römische Zahlen) in Gelb",
         "country_code": "DE",
         "overlay": true,
-        "category": "map",
+        "category": "other",
         "available_projections": [
             "EPSG:3034",
             "EPSG:3035",


### PR DESCRIPTION
https://github.com/osmlab/editor-layer-index/blob/gh-pages/CONTRIBUTING.md?plain=1#L80-L87 defines "map" as "A map which is not mostly based on OSM data." which is not the case for ALKIS Data. Other Alkis layer where mapped as "other".