### PR TITLE
Switch to PNGs for FI background maps

### DIFF
--- a/sources/europe/fi/mml-orto.geojson
+++ b/sources/europe/fi/mml-orto.geojson
@@ -6,7 +6,7 @@
         "id": "mml-orto",
         "country_code": "FI",
         "description": "Ortophotos from the National Land Survey of Finland",
-        "url": "https://tiles.kartat.kapsi.fi/ortokuva/{zoom}/{x}/{y}.jpg",
+        "url": "https://tiles.kartat.kapsi.fi/ortokuva/{zoom}/{x}/{y}.png",
         "icon": "https://www.maanmittauslaitos.fi/apple-touch-icon.png",
         "min_zoom": 2,
         "max_zoom": 19,

--- a/sources/europe/fi/mml-tausta.geojson
+++ b/sources/europe/fi/mml-tausta.geojson
@@ -6,7 +6,7 @@
         "id": "mml-tausta",
         "country_code": "FI",
         "description": "Background map from the National Land Survey of Finland",
-        "url": "https://tiles.kartat.kapsi.fi/taustakartta/{zoom}/{x}/{y}.jpg",
+        "url": "https://tiles.kartat.kapsi.fi/taustakartta/{zoom}/{x}/{y}.png",
         "icon": "https://www.maanmittauslaitos.fi/apple-touch-icon.png",
         "min_zoom": 2,
         "max_zoom": 19,

--- a/sources/europe/fi/mml-topo.geojson
+++ b/sources/europe/fi/mml-topo.geojson
@@ -6,7 +6,7 @@
         "id": "mml-topo",
         "country_code": "FI",
         "description": "Topographic map from the National Land Survey of Finland",
-        "url": "https://tiles.kartat.kapsi.fi/peruskartta/{zoom}/{x}/{y}.jpg",
+        "url": "https://tiles.kartat.kapsi.fi/peruskartta/{zoom}/{x}/{y}.png",
         "icon": "https://www.maanmittauslaitos.fi/apple-touch-icon.png",
         "min_zoom": 2,
         "max_zoom": 19,


### PR DESCRIPTION
Infrastructure related to Kapsi background maps have been upgraded and JPG support is still lacking.