### PR TITLE
add LINZ 2023 Auckland imagery

### DIFF
--- a/sources/oceania/nz/LINZ-NZ-Auckland-2023.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Auckland-2023.geojson
@@ -1,0 +1,50 @@
+{
+    "type": "Feature",
+    "properties": {
+        "attribution": {
+            "url": "https://www.linz.govt.nz/data/licensing-and-using-data/attributing-elevation-or-aerial-imagery-data",
+            "text": "Sourced from LINZ CC-BY 4.0",
+            "required": true
+        },
+        "license_url": "https://wiki.openstreetmap.org/wiki/Contributors#New_Zealand",
+        "name": "LINZ Auckland 2023",
+        "privacy_policy_url": "https://www.linz.govt.nz/privacy",
+        "category": "photo",
+        "url": "https://basemaps.linz.govt.nz/v1/tiles/auckland-central-2023-0.06m/EPSG:3857/{zoom}/{x}/{y}.jpg?api=d01egend5f8dv4zcbfj6z2t7rs3",
+        "max_zoom": 21,
+        "country_code": "NZ",
+        "type": "tms",
+        "id": "LINZ_Auckland_2023",
+        "icon": "https://basemaps.linz.govt.nz/assets/logo-linz.svg",
+        "start_date": "2023-03-19",
+        "end_date": "2023-05-10",
+        "best": true
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [174.74766203520983, -36.823985105786136],
+                [174.7007945547432, -36.88987186161511],
+                [174.70716027166952, -36.91694813065771],
+                [174.75757970907574, -36.947599921495474],
+                [174.762696348762, -36.96514165063819],
+                [174.75295822806663, -36.978723822277665],
+                [174.76913341159496, -37.02459516976469],
+                [174.8199697026791, -37.01220736165776],
+                [174.8105616877703, -36.98966691543545],
+                [174.82525139525967, -36.97648227163624],
+                [174.83152340519842, -36.963690984212576],
+                [174.8323486696641, -36.93955311525599],
+                [174.81567832745844, -36.93849773336901],
+                [174.81389413292385, -36.91125549325793],
+                [174.78121366008406, -36.90188499127763],
+                [174.78732061712861, -36.870597659829485],
+                [174.7947479368463, -36.865793858648],
+                [174.79573825420442, -36.856021577673516],
+                [174.78831087401346, -36.83237805548592],
+                [174.74766203520983, -36.823985105786136]
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
This layer is useful but won't be included in the main LINZ Basemap[^1], so I've created a separate layer for it. No changes to the `Auckland 2016` layer (for now)

[^1]: https://maptimeoceania.slack.com/archives/CG2H76ENT/p1726566021694529?thread_ts=1686019181.549189&cid=CG2H76ENT