### PR TITLE
2024 imagery for the Canton Zürich

### DIFF
--- a/sources/europe/ch/Kanton_Zurich_ortho_2020_wms.geojson
+++ b/sources/europe/ch/Kanton_Zurich_ortho_2020_wms.geojson
@@ -13,7 +13,6 @@
             "EPSG:21780",
             "EPSG:21781"
         ],
-        "best": true,
         "country_code": "CH",
         "start_date": "2020",
         "end_date": "2020",

--- a/sources/europe/ch/Kanton_Zurich_ortho_2024_wms.geojson
+++ b/sources/europe/ch/Kanton_Zurich_ortho_2024_wms.geojson
@@ -2,7 +2,7 @@
     "type": "Feature",
     "properties": {
         "attribution": {
-            "text": "Geographisches Informationssystem des Kantons Zürich (GIS-ZH), Orthofoto ZH Frühjahr 2021 RGB 5cm",
+            "text": "Geographisches Informationssystem des Kantons Zürich (GIS-ZH), Orthofoto ZH Sommer 2024 RGB 5cm",
             "required": false
         },
         "available_projections": [
@@ -13,17 +13,18 @@
             "EPSG:21780",
             "EPSG:21781"
         ],
+        "best": false,
         "country_code": "CH",
-        "start_date": "2021",
-        "end_date": "2021",
+        "start_date": "2024",
+        "end_date": "2024",
         "min_zoom": 10,
-        "id": "OGDOrthoZH2021",
-        "name": "Kanton Zurich, Orthofoto ZH Frühjahr 2021 RGB 5cm",
+        "id": "OGDOrthoZH2024",
+        "name": "Kanton Zurich, Orthofoto ZH Sommer 2024 RGB 5cm",
         "license_url": "https://opendata.swiss/de/dataset/orthofoto-fruhjahr-rgb-infrarot-2021",
         "privacy_policy_url": "https://www.zh.ch/internet/de/service/nav/footer/nutzungsregelungen.html",
         "type": "wms",
         "category": "photo",
-        "url": "https://wms.zh.ch/OGDOrthoZH?LAYERS=ortho_w_2021&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
+        "url": "https://wms.zh.ch/OGDOrthoZH?LAYERS=ortho_s_2024&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap"
     },
     "geometry": {
         "type": "Polygon",


### PR DESCRIPTION
Note: the imagery is currently missing a diagonal stripe that couldn't be recorded in 2024 due to the weather. For this reason I've currently set the "best" value to false.

![Screenshot_1749651917](https://github.com/user-attachments/assets/6c9ee5cb-20eb-4174-90f5-14ad68ad48b3)
