### PR TITLE
Add grid voltages & owners overlay for Norway

### DIFF
--- a/sources/europe/no/gridVoltagesOwnersOverlay.geojson
+++ b/sources/europe/no/gridVoltagesOwnersOverlay.geojson
@@ -1,0 +1,55 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "grid-voltages-owners",
+        "name": "Electricity grid voltages & owners overlay",
+        "type": "tms",
+        "url": "https://api.mapbox.com/styles/v1/zabop/cm2rk5cgu00b701pmahzcegli/tiles/{zoom}/{x}/{y}?access_token=pk.eyJ1IjoiemFib3AiLCJhIjoiY2xrOHAyZGdjMDFsaDNlbWIyODhhc3VoZSJ9.ldiQmCyhLWNt1-U2jDI3PQ",
+        "overlay": true,
+        "country_code": "NO",
+        "attribution": {
+            "text": "© NVE",
+            "url": "https://www.nve.no/karttjenester/"
+        },
+        "icon": "https://kommunikasjon.ntb.no/data/images/00525/e8799776-4b69-4ec4-906d-46285ccb3dbe-w_300_h_100.png",
+        "max_zoom": 22,
+        "min_zoom": 7,
+        "license_url": "https://web.archive.org/web/20240114010212/https://lists.nuug.no/pipermail/kart/2017-December/006312.html",
+        "privacy_policy_url": "https://www.nve.no/nves-personvernerklaering/",
+        "description": "Power lines, their voltages and their owners.",
+        "category": "other"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [31.904253, 70.4368136],
+                [28.4765186, 71.3289643],
+                [23.6865015, 71.2514263],
+                [16.8090601, 70.0730823],
+                [11.1620655, 67.5253903],
+                [9.975542, 64.811576],
+                [4.2187061, 62.1449966],
+                [4.3725367, 59.1871966],
+                [6.1743055, 57.8915032],
+                [7.932118, 57.7393554],
+                [10.777577, 58.8649103],
+                [11.7224012, 58.762509],
+                [12.722157, 60.1141506],
+                [13.0517469, 61.3493518],
+                [12.5243921, 63.6169922],
+                [14.2382593, 63.9856094],
+                [15.1171656, 65.9016624],
+                [18.6987085, 68.3749083],
+                [20.0610132, 68.2612583],
+                [21.0058375, 68.7841518],
+                [25.2465601, 68.3506025],
+                [26.9384546, 69.8472011],
+                [28.7621851, 69.6112133],
+                [28.5864039, 68.8556004],
+                [31.069314, 69.5191547],
+                [31.904253, 70.4368136]
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
This overlay layer enables visualisation of locations, voltages and owners of electricity gridlines in Norway. This is how it looks like as a background:
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/06d5e8dd-330d-4d76-b5dd-131cb106b525">
More zoomed in view:
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/a25d26f0-bfc8-4a33-b312-a4cced69ec0f">
The lines are colored as a function of their voltage (low: blue, high: red). The lines have labels, which includes voltage and owner info. I hope this will help mapping [power=line](https://wiki.openstreetmap.org/wiki/Tag:power%3Dline)s and [power=minor_line](https://wiki.openstreetmap.org/wiki/Tag:power%3Dminor_line)s [voltage](https://wiki.openstreetmap.org/wiki/Key:voltage) and [owner](https://wiki.openstreetmap.org/wiki/Key:owner) attributes.

I would like to have this source added as an overlay. It is similar to [NVEElectricityNetworkoverlay.geojson](https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/no/NVEElectricityNetworkoverlay.geojson), which points to a source maintained by state authorities. This new overlay points to a tileset I created using Mapbox Studio, using data I accessed though [the authority's website](https://kartkatalog.nve.no/nedlasting) (and processed locally, see [this notebook](https://github.com/zabop/NORgrid/blob/main/dataPrep.ipynb)). The old overlay also includes data on [power=pole](https://wiki.openstreetmap.org/wiki/Tag:power%3Dpole)s and [power=tower](https://wiki.openstreetmap.org/wiki/Tag:power%3Dtower)s as yellow squares:
<img width="848" alt="image" src="https://github.com/user-attachments/assets/19655480-3e5a-4fb0-b5dc-0c42a13b9236">
and [power=substation](https://wiki.openstreetmap.org/wiki/Tag:power%3Dsubstation)s as red squares. 

I believe my new overlay is a useful addition to the previously existing one, but it does not void the need for the previously existing one. Hence, I am proposing to add it as a new overlay, and not as a replacement for the previous one.


