### PR TITLE
Add Hungarian FÖMI 2015 orthophotos

### DIFF
--- a/sources/europe/hu/Hungary-FOMI-2007-2010.geojson
+++ b/sources/europe/hu/Hungary-FOMI-2007-2010.geojson
@@ -14,6 +14,7 @@
         "url": "https://e.tile.openstreetmap.hu/ortofoto-2007-2010/{zoom}/{x}/{y}.jpg",
         "max_zoom": 18,
         "license_url": "https://e.tile.openstreetmap.hu/ortofoto-2007-2010/license.txt",
+        "privacy_policy_url": "https://lechnerkozpont.hu/oldal/adatvedelem",
         "type": "tms",
         "category": "historicphoto"
     },

--- a/sources/europe/hu/Hungary-FOMI-2007-2010.geojson
+++ b/sources/europe/hu/Hungary-FOMI-2007-2010.geojson
@@ -15,7 +15,7 @@
         "max_zoom": 18,
         "license_url": "https://e.tile.openstreetmap.hu/ortofoto-2007-2010/license.txt",
         "type": "tms",
-        "category": "photo"
+        "category": "historicphoto"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/hu/Hungary-FOMI-2011-2014.geojson
+++ b/sources/europe/hu/Hungary-FOMI-2011-2014.geojson
@@ -17,7 +17,7 @@
         "license_url": "https://wiki.openstreetmap.org/wiki/Hungary/Ortofot%C3%B3k#F%C3%96MI_ortofot%C3%B3k",
         "privacy_policy_url": "https://lechnerkozpont.hu/oldal/adatvedelem",
         "type": "tms",
-        "category": "historicphoto"
+        "category": "historicphoto",
         "description": "Goverment-based leaf-covered orthophotos with 40 cm/pixel resolution for the entire country. This layer should be used as an alignment base in lack of a more accurate reference. WEBP format images, JOSM needs a webp plugin for them.",
         "i18n": true
     },

--- a/sources/europe/hu/Hungary-FOMI-2015.geojson
+++ b/sources/europe/hu/Hungary-FOMI-2015.geojson
@@ -11,7 +11,7 @@
         },
         "start_date": "2015-05-08",
         "end_date": "2015-07-10",
-        "url": "https://orto1.tile.openstreetmap.hu/fomi2015/{zoom}/{x}/{y}.webp",
+        "url": "https://orto1.tile.openstreetmap.hu/fomi_2015/{zoom}/{x}/{y}.webp",
         "min_zoom": 8,
         "max_zoom": 18,
         "license_url": "https://wiki.openstreetmap.org/wiki/Hungary/Ortofot%C3%B3k#F%C3%96MI_ortofot%C3%B3k",

--- a/sources/europe/hu/Hungary-FOMI-2015.geojson
+++ b/sources/europe/hu/Hungary-FOMI-2015.geojson
@@ -1,23 +1,23 @@
 {
     "type": "Feature",
     "properties": {
-        "name": "FÖMI orthophoto 2011–2014 (WEBP)",
-        "id": "FOMI_2011_2014",
+        "name": "FÖMI orthophoto 2015 (WEBP)",
+        "id": "FOMI_2015",
         "country_code": "HU",
         "attribution": {
             "url": "https://lechnerkozpont.hu/oldal/ortofotok-es-legifelvetelek",
             "text": "Lechner Tudásközpont",
             "required": true
         },
-        "start_date": "2011-08-11",
-        "end_date": "2014-06-10",
-        "url": "https://orto1.tile.openstreetmap.hu/fomi2011-2014/{zoom}/{x}/{y}.webp",
+        "start_date": "2015-05-08",
+        "end_date": "2015-07-10",
+        "url": "https://orto1.tile.openstreetmap.hu/fomi2015/{zoom}/{x}/{y}.webp",
         "min_zoom": 8,
         "max_zoom": 18,
         "license_url": "https://wiki.openstreetmap.org/wiki/Hungary/Ortofot%C3%B3k#F%C3%96MI_ortofot%C3%B3k",
         "privacy_policy_url": "https://lechnerkozpont.hu/oldal/adatvedelem",
         "type": "tms",
-        "category": "historicphoto"
+        "category": "photo",
         "description": "Goverment-based leaf-covered orthophotos with 40 cm/pixel resolution for the entire country. This layer should be used as an alignment base in lack of a more accurate reference. WEBP format images, JOSM needs a webp plugin for them.",
         "i18n": true
     },


### PR DESCRIPTION
Added Hungarian FÖMI 2015 leaf-off country-wide, 40 cm/px orthophotos. This layer should be used as the reference for alignment.