### PR TITLE
Fix URL structure to open iD using requested imagery

### DIFF
--- a/site/site.js
+++ b/site/site.js
@@ -44,7 +44,7 @@ function idURL(d, e) {
         editor: 'id',
         background: 'custom:' + d.properties.url
     };
-    return 'https://www.openstreetmap.org/edit?' + (new URLSearchParams(params)).toString() + position;
+    return 'https://www.openstreetmap.org/edit?' + position + (new URLSearchParams(params)).toString();
 }
 
 


### PR DESCRIPTION
Users cannot easily go from https://osmlab.github.io/editor-layer-index to editing OSM in iD using a custom source, as the link pointing to iD is malformed.

Illustration:

https://github.com/user-attachments/assets/8c70ae15-d381-4bc5-aee0-fc35bd63fdfc

In the above example, instead of [NPI Jan Mayen topo](https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/no/NPIJanMayentopo.geojson), users are presented with the default Bing Maps Aerial imagery. This commit fixes this issue by adjusting the structure of the URL pointing to iD. Illustration:

https://github.com/user-attachments/assets/ce5c8bc4-da3f-49ef-979b-e39212fdec30

Now when we click the iD link next to a particular layer, we get that layer in iD.