### PR TITLE
Slippy map Ny-Ålesund tiles for iD

### DIFF
--- a/sources/europe/no/NPI_Svalbard_satellite_tiled.geojson
+++ b/sources/europe/no/NPI_Svalbard_satellite_tiled.geojson
@@ -1,0 +1,55 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "id": "npi-svalbard-landsat-tiled",
+          "name": "NPI Svalbard satellite (tiled)",
+          "type": "tms",
+          "url": "https://zabop.github.io/svalbard-xyz/tiles/{z}/{x}/{y}.jpg",
+          "country_code": "NO",
+          "available_projections": [
+            "EPSG:25833"
+          ],
+          "attribution": {
+            "url": "https://geodata.npolar.no/",
+            "text": "© Norwegian Polar Institute / USGS Landsat | loaded as tiles"
+          },
+          "icon": "https://www.npolar.no/npcms/export/sites/np/images/logos/NPI-logo-eng.png",
+          "min_zoom": 13,
+          "max_zoom": 18,
+          "license_url": "https://lists.nuug.no/pipermail/kart/2018-February/006371.html",
+          "description": "Satellite imagery for Svalbard from the Norwegian Polar Institute/USGS Landsat",
+          "category": "photo"
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                11.953125,
+                78.92927320597397
+              ],
+              [
+                11.953125,
+                78.92083162470739
+              ],
+              [
+                11.90917968749994,
+                78.92083162470739
+              ],
+              [
+                11.90917968749994,
+                78.92927320597397
+              ],
+              [
+                11.953125,
+                78.92927320597397
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  }

--- a/sources/europe/no/NPI_Svalbard_satellite_tiled.geojson
+++ b/sources/europe/no/NPI_Svalbard_satellite_tiled.geojson
@@ -1,55 +1,49 @@
 {
-    "type": "FeatureCollection",
-    "features": [
-      {
-        "type": "Feature",
-        "properties": {
-          "id": "npi-svalbard-landsat-tiled",
-          "name": "NPI Svalbard satellite (tiled)",
-          "type": "tms",
-          "url": "https://zabop.github.io/svalbard-xyz/tiles/{z}/{x}/{y}.jpg",
-          "country_code": "NO",
-          "available_projections": [
+    "type": "Feature",
+    "properties": {
+        "id": "npi-svalbard-landsat-tiled",
+        "name": "NPI Svalbard satellite (tiled)",
+        "type": "tms",
+        "url": "https://zabop.github.io/svalbard-xyz/tiles/{z}/{x}/{y}.jpg",
+        "country_code": "NO",
+        "available_projections": [
             "EPSG:25833"
-          ],
-          "attribution": {
+        ],
+        "attribution": {
             "url": "https://geodata.npolar.no/",
             "text": "© Norwegian Polar Institute / USGS Landsat | loaded as tiles"
-          },
-          "icon": "https://www.npolar.no/npcms/export/sites/np/images/logos/NPI-logo-eng.png",
-          "min_zoom": 13,
-          "max_zoom": 18,
-          "license_url": "https://lists.nuug.no/pipermail/kart/2018-February/006371.html",
-          "description": "Satellite imagery for Svalbard from the Norwegian Polar Institute/USGS Landsat",
-          "category": "photo"
         },
-        "geometry": {
-          "type": "Polygon",
-          "coordinates": [
+        "icon": "https://www.npolar.no/npcms/export/sites/np/images/logos/NPI-logo-eng.png",
+        "min_zoom": 13,
+        "max_zoom": 18,
+        "license_url": "https://lists.nuug.no/pipermail/kart/2018-February/006371.html",
+        "description": "Satellite imagery for Svalbard from the Norwegian Polar Institute/USGS Landsat",
+        "category": "photo"
+    },      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
             [
-              [
-                11.953125,
-                78.92927320597397
-              ],
-              [
-                11.953125,
-                78.92083162470739
-              ],
-              [
-                11.90917968749994,
-                78.92083162470739
-              ],
-              [
-                11.90917968749994,
-                78.92927320597397
-              ],
-              [
-                11.953125,
-                78.92927320597397
-              ]
+              11.953125,
+              78.929273205973971
+            ],
+            [
+              11.953125,
+              78.92083162470739
+            ],
+            [
+              11.90917968749994,
+              78.92083162470739
+            ],
+            [
+              11.90917968749994,
+              78.929273205973971
+            ],
+            [
+              11.953125,
+              78.929273205973971
             ]
           ]
-        }
+        ]
       }
-    ]
-  }
+}


### PR DESCRIPTION
Some Svalbard layers are available from WMTS endpoints, but they do not support slippy map tiling. Hence, they are unavailable in iD. This commit aims to address this issue for one a small area ([Ny-Ålesund](https://www.openstreetmap.org/node/274786503#map=19/78.925530/11.929166)) of [one such layer](https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/no/NPISvalbardsatellite.geojson).

The tileset I am proposing to include is available using this endpoint: [https://zabop.github.io/svalbard-xyz/tiles/{z}/{x}/{y}.jpg](https://zabop.github.io/svalbard-xyz/tiles/%7Bz%7D/%7Bx%7D/%7By%7D.jpg). I created the tiles using QGIS and the QTiles plugin. The area I chose to tile is the area covered by webmercator tile [13/4367/1053](https://lp-tools.toolforge.org/misc/bbox.html?sw=78.92083162470739,11.953125000000016&ne=78.92927320597397,11.90917968749994). Deepest zoom level: 18.

The GeoJSON added in this PR is based on [this GeoJSON](https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/no/NPISvalbardsatellite.geojson). Unfortunately, `license_url` and the `icon` URLs do not work anymore. I aim to find up to date URLs for these two fields. I hope that once I have a proper `license_url`, it'll make it clear that it is allowed to retile the imagery from the [original WMTS](https://geodata.npolar.no/arcgis/rest/services/Basisdata/NP_Ortofoto_Svalbard_WMTS_25833/MapServer/WMTS/) before using it for OSM edits.

Once (if?) this works, and Svalbard has a new imagery layer available in iD, I aim to expand the tiled area and come up with proper infrastructure to serve the tiles. Using [GitHub pages](https://github.com/zabop/svalbard-xyz/tree/main) to do so is not ideal, but since the tiled area is so small, I think it'll do as a first step towards something greater.