### PR TITLE
Update image source URLs for Berlin; Switch 2020 to non-infrared; Update some strings

### DIFF
--- a/sources/europe/de/Berlinaerialphotograph2014.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2014.geojson
@@ -6,7 +6,7 @@
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/de/Berlin.png",
         "type": "tms",
         "category": "historicphoto",
-        "url": "https://tiles.codefor.de/berlin-2014-dop20rgb/{zoom}/{x}/{y}.png",
+        "url": "https://tiles.codefor.de/berlin/geoportal/luftbilder/2014-dop20rgb/{zoom}/{x}/{y}.png",
         "start_date": "2014",
         "end_date": "2014",
         "country_code": "DE",

--- a/sources/europe/de/Berlinaerialphotograph2015.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2015.geojson
@@ -6,7 +6,7 @@
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/de/Berlin.png",
         "type": "tms",
         "category": "historicphoto",
-        "url": "https://tiles.codefor.de/berlin-2015-dop20rgb/{zoom}/{x}/{y}.png",
+        "url": "https://tiles.codefor.de/berlin/geoportal/luftbilder/2015-dop20rgb/{zoom}/{x}/{y}.png",
         "start_date": "2015-08-02",
         "end_date": "2015-08-03",
         "country_code": "DE",

--- a/sources/europe/de/Berlinaerialphotograph2016.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2016.geojson
@@ -6,7 +6,7 @@
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/de/Berlin.png",
         "type": "tms",
         "category": "historicphoto",
-        "url": "https://tiles.codefor.de/berlin-2016-dop20rgb/{zoom}/{x}/{y}.png",
+        "url": "https://tiles.codefor.de/berlin/geoportal/luftbilder/2016-dop20rgb/{zoom}/{x}/{y}.png",
         "start_date": "2016-04-02",
         "end_date": "2016-04-03",
         "country_code": "DE",

--- a/sources/europe/de/Berlinaerialphotograph2017.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2017.geojson
@@ -6,7 +6,7 @@
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/de/Berlin.png",
         "type": "tms",
         "category": "historicphoto",
-        "url": "https://tiles.codefor.de/berlin-2017-dop20rgb/{zoom}/{x}/{y}.png",
+        "url": "https://tiles.codefor.de/berlin/geoportal/luftbilder/2017-dop20rgb/{zoom}/{x}/{y}.png",
         "start_date": "2017-03-27",
         "end_date": "2017-03-28",
         "country_code": "DE",

--- a/sources/europe/de/Berlinaerialphotograph2018.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2018.geojson
@@ -6,7 +6,7 @@
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/de/Berlin.png",
         "type": "tms",
         "category": "historicphoto",
-        "url": "https://tiles.codefor.de/berlin-2018-dop20rgb/{zoom}/{x}/{y}.png",
+        "url": "https://tiles.codefor.de/berlin/geoportal/luftbilder/2018-dop20rgb/{zoom}/{x}/{y}.png",
         "start_date": "2018-03-19",
         "end_date": "2018-04-07",
         "country_code": "DE",

--- a/sources/europe/de/Berlinaerialphotograph2019.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2019.geojson
@@ -6,7 +6,7 @@
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/de/Berlin.png",
         "type": "tms",
         "category": "historicphoto",
-        "url": "https://tiles.codefor.de/berlin-2019-dop20rgb/{zoom}/{x}/{y}.png",
+        "url": "https://tiles.codefor.de/berlin/geoportal/luftbilder/2019-dop20rgb/{zoom}/{x}/{y}.png",
         "start_date": "2019-04-01",
         "end_date": "2019-04-06",
         "country_code": "DE",

--- a/sources/europe/de/Berlinaerialphotograph2020.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2020.geojson
@@ -1,18 +1,18 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "Berlin-2020-infrared",
-        "name": "Berlin/Geoportal DOP20CIR (2020 infrared)",
+        "id": "Berlin-2020",
+        "name": "Berlin/Geoportal DOP20RGB (2020)",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/de/Berlin.png",
         "type": "tms",
         "category": "historicphoto",
-        "url": "https://tiles.codefor.de/berlin-2020-dop20cir/{zoom}/{x}/{y}.png",
+        "url": "https://tiles.codefor.de/berlin/geoportal/luftbilder/2020-truedop20rgb/{zoom}/{x}/{y}.png",
         "start_date": "2020-08",
         "end_date": "2020-08",
         "country_code": "DE",
         "best": false,
         "attribution": {
-            "text": "Geoportal Berlin/Digitale Color-Infrarot-Orthophotos 2020 (DOP20CIR) (codefor.de mirror)",
+            "text": "Geoportal Berlin/Digitale farbige TrueOrthophotos 2020 (DOP20RGB) (codefor.de mirror)",
             "required": true
         },
         "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf",

--- a/sources/europe/de/Berlinaerialphotograph2021.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2021.geojson
@@ -6,13 +6,13 @@
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/de/Berlin.png",
         "type": "tms",
         "category": "photo",
