### PR TITLE
Fix geoscribble wms url

### DIFF
--- a/sources/world/GeoScribbles.geojson
+++ b/sources/world/GeoScribbles.geojson
@@ -21,7 +21,7 @@
         "transparent": true,
         "category": "other",
         "valid-georeference": true,
-        "url": "https://geoscribble.osmz.ru/?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=latest&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://geoscribble.osmz.ru/wms?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=latest&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "license_url": "https://wiki.openstreetmap.org/wiki/GeoScribble#License",
         "privacy_policy_url": false
     },


### PR DESCRIPTION
I have made a stupid mistake, because of which the GeoScribble layer is currently not usable in iD. Please merge this before the next iD release :)