### PR TITLE
Remove best flag from AGIS 2023

### DIFF
--- a/sources/europe/ch/KantonAargau20cm-AGIS2023.geojson
+++ b/sources/europe/ch/KantonAargau20cm-AGIS2023.geojson
@@ -17,8 +17,7 @@
         "min_zoom": 4,
         "country_code": "CH",
         "type": "tms",
-        "category": "photo",
-        "best": true
+        "category": "photo"
     },
     "geometry": {
         "type": "Polygon",


### PR DESCRIPTION
The 2024 imagery is the same as the current swisstopo imagery and does not exist as a production layer from any other source (as every three years it seems).