### PR TITLE
Don't expose mapbox token

### DIFF
--- a/sources/europe/no/gridVoltagesOwnersOverlay.geojson
+++ b/sources/europe/no/gridVoltagesOwnersOverlay.geojson
@@ -4,7 +4,7 @@
         "id": "grid-voltages-owners",
         "name": "Electricity grid voltages & owners overlay",
         "type": "tms",
-        "url": "https://api.mapbox.com/styles/v1/zabop/cm2rk5cgu00b701pmahzcegli/tiles/{zoom}/{x}/{y}?access_token=pk.eyJ1IjoiemFib3AiLCJhIjoiY2xrOHAyZGdjMDFsaDNlbWIyODhhc3VoZSJ9.ldiQmCyhLWNt1-U2jDI3PQ",
+        "url": "https://norgrid.zabop.workers.dev/{zoom}/{x}/{y}",
         "overlay": true,
         "country_code": "NO",
         "attribution": {


### PR DESCRIPTION
I decided its not a good idea to expose my mapbox token publicly. I rerouted tile requests through a Cloudflare worker. The same setup has worked well for the *Medium voltage gridlines* overlay in Zambia, see [here](https://github.com/osmlab/editor-layer-index/blob/3e15818cc1da3945a3e3747a9203942dde88a90a/sources/africa/zm/medium_voltage_overhead_gridlines.geojson#L7), I think it'll work well here as well.