### PR TITLE
consider {wkid} as a synonym for {proj} in CI

### DIFF
--- a/scripts/check.py
+++ b/scripts/check.py
@@ -156,7 +156,8 @@ for filename in arguments.path:
             ):
                 logger.warning(f"WMTS source supports EPSG:3857, could this be tms? {filename}")
 
-        missingparams = [x for x in params if x not in source["properties"]["url"].replace("{-y}", "{y}")]
+        source_url_excl_synonyms = source["properties"]["url"].replace("{-y}", "{y}").replace("{wkid}", "{proj}")
+        missingparams = [x for x in params if x not in source_url_excl_synonyms]
         if missingparams:
             raise ValidationError("Missing parameter in {}: {}".format(filename, missingparams))
 


### PR DESCRIPTION
Follow-up for #1976/#1975: If `{wkid}` is a documented alternative to `{proj}` for WMS service URLs, the CI checks should not complain about it.

This will allow to get rid of the hacky workarounds like f39630a, [`…&foo={proj}`](https://github.com/search?q=repo%3Aosmlab%2Feditor-layer-index+foo%3D%7Bproj%7D&type=code) in a lot of layers.