### PR TITLE
Ohter ALKIS sources: Update category to "other"

### DIFF
--- a/sources/europe/de/Hessen-ALKIS.geojson
+++ b/sources/europe/de/Hessen-ALKIS.geojson
@@ -6,7 +6,7 @@
         "url": "https://www.gds-srv.hessen.de/cgi-bin/lika-services/ogc-free-maps.ows?LAYERS=he_alk&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
         "id": "Hessen-ALKIS",
         "country_code": "DE",
-        "category": "map",
+        "category": "other",
         "available_projections": [
             "EPSG:3044",
             "EPSG:3857",

--- a/sources/europe/de/aachen_alkis.geojson
+++ b/sources/europe/de/aachen_alkis.geojson
@@ -10,7 +10,7 @@
         "description": "Amtliches Liegenschaftskatasterinformationssystem (ALKIS). Zeigt Gebäude- und Flurstücksdaten (tagesaktuell)",
         "country_code": "DE",
         "best": true,
-        "category": "map",
+        "category": "other",
         "available_projections": [
             "CRS:84",
             "EPSG:25832"

--- a/sources/europe/de/viersen_alkis.geojson
+++ b/sources/europe/de/viersen_alkis.geojson
@@ -11,7 +11,7 @@
         "description": "Amtliches Liegenschaftskatasterinformationssystem (ALKIS). Zeigt Gebäude- und Flurstücksdaten (tagesaktuell)",
         "country_code": "DE",
         "best": true,
-        "category": "map",
+        "category": "other",
         "available_projections": [
             "CRS:84",
             "EPSG:25831",


### PR DESCRIPTION
https://github.com/osmlab/editor-layer-index/blob/gh-pages/CONTRIBUTING.md?plain=1#L80-L87 defines "map" as "A map which is not mostly based on OSM data." which is not the case for ALKIS Data. Other Alkis layer where mapped as "other".