### PR TITLE
Adjust max_zoom of BDOrtho IGN

### DIFF
--- a/sources/europe/fr/BDOrthoIGN.geojson
+++ b/sources/europe/fr/BDOrthoIGN.geojson
@@ -11,7 +11,7 @@
         "start_date": "2021",
         "end_date": "2023",
         "min_zoom": 2,
-        "max_zoom": 21,
+        "max_zoom": 19,
         "country_code": "FR",
         "attribution": {
             "text": "BDOrtho IGN",


### PR DESCRIPTION
This service doesn't return tiles at zoom level 20 and 21. I checked this in QGIS:

![image](https://github.com/user-attachments/assets/c9d5c868-eca7-4379-ab82-63dcf250037e)

and using some of the URLs below.

**Zoom level 19 returns a JPEG:**
https://data.geopf.fr/tms/1.0.0/ORTHOIMAGERY.ORTHOPHOTOS/19/267940/187278.jpeg
![image](https://github.com/user-attachments/assets/9b3b17eb-2fb9-4e42-8c5c-724b8e02a26a)
([Location of 19/267940/187278](https://lp-tools.toolforge.org/misc/bbox.html?sw=45.63756719669649,3.980484008789002&ne=45.63804729356088,3.979797363281236) - zoom out a bit to see context)

**Zoom level 20 and 21 return an XML error message:**
https://data.geopf.fr/tms/1.0.0/ORTHOIMAGERY.ORTHOPHOTOS/20/535880/374556.jpeg
([location of 20/535880/374556](https://lp-tools.toolforge.org/misc/bbox.html?sw=45.6378072456429,3.9801406860351194&ne=45.63804729356088,3.979797363281236) - zoom out a bit to see context)
https://data.geopf.fr/tms/1.0.0/ORTHOIMAGERY.ORTHOPHOTOS/21/1071760/749112.jpeg
([location of 21/1071760/749112](https://lp-tools.toolforge.org/misc/bbox.html?sw=45.63792726973045,3.979969024658178&ne=45.63804729356088,3.979797363281236) - zoom out a bit to see context)

This commit sets `max_zoom` at 19, solving this issue.
