### PR TITLE
Revert "Drop best flag for two layers from Portugal"

### DIFF
--- a/sources/europe/pt/Orthophotos_mainland-25cm-2018.geojson
+++ b/sources/europe/pt/Orthophotos_mainland-25cm-2018.geojson
@@ -15,6 +15,7 @@
             "EPSG:4258",
             "EPSG:4326"
         ],
+        "best": true,
         "attribution": {
             "text": "Informação geográfica cedida pela Direção-Geral do Território",
             "url": "https://snig.dgterritorio.gov.pt/rndg/srv/por/catalog.search#/metadata/daf5479d-29c8-4e0c-b7b8-0e1791891186",

--- a/sources/europe/pt/Orthophotos_north-25cm-2021.geojson
+++ b/sources/europe/pt/Orthophotos_north-25cm-2021.geojson
@@ -15,6 +15,7 @@
             "EPSG:4258",
             "EPSG:4326"
         ],
+        "best": true,
         "attribution": {
             "text": "Informação geográfica cedida pela Direção-Geral do Território",
             "url": "https://snig.dgterritorio.gov.pt/rndg/srv/por/catalog.search#/metadata/d70dd232-aaee-4e6b-a804-5a0b70c537be",

--- a/sources/europe/pt/OrtoSat-30cm-2023.geojson
+++ b/sources/europe/pt/OrtoSat-30cm-2023.geojson
@@ -15,7 +15,6 @@
             "EPSG:4258",
             "EPSG:4326"
         ],
-        "best": true,
         "attribution": {
             "text": "Informação geográfica cedida pela Direção-Geral do Território",
             "url": "https://snig.dgterritorio.gov.pt/rndg/srv/por/catalog.search#/metadata/b2a1ca02-779b-4189-b895-85d10fff610f",


### PR DESCRIPTION
As asked by Portuguese community, in fact 2023 layer is worse than 2021 and 2018: lower resolution and with a quite big offset. It reverts osmlab/editor-layer-index#2501

And for further information: 2021 only spans the northern part of the country, so that's why Portugal has 2 "best" layers.