### PR TITLE
Make latest FÖMI orto the default in Hungary

### DIFF
--- a/sources/europe/hu/Hungary-FOMI-2011-2014.geojson
+++ b/sources/europe/hu/Hungary-FOMI-2011-2014.geojson
@@ -11,6 +11,7 @@
         },
         "start_date": "2011-08-11",
         "end_date": "2014-06-10",
+        "best": true,
         "url": "https://orto1.tile.openstreetmap.hu/fomi2011-2014/{zoom}/{x}/{y}.webp",
         "min_zoom": 8,
         "max_zoom": 18,


### PR DESCRIPTION
The latest FÖMI layer is _always_ 10 years behind, but government-based and still the best source for mapping and alignment. This should help new mappers to draw anything accurately.