### PR TITLE
Berlin2024: Fix missing `max_zoom`

### DIFF
--- a/sources/europe/de/Berlinaerialphotograph2024.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2024.geojson
@@ -15,7 +15,8 @@
             "required": true
         },
         "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf",
-        "privacy_policy_url": "https://codefor.de/datenschutz/"
+        "privacy_policy_url": "https://codefor.de/datenschutz/",
+        "max_zoom": 20
     },
     "geometry": {
         "type": "Polygon",


### PR DESCRIPTION
Right now the images disappear when zoomed in too far.
https://www.openstreetmap.org/edit?node=599873093#map=20/52.4714604/13.4496780

We have this setting for [2022](https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/de/Berlinaerialphotograph2022.geojson?short_path=7b50115), [2023](https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/de/Berlinaerialphotograph2023.geojson?short_path=61f40d5)

No idea why I did not add it to 2024…