### PR TITLE
add CI script to automatically update a git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  schedule:
+    - cron: '0 7 * * 2'
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      checks: read
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check that the CI is passing
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const checks = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: '${{github.event.repository.default_branch}}',
+            });
+
+            const isSuccessful = checks.data.check_runs
+              .filter((run) => run.name !== process.env.GITHUB_JOB)
+              .every((run) => run.conclusion === 'success');
+
+            if (!isSuccessful) {
+              core.error('Not creating a release because the CI is failing.');
+              process.exit(1);
+            }
+
+      - name: Update git tag
+        uses: EndBug/latest-tag@latest
+        with:
+          ref: latest


### PR DESCRIPTION
Currently, anyone who wants to consume ELI's data has to fetch the data directly from the main git branch ([via github pages](https://osmlab.github.io/editor-layer-index/imagery.geojson) or [github](https://github.com/osmlab/editor-layer-index/raw/gh-pages/imagery.geojson)), since this repository does not do versioning. 

This can be risky, and cause confusion when the CI is failing on the main branch (like what happened last week).

To give data consumers more certainty, this PR introduces a weekly cronjob which moves [a git tag](https://github.com/k-yle/editor-layer-index/tags) to the latest commit on the main branch, but only if the CI is passing.

This gives people the flexibility to consume data directly from the main branch, or from this git tag if you want to be more safe.

Tested in a fork of this repository ([logs here](https://github.com/k-yle/editor-layer-index/actions/runs/11311561456/job/31457943990))