### PR TITLE
Detailed topo map of some Svalbard settlements in iD

### DIFF
--- a/sources/europe/no/NPISvalbarddetailedtopo.geojson
+++ b/sources/europe/no/NPISvalbarddetailedtopo.geojson
@@ -3,19 +3,17 @@
     "properties": {
         "id": "npi-svalbard-fkb",
         "name": "NPI Svalbard detailed topo",
-        "type": "wmts",
-        "url": "https://geodata.npolar.no/arcgis/rest/services/Basisdata/FKB_Svalbard_WMTS_25833/MapServer/WMTS/",
+        "type": "tms",
+        "url": "https://geodata.npolar.no/arcgis/rest/services/Basisdata/FKB_Svalbard_WMTS_3857/MapServer/WMTS/tile/1.0.0/Basisdata_FKB_Svalbard_WMTS_3857/default/default028mm/{zoom}/{y}/{x}",
         "country_code": "NO",
-        "available_projections": [
-            "EPSG:25833"
-        ],
         "attribution": {
             "url": "https://geodata.npolar.no/",
             "text": "© Norwegian Polar Institute"
         },
-        "icon": "https://www.npolar.no/npcms/export/sites/np/images/logos/NPI-logo-eng.png",
+        "icon": "https://www.npolar.no/wp-content/uploads/2022/05/NP-logo-skjerm.png",
         "max_zoom": 17,
-        "license_url": "https://lists.nuug.no/pipermail/kart/2018-February/006371.html",
+        "license_url": "https://web.archive.org/web/20240114010212/https://lists.nuug.no/pipermail/kart/2018-February/006371.html",
+        "privacy_policy_url": "https://www.npolar.no/en/privacy-policy/",
         "description": "Detailed topographic map for Longyearbyen, Barentsburg and Ny-Ålesund from the Norwegian Polar Institute",
         "category": "map"
     },


### PR DESCRIPTION
[The source](https://geodata.npolar.no/) for this layer offers webmercator tiles ([WMTS endpoint](https://geodata.npolar.no/arcgis/rest/services/Basisdata/FKB_Svalbard_WMTS_3857/MapServer/WMTS/1.0.0/WMTSCapabilities.xml), [online viewer](https://geodata.npolar.no/arcgis/rest/services/Basisdata/FKB_Svalbard_WMTS_3857/MapServer?f=jsapi).) Hence, we can make them available in iD.
I used #2473 as a model.