### PR TITLE
Update PAgis_Ortho_2021.geojson

### DIFF
--- a/sources/north-america/us/ar/PAgis_Ortho_2021.geojson
+++ b/sources/north-america/us/ar/PAgis_Ortho_2021.geojson
@@ -10,7 +10,7 @@
         "name": "PAgis 2021 Orthophotography",
         "icon": "http://www.pagis.org/wp-content/uploads/2019/10/Home2.gif",
         "url": "https://www.pagis.org/arcgis/rest/services/MAPS/AerialPhotos2021/MapServer/export?f=image&format=jpg&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&foo={proj}",
-        "max_zoom": 19,
+        "max_zoom": 22,
         "license_url": "https://wiki.openstreetmap.org/wiki/Arkansas/PAgis",
         "country_code": "US",
         "type": "wms",


### PR DESCRIPTION
Updated max_zoom level from 19 to 22.  Using JOSM I found that this map layer will zoom up to level 22 providing much more detail than the currently configured level 19.