### PR TITLE
Update the Kanton Bern hillshade wms

### DIFF
--- a/sources/europe/ch/Kanton_Bern_dsm_hillshade_wms.geojson
+++ b/sources/europe/ch/Kanton_Bern_dsm_hillshade_wms.geojson
@@ -22,7 +22,7 @@
         "privacy_policy_url": "http://www.geo.apps.be.ch/de/rechtliches.html",
         "type": "wms",
         "category": "elevation",
-        "url": "https://www.geoservice.apps.be.ch/geoservice2/services/a42geo/a42geo_hoehenwms_d_fk/MapServer/WMSServer?LAYERS=GEODB.LDOM50CM_LORELIEF_KMGDM1&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
+        "url": "https://www.geoservice.apps.be.ch/geoservice3/services/a42geo/of_elevation01_de_ms_wms/MapServer/WMSServer?LAYERS=LDOM50CM_LORELIEF_4163&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/ch/Kanton_Bern_dtm_hillshade_wms.geojson
+++ b/sources/europe/ch/Kanton_Bern_dtm_hillshade_wms.geojson
@@ -22,7 +22,7 @@
         "privacy_policy_url": "http://www.geo.apps.be.ch/de/rechtliches.html",
         "type": "wms",
         "category": "elevation",
-        "url": "https://www.geoservice.apps.be.ch/geoservice2/services/a42geo/a42geo_hoehenwms_d_fk/MapServer/WMSServer?LAYERS=GEODB.LDTM50CM_LTRELIEF_KMGDM1&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
+        "url": "https://www.geoservice.apps.be.ch/geoservice3/services/a42geo/of_elevation01_de_ms_wms/MapServer/WMSServer?LAYERS=LDTM50CM_LTRELIEF_883&STYLES=default&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
     },
     "geometry": {
         "type": "Polygon",


### PR DESCRIPTION
Seems like the old service is no longer working. This PR updates the service and uses the new later names:

- geoservice2 => geoservice3
- a42geo_hoehenwms_d_fk => of_elevation01_de_ms_wms
- Kanton_Bern_dsm_hillshade_wms.geojson:
  - "LAYERS=GEODB.LDOM50CM_LORELIEF_KMGDM1" => "LAYERS=LDOM50CM_LORELIEF_4163"
-  Kanton_Bern_dtm_hillshade_wms.geojson:
   - "LAYERS=GEODB.LDTM50CM_LTRELIEF_KMGDM" => "LAYERS=LDTM50CM_LTRELIEF_883"
