### PR TITLE
remove layer 4 from NYS color IR url

### DIFF
--- a/sources/north-america/us/ny/NYSDOP_Latest_CIR.geojson
+++ b/sources/north-america/us/ny/NYSDOP_Latest_CIR.geojson
@@ -1379,7 +1379,7 @@
         "max_zoom": 19,
         "name": "NYSDOP Latest Orthoimagery (Infrared)",
         "type": "wms",
-        "url": "https://orthos.its.ny.gov/arcgis/services/wms/Latest_cir/MapServer/WmsServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0,1,2,3,4&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://orthos.its.ny.gov/arcgis/services/wms/Latest_cir/MapServer/WmsServer?FORMAT=image/jpeg&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0,1,2,3&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "privacy_policy_url": "https://its.ny.gov/its-internet-security-and-privacy-policy",
         "category": "photo",
         "valid-georeference": true


### PR DESCRIPTION
Following up on https://github.com/osmlab/editor-layer-index/pull/2674, the NY Orthos color IR imagery is now throwing errors if `4` is included in the `LAYERS` param. Changing from `LAYERS=0,1,2,3,4` to `LAYERS=0,1,2,3`