### PR TITLE
Layer name fix for Swedish Vacation Home Areas

### DIFF
--- a/sources/europe/se/scb-vacation.geojson
+++ b/sources/europe/se/scb-vacation.geojson
@@ -7,7 +7,7 @@
         "id": "scb-vacation",
         "country_code": "SE",
         "description": "Contiguous areas that consist mainly of holiday homes; a collection of at least 50 holiday homes, where the distance between them does not exceed 150 metres",
-        "url": "http://geodata.scb.se/geoserver/stat/Fritidshusomraden/ows?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=stat:Fritidshusomraden.2015&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "http://geodata.scb.se/geoserver/stat/Fritidshusomraden/ows?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=Fritidshusomraden&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "icon": "https://scb.se/StyleguideAssets/scb/img/Start/favicon-32x32.png",
         "min_zoom": 5,
         "max_zoom": 24,

--- a/sources/europe/se/scb-vacation.geojson
+++ b/sources/europe/se/scb-vacation.geojson
@@ -8,7 +8,7 @@
         "country_code": "SE",
         "description": "Contiguous areas that consist mainly of holiday homes; a collection of at least 50 holiday homes, where the distance between them does not exceed 150 metres",
         "url": "http://geodata.scb.se/geoserver/stat/Fritidshusomraden/ows?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=Fritidshusomraden&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
-        "icon": "https://scb.se/StyleguideAssets/scb/img/Start/favicon-32x32.png",
+        "icon": "https://www.scb.se/img/scb-logo.svg",
         "min_zoom": 5,
         "max_zoom": 24,
         "attribution": {


### PR DESCRIPTION
Very similar to #2709.
[GetCapabilites link](https://geodata.scb.se/geoserver/stat/Fritidshusomraden/ows?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0), [existing URL returning an exception](https://geodata.scb.se/geoserver/stat/Fritidshusomraden/ows?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=stat:Fritidshusomraden.2015&STYLES=&CRS=EPSG:3857&WIDTH=256&HEIGHT=256&BBOX=1878516.4068749992,8140237.763125001,1956787.9238281238,8218509.280078128), [new URL returning an image](https://geodata.scb.se/geoserver/stat/Fritidshusomraden/ows?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=Fritidshusomraden&STYLES=&CRS=EPSG:3857&WIDTH=256&HEIGHT=256&BBOX=1878516.4068749992,8140237.763125001,1956787.9238281238,8218509.280078128).