### PR TITLE
SaxonyAnhalt_ATKIS_BU: Category "other"

### DIFF
--- a/sources/europe/de/SaxonyAnhalt_ATKIS_BU.geojson
+++ b/sources/europe/de/SaxonyAnhalt_ATKIS_BU.geojson
@@ -9,6 +9,7 @@
         "category": "other",
         "url": "https://www.geodatenportal.sachsen-anhalt.de/wss/service/INSPIRE_LVermGeo_ATKIS_BU/guest?LANGUAGE=GER&FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=BU.Building&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "eula": "https://wiki.openstreetmap.org/wiki/DE:Permissions/Geobasisdaten_Sachsen-Anhalt",
+        "privacy_policy_url": "https://geodatenportal.sachsen-anhalt.de/gfds/de/datenschutz-service.html",
         "best": true,
         "overlay": true,
         "valid-georeference": true,

--- a/sources/europe/de/SaxonyAnhalt_ATKIS_BU.geojson
+++ b/sources/europe/de/SaxonyAnhalt_ATKIS_BU.geojson
@@ -6,7 +6,7 @@
         "description": "Shape of buildings in saxony-anhalt",
         "i18n": true,
         "type": "wms",
-        "category": "map",
+        "category": "other",
         "url": "https://www.geodatenportal.sachsen-anhalt.de/wss/service/INSPIRE_LVermGeo_ATKIS_BU/guest?LANGUAGE=GER&FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=BU.Building&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "eula": "https://wiki.openstreetmap.org/wiki/DE:Permissions/Geobasisdaten_Sachsen-Anhalt",
         "best": true,


### PR DESCRIPTION
https://github.com/osmlab/editor-layer-index/blob/gh-pages/CONTRIBUTING.md?plain=1#L80-L87 defines "map" as "A map which is not mostly based on OSM data." which is not the case for ALKIS Data. Other Alkis layer where mapped as "other".