### PR TITLE
Make Jan Mayen topo available in iD

### DIFF
--- a/sources/europe/no/NPIJanMayentopo.geojson
+++ b/sources/europe/no/NPIJanMayentopo.geojson
@@ -4,7 +4,7 @@
         "id": "NPI-JanMayen-topo",
         "name": "NPI Jan Mayen topo",
         "type": "tms",
-        "url": "https://geodata.npolar.no/arcgis/rest/services/Basisdata/NP_Basiskart_JanMayen_WMTS_3857/MapServer/tile/{z}/{y}/{x}",
+        "url": "https://geodata.npolar.no/arcgis/rest/services/Basisdata/NP_Basiskart_JanMayen_WMTS_3857/MapServer/tile/{zoom}/{y}/{x}",
         "country_code": "NO",
         "attribution": {
             "url": "https://geodata.npolar.no/",

--- a/sources/europe/no/NPIJanMayentopo.geojson
+++ b/sources/europe/no/NPIJanMayentopo.geojson
@@ -4,18 +4,17 @@
         "id": "NPI-JanMayen-topo",
         "name": "NPI Jan Mayen topo",
         "type": "wmts",
-        "url": "https://geodata.npolar.no/arcgis/rest/services/Basisdata/NP_Basiskart_JanMayen_WMTS_25829/MapServer/WMTS/",
+        "url": "https://geodata.npolar.no/arcgis/rest/services/Basisdata/NP_Basiskart_JanMayen_WMTS_3857/MapServer/WMTS/",
         "country_code": "NO",
-        "available_projections": [
-            "EPSG:25829"
-        ],
+        "available_projections": ["EPSG:3857"],
         "attribution": {
             "url": "https://geodata.npolar.no/",
             "text": "© Norwegian Polar Institute"
         },
-        "icon": "https://www.npolar.no/npcms/export/sites/np/images/logos/NPI-logo-eng.png",
-        "max_zoom": 13,
-        "license_url": "https://lists.nuug.no/pipermail/kart/2018-February/006371.html",
+        "icon": "https://www.npolar.no/wp-content/uploads/2022/05/NP-logo-skjerm.png",
+        "max_zoom": 16,
+        "license_url": "https://web.archive.org/web/20240114010212/https://lists.nuug.no/pipermail/kart/2018-February/006371.html",
+        "privacy_policy_url": "https://www.npolar.no/en/privacy-policy/",
         "description": "Topographic map for Jan Mayen from the Norwegian Polar Institute",
         "category": "map"
     },

--- a/sources/europe/no/NPIJanMayentopo.geojson
+++ b/sources/europe/no/NPIJanMayentopo.geojson
@@ -6,7 +6,6 @@
         "type": "tms",
         "url": "https://geodata.npolar.no/arcgis/rest/services/Basisdata/NP_Basiskart_JanMayen_WMTS_3857/MapServer/tile/{z}/{y}/{x}",
         "country_code": "NO",
-        "available_projections": ["EPSG:3857"],
         "attribution": {
             "url": "https://geodata.npolar.no/",
             "text": "© Norwegian Polar Institute"

--- a/sources/europe/no/NPIJanMayentopo.geojson
+++ b/sources/europe/no/NPIJanMayentopo.geojson
@@ -3,8 +3,8 @@
     "properties": {
         "id": "NPI-JanMayen-topo",
         "name": "NPI Jan Mayen topo",
-        "type": "wmts",
-        "url": "https://geodata.npolar.no/arcgis/rest/services/Basisdata/NP_Basiskart_JanMayen_WMTS_3857/MapServer/WMTS/",
+        "type": "tms",
+        "url": "https://geodata.npolar.no/arcgis/rest/services/Basisdata/NP_Basiskart_JanMayen_WMTS_3857/MapServer/tile/{z}/{y}/{x}",
         "country_code": "NO",
         "available_projections": ["EPSG:3857"],
         "attribution": {


### PR DESCRIPTION
Jan Mayen now has a topography WMTS available in EPSG:3857. I found the service [here](https://geodata.npolar.no/). Previously, the EPSG:25829 version was added, which iD couldn't use. I hope this update will benefit iD users (while not effecting anyone adversely, as JOSM and other tools can use the new version as well).

This PR is modelled on #2473.