### PR TITLE
add Singapore OneMap Orthophoto

### DIFF
--- a/sources/asia/sg/Singapore-Orthophoto.geojson
+++ b/sources/asia/sg/Singapore-Orthophoto.geojson
@@ -1,0 +1,55 @@
+{
+    "type": "Feature",
+    "geometry": {
+        "coordinates": [
+            [
+                [
+                    103.564,
+                    1.189
+                ],
+                [
+                    103.7453,
+                    1.12465
+                ],
+                [
+                    104.1284,
+                    1.28255
+                ],
+                [
+                    104.08035,
+                    1.3457
+                ],
+                [
+                    104.1229,
+                    1.491226
+                ],
+                [
+                    103.6615,
+                    1.491226
+                ],
+                [
+                    103.564,
+                    1.189
+                ]
+            ]
+        ],
+        "type": "Polygon"
+    },
+    "properties": {
+        "attribution": {
+            "required": true,
+            "text": "©OneMap Singapore ODL v1.0",
+            "url": "https://www.onemap.sg/legal/opendatalicence.html"
+        },
+        "country_code": "SG",
+        "icon": "https://osmlab.github.io/editor-layer-index/sources/asia/sg/OM2_logo.png",
+        "id": "Singapore-Orthophoto",
+        "license_url": "https://www.onemap.sg/legal/opendatalicence.html",
+        "name": "Singapore OneMap Orthophoto",
+        "type": "tms",
+        "url": "https://www.onemap.gov.sg/maps/tiles/Satellite/{zoom}/{x}/{y}.png",
+        "category": "map",
+        "privacy_policy_url": "https://www.onemap.sg/legal/privacystatement.html",
+        "min_zoom": 10
+    }
+}


### PR DESCRIPTION
We already have 2 layers from Singapore OneMap, and now https://onemap.gov.sg has an aerial imagery layer too (from the home page, click <kbd>☰</kbd> → <kbd>Select Map Styles</kbd> → <kbd>Orthophoto</kbd>)