### PR TITLE
Remove NY Orthos layer 4, update attribution url

### DIFF
--- a/sources/north-america/us/ny/NYSDOP_Latest.geojson
+++ b/sources/north-america/us/ny/NYSDOP_Latest.geojson
@@ -1363,7 +1363,7 @@
         "attribution": {
             "required": false,
             "text": "New York State Statewide Digital Orthoimagery Program",
-            "url": "http://gis.ny.gov/gateway/mg/index.html"
+            "url": "https://gis.ny.gov/orthoimagery"
         },
         "available_projections": [
             "CRS:84",
@@ -1379,7 +1379,7 @@
         "max_zoom": 19,
         "name": "NYSDOP Latest Orthoimagery (Natural Color)",
         "type": "wms",
-        "url": "https://orthos.its.ny.gov/arcgis/services/wms/Latest/MapServer/WmsServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0,1,2,3,4&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://orthos.its.ny.gov/arcgis/services/wms/Latest/MapServer/WmsServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0,1,2,3&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "privacy_policy_url": "https://its.ny.gov/its-internet-security-and-privacy-policy",
         "category": "photo",
         "valid-georeference": true

--- a/sources/north-america/us/ny/NYSDOP_Latest_CIR.geojson
+++ b/sources/north-america/us/ny/NYSDOP_Latest_CIR.geojson
@@ -1379,7 +1379,7 @@
         "max_zoom": 19,
         "name": "NYSDOP Latest Orthoimagery (Infrared)",
         "type": "wms",
-        "url": "https://orthos.its.ny.gov/arcgis/services/wms/Latest_cir/MapServer/WmsServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0,1,2,3&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://orthos.its.ny.gov/arcgis/services/wms/Latest_cir/MapServer/WmsServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0,1,2,3,4&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "privacy_policy_url": "https://its.ny.gov/its-internet-security-and-privacy-policy",
         "category": "photo",
         "valid-georeference": true

--- a/sources/north-america/us/ny/NYSDOP_Latest_CIR.geojson
+++ b/sources/north-america/us/ny/NYSDOP_Latest_CIR.geojson
@@ -1363,7 +1363,7 @@
         "attribution": {
             "required": false,
             "text": "New York State Statewide Digital Orthoimagery Program",
-            "url": "http://gis.ny.gov/gateway/mg/index.html"
+            "url": "https://gis.ny.gov/orthoimagery"
         },
         "available_projections": [
             "CRS:84",
@@ -1379,7 +1379,7 @@
         "max_zoom": 19,
         "name": "NYSDOP Latest Orthoimagery (Infrared)",
         "type": "wms",
-        "url": "https://orthos.its.ny.gov/arcgis/services/wms/Latest_cir/MapServer/WmsServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0,1,2,3,4&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://orthos.its.ny.gov/arcgis/services/wms/Latest_cir/MapServer/WmsServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0,1,2,3&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "privacy_policy_url": "https://its.ny.gov/its-internet-security-and-privacy-policy",
         "category": "photo",
         "valid-georeference": true


### PR DESCRIPTION
- Remove layer 4 from LAYERS parameter, which is once again causing "parameter layers contains unacceptable layer names" errors in WMS requests (see https://github.com/osmlab/editor-layer-index/pull/1868/files and https://github.com/osmlab/editor-layer-index/pull/2589/files)
- Update imagery attribution url (currently a dead link)