### PR TITLE
Drop best flag for two layers from Portugal

### DIFF
--- a/sources/europe/pt/Orthophotos_mainland-25cm-2018.geojson
+++ b/sources/europe/pt/Orthophotos_mainland-25cm-2018.geojson
@@ -15,7 +15,6 @@
             "EPSG:4258",
             "EPSG:4326"
         ],
-        "best": true,
         "attribution": {
             "text": "Informação geográfica cedida pela Direção-Geral do Território",
             "url": "https://snig.dgterritorio.gov.pt/rndg/srv/por/catalog.search#/metadata/daf5479d-29c8-4e0c-b7b8-0e1791891186",

--- a/sources/europe/pt/Orthophotos_north-25cm-2021.geojson
+++ b/sources/europe/pt/Orthophotos_north-25cm-2021.geojson
@@ -15,7 +15,6 @@
             "EPSG:4258",
             "EPSG:4326"
         ],
-        "best": true,
         "attribution": {
             "text": "Informação geográfica cedida pela Direção-Geral do Território",
             "url": "https://snig.dgterritorio.gov.pt/rndg/srv/por/catalog.search#/metadata/d70dd232-aaee-4e6b-a804-5a0b70c537be",


### PR DESCRIPTION
Since #2500 now spans the whole continental part of Portugal, I'm dropping the "best" flag from two older orthophotos (2018 and 2021).

Without the PR, in the northern part of Portugal, there are 3 "best" layers.

Now it only favors 2023 imagery.