### PR TITLE
Hamburg: Update imagery

### DIFF
--- a/sources/europe/de/Hamburg-DOP20-belaubt.geojson
+++ b/sources/europe/de/Hamburg-DOP20-belaubt.geojson
@@ -1,10 +1,11 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "Hamburg-DK5",
-        "url": "https://geodienste.hamburg.de/HH_WMS_DK5?LAYERS=DK5&STYLES=&CRS={proj}&BBOX={bbox}&FORMAT=image/png&WIDTH={width}&HEIGHT={height}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "id": "Hamburg-DOP20-belaubt",
+        "url": "https://geodienste.hamburg.de/wms_dop_zeitreihe_belaubt?LAYERS=dop_zeitreihe_belaubt&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
         "type": "wms",
-        "name": "Hamburg DK5 (HH LGV DK5 2024)",
+        "category": "photo",
+        "name": "Hamburg 20cm (HH LGV DOP20 belaubt 2024)",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/de/Hamburg.png",
         "attribution": {
             "url": "https://www.hamburg.de/bsw/landesbetrieb-geoinformation-und-vermessung",
@@ -14,18 +15,16 @@
         "country_code": "DE",
         "available_projections": [
             "CRS:84",
-            "EPSG:3034",
-            "EPSG:3035",
             "EPSG:3044",
             "EPSG:3857",
             "EPSG:4258",
             "EPSG:4326",
+            "EPSG:4647",
             "EPSG:25832",
             "EPSG:31467"
         ],
-        "category": "map",
         "privacy_policy_url": "https://www.hamburg.de/datenschutz/",
-        "license_url": "https://metaver.de/trefferanzeige?docuuid=84BF7263-E92C-45BE-9D4D-21CB48AD5D88"
+        "license_url": "https://metaver.de/trefferanzeige?docuuid=cc0eaed8-cb36-44a0-9bda-153f28d9e7ba"
     },
     "geometry": {
         "type": "MultiPolygon",

--- a/sources/europe/de/Hamburg-DOP20-unbelaubt.geojson
+++ b/sources/europe/de/Hamburg-DOP20-unbelaubt.geojson
@@ -1,11 +1,11 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "hamburg-20cm",
-        "url": "https://geodienste.hamburg.de/HH_WMS_DOP?LAYERS=DOP&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "id": "Hamburg-DOP20-unbelaubt",
+        "url": "https://geodienste.hamburg.de/wms_dop_zeitreihe_unbelaubt?LAYERS=dop_zeitreihe_unbelaubt&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
         "type": "wms",
         "category": "photo",
-        "name": "Hamburg 20cm (HH LGV DOP20 2022)",
+        "name": "Hamburg 20cm (HH LGV DOP20 unbelaubt 2025)",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/de/Hamburg.png",
         "attribution": {
             "url": "https://www.hamburg.de/bsw/landesbetrieb-geoinformation-und-vermessung",
@@ -25,7 +25,7 @@
         ],
         "best": true,
         "privacy_policy_url": "https://www.hamburg.de/datenschutz/",
-        "license_url": "https://metaver.de/trefferanzeige?cmd=doShowDocument&docuuid=B2013F67-EB8A-4629-8E6D-55A5F74CE129"
+        "license_url": "https://metaver.de/trefferanzeige?docuuid=2a60c6c0-e914-4b60-89b8-bebd2f0b5971"
     },
     "geometry": {
         "type": "MultiPolygon",


### PR DESCRIPTION
The Hamburg 20cm imagery is currently broken because they reorganized their WMS URLs now. You can find up-to-date information on their data sets [here](https://metaver.de/trefferanzeige?docuuid=DD10AFD3-5530-4FD4-933D-5FC71D14B8C7).

They split their "DOP" imagery into two versions: one where trees have leaves and one where they don't ("belaubt" and "unbelaubt", respectively). The unbelaubt one is updated annually and seems a lot more useful, but I thought I'd include the other one as well. The license has stayed the same.