-        "url": "https://tiles.codefor.de/berlin-2021-dop20rgbi/{zoom}/{x}/{y}.png",
+        "url": "https://tiles.codefor.de/berlin/geoportal/luftbilder/2021-dop20rgbi/{zoom}/{x}/{y}.png",
         "start_date": "2021-02-22",
         "end_date": "2021-02-22",
         "country_code": "DE",
         "best": false,
         "attribution": {
-            "text": "Geoportal Berlin/Digitale farbige Orthophotos 2021 (DOP20RGBI) (codefor.de mirror)",
+            "text": "Geoportal Berlin/Digitale farbige Orthophotos 2021 (DOP20RGB) (codefor.de mirror)",
             "required": true
         },
         "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf",

--- a/sources/europe/de/Berlinaerialphotograph2022.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2022.geojson
@@ -2,17 +2,17 @@
     "type": "Feature",
     "properties": {
         "id": "Berlin-2022",
-        "name": "Berlin/Geoportal DOP20RGBI (2022)",
+        "name": "Berlin/Geoportal DOP20RGB (2022)",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/de/Berlin.png",
         "type": "tms",
         "category": "photo",
-        "url": "https://tiles.codefor.de/berlin-2022-dop20rgbi/{zoom}/{x}/{y}.png",
+        "url": "https://tiles.codefor.de/berlin/geoportal/luftbilder/2022-dop20rgbi/{zoom}/{x}/{y}.png",
         "start_date": "2022-03-01",
         "end_date": "2022-03-09",
         "country_code": "DE",
         "best": false,
         "attribution": {
-            "text": "Geoportal Berlin/Digitale farbige TrueOrthophotos 2022 (DOP20RGBI) (codefor.de mirror)",
+            "text": "Geoportal Berlin/Digitale farbige TrueOrthophotos 2022 (DOP20RGB) (codefor.de mirror)",
             "required": true
         },
         "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf",

--- a/sources/europe/de/Berlinaerialphotograph2023.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2023.geojson
@@ -2,17 +2,17 @@
     "type": "Feature",
     "properties": {
         "id": "Berlin-2023",
-        "name": "Berlin/Geoportal DOP20RGBI (2023)",
+        "name": "Berlin/Geoportal DOP20RGB (2023)",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/de/Berlin.png",
         "type": "tms",
         "category": "photo",
-        "url": "https://tiles.codefor.de/berlin-2023-dop20rgbi/{zoom}/{x}/{y}.png",
+        "url": "https://tiles.codefor.de/berlin/geoportal/luftbilder/2023-dop20rgbi/{zoom}/{x}/{y}.png",
         "start_date": "2023",
         "end_date": "2023",
         "country_code": "DE",
         "best": false,
         "attribution": {
-            "text": "Geoportal Berlin/Digitale farbige TrueOrthophotos 2023 (DOP20RGBI) (codefor.de mirror)",
+            "text": "Geoportal Berlin/Digitale farbige TrueOrthophotos 2023 (DOP20RGB) (codefor.de mirror)",
             "required": true
         },
         "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf",

--- a/sources/europe/de/Berlinaerialphotograph2024.geojson
+++ b/sources/europe/de/Berlinaerialphotograph2024.geojson
@@ -2,17 +2,17 @@
     "type": "Feature",
     "properties": {
         "id": "Berlin-2024",
-        "name": "Berlin/Geoportal DOP20RGBI (2024)",
+        "name": "Berlin/Geoportal DOP20RGB (2024)",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/de/Berlin.png",
         "type": "tms",
         "category": "photo",
-        "url": "https://tiles.codefor.de/berlin-2024-dop20rgbi/{zoom}/{x}/{y}.png",
+        "url": "https://tiles.codefor.de/berlin/geoportal/luftbilder/2024-dop20rgbi/{zoom}/{x}/{y}.png",
         "start_date": "2024",
         "end_date": "2024",
         "country_code": "DE",
         "best": true,
         "attribution": {
-            "text": "Geoportal Berlin/Digitale farbige TrueOrthophotos 2024 (DOP20RGBI) (codefor.de mirror)",
+            "text": "Geoportal Berlin/Digitale farbige TrueOrthophotos 2024 (DOP20RGB) (codefor.de mirror)",
             "required": true
         },
         "license_url": "https://wiki.openstreetmap.org/wiki/File:2019-06-03_Datenlizenz_Deutschland_Berlin_OSM.pdf",


### PR DESCRIPTION
- The urls changed after server changes. The old URLs will still redirect but its better to avoid the redirects…
- Given 2020 is a "historicphoto" I switched to the regular imagery (non-infrared) because that makes it easier to compare to other years
- I also change some strings with minor changes to streamline the names and attributions. The "I" is for infrared, which we don't provide in the data (but it was present in the source data…)

https://maps.berlin.codefor.de/ is a preview of all those layers

@jochenklar FYI