### PR TITLE
Add Wood Ortho 2023

### DIFF
--- a/sources/north-america/us/oh/Wood_OH_2023.geojson
+++ b/sources/north-america/us/oh/Wood_OH_2023.geojson
@@ -1,27 +1,27 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "Wood_OH_2020",
+        "id": "Wood_OH_2023",
         "attribution": {
             "url": "https://www.woodcountyohio.gov",
             "text": "Wood County, State of Ohio",
             "required": false
         },
-        "name": "Wood County Orthoimagery (2020)",
+        "name": "Wood County Orthoimagery (2023)",
         "icon": "https://www.woodcountyohio.gov/ImageRepository/Document?documentID=70",
-        "url": "https://engineergis.co.wood.oh.us/arcgis/rest/services/Imagery/Wood_2020_rgb_20x/ImageServer/exportImage?f=image&format=jpg&imageSR={wkid}&bboxSR={wkid}&bbox={bbox}&size={width},{height}&foo={proj}",
+        "url": "https://wcohgis.woodcountyohio.gov/arcgis/rest/services/Services_for_Web_Apps/Wood_2023_Orthoimagery/ImageServer/exportImage?f=image&format=jpg&imageSR={wkid}&bboxSR={wkid}&bbox={bbox}&size={width},{height}&foo={proj}",
         "max_zoom": 21,
-        "license_url": "https://engineergis.co.wood.oh.us/arcgis/rest/services/Imagery/Wood_2020_rgb_20x/ImageServer",
+        "license_url": "https://gis1.oit.ohio.gov/OGRIPWeb/WebContent/OSIP/OSIP%20III%20RFP%200A1177.pdf#page=26",
         "country_code": "US",
         "type": "wms",
         "available_projections": [
             "CRS:84",
             "EPSG:3857"
         ],
-        "start_date": "2020",
-        "end_date": "2020",
-        "description": "Spring 2020 orthoimagery for Wood County in the State of Ohio",
-        "category": "historicphoto",
+        "start_date": "2023",
+        "end_date": "2023",
+        "description": "Spring 2023 orthoimagery for Wood County in the State of Ohio",
+        "category": "photo",
         "valid-georeference": true,
         "privacy_policy_url": "https://www.woodcountyohio.gov/privacy"
     },


### PR DESCRIPTION
Wood County's 2023 imagery was captured under OSIP III (as listed on [OGRIP's download portal](https://gis1.oit.ohio.gov/geodatadownload/)), which is in the public domain.