### PR TITLE
Fix license issue

### DIFF
--- a/sources/europe/de/BY_Label.geojson
+++ b/sources/europe/de/BY_Label.geojson
@@ -14,7 +14,7 @@
             "url": "https://www.ldbv.bayern.de/",
             "required": true
         },
-        "max_zoom": 22,
+        "max_zoom": 17,
         "min_zoom": 7,
         "privacy_policy_url": "https://www.ldbv.bayern.de/datenschutz.html"
     },


### PR DESCRIPTION
Fixes #2456

From min_zoom=7 to 17 the images are CC-BY 4.0. From 18 to 22 the image changes to a CC BY ND 4.0 image.

From ( CC BY 4.0 )
https://geodaten.bayern.de/opengeodata/OpenDataDetail.html?pn=dok

To ( CC BY-ND 4.0 )
https://geodaten.bayern.de/opengeodata/OpenDataDetail.html?pn=parzellarkarte