### PR TITLE
Update MinnesotaCompositeImageService.geojson - Remove unavailable projection EPSG:3857

### DIFF
--- a/sources/north-america/us/mn/MinnesotaCompositeImageService.geojson
+++ b/sources/north-america/us/mn/MinnesotaCompositeImageService.geojson
@@ -805,7 +805,6 @@
             "url": "https://www.mngeo.state.mn.us/chouse/wms/composite_image.html"
         },
         "available_projections": [
-            "EPSG:3857",
             "EPSG:26915"
         ],
         "country_code": "US",


### PR DESCRIPTION
Remove unavailable projection from Minnesota Composite layer, see https://github.com/openstreetmap/iD/issues/10430

It seems only the originally listed projection for NAD 83 is available at the server for this and similar resources.
( in particular I looked at
https://resources.gisdata.mn.gov/pub/gdrs/data/pub/us_mn_state_metc/base_metro_orthos_2020/metadata/metadata.html
)