### PR TITLE
Add Dublin Ortho 2023

### DIFF
--- a/sources/north-america/us/oh/City_of_Dublin_OH_2023.geojson
+++ b/sources/north-america/us/oh/City_of_Dublin_OH_2023.geojson
@@ -1,0 +1,51 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "City_of_Dublin_OH_2023",
+        "attribution": {
+            "url": "https://dublinohiousa.gov/",
+            "text": "City of Dublin",
+            "required": false
+        },
+        "name": "City of Dublin Orthoimagery (2023)",
+        "icon": "https://dublinohiousa.gov/alpha/wp-content/uploads/2020/12/cod-1.png",
+        "url": "https://tiles.arcgis.com/tiles/NqY8dnPSEdMJhuRw/arcgis/rest/services/Dublin_Aerials_2023/MapServer/tile/{zoom}/{y}/{x}",
+        "max_zoom": 21,
+        "license_url": "https://gis1.oit.ohio.gov/OGRIPWeb/WebContent/OSIP/OSIP%20III%20RFP%200A1177.pdf#page=26",
+        "country_code": "US",
+        "type": "tms",
+        "start_date": "2023",
+        "end_date": "2023",
+        "description": "Spring 2023 orthoimagery for the City of Dublin in the State of Ohio",
+        "category": "photo",
+        "valid-georeference": true,
+        "privacy_policy_url": "https://www.esri.com/en-us/privacy/overview"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -83.2804923760416,
+                    40.0428509957606
+                ],
+                [
+                    -83.08062089757149,
+                    40.0428509957606
+                ],
+                [
+                    -83.08062089757149,
+                    40.20173110149736
+                ],
+                [
+                    -83.2804923760416,
+                    40.20173110149736
+                ],
+                [
+                    -83.2804923760416,
+                    40.0428509957606
+                ]
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
The City of Dublin's 2023 imagery was captured under OSIP III (as listed on [OGRIP's download portal](https://gis1.oit.ohio.gov/geodatadownload/)), which is in the public domain.