### PR TITLE
Adjust maxzoom to avoid loading empty tiles

### DIFF
--- a/sources/world/OpenAerialMap-Mosaic.geojson
+++ b/sources/world/OpenAerialMap-Mosaic.geojson
@@ -11,7 +11,7 @@
         "license_url": "http://openaerialmap.org/legal/",
         "privacy_policy_url": "https://www.kontur.io/privacy-policy/",
         "min_zoom": 1,
-        "max_zoom": 31,
+        "max_zoom": 19,
         "name": "OpenAerialMap Mosaic, by Kontur.io",
         "overlay": false,
         "type": "tms",


### PR DESCRIPTION
At zoom level 19, the service mentioned in this source does return useful tiles, for example https://apps.kontur.io/raster-tiler/oam/mosaic/19/315735/264021.png:
![](https://apps.kontur.io/raster-tiler/oam/mosaic/19/315735/264021.png)
However, at zoom level 20, the tiles returned are empty. https://apps.kontur.io/raster-tiler/oam/mosaic/20/631470/528042.png:
![](https://apps.kontur.io/raster-tiler/oam/mosaic/20/631470/528042.png)
I hope limiting maxzoom to 19 will avoid situations when seemingly everything is ok, but the iD canvas is empty:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/52f1a912-0ec3-424f-989a-bb8702e76163">

