### PR TITLE
Recommend testing URL in iD

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ An imagery source can have an icon by setting the `icon` property to a URL of an
 
 Follow [this workflow](https://gist.github.com/Chaser324/ce0505fbed06b947d962) to create and submit a change to the editor layer index. Whenever branches are mentioned, replace `master` with `gh-pages`.
 
-After you've made a modification, and submit a pull request including those json files. Tests will be run automatically, though if you'd like to manually test as it would appear in the iD editor you can try at https://rapideditor.github.io/imagery-index/index.html.
+After you've made a modification, and submit a pull request including those json files. Tests will be run automatically, though if you'd like to manually test it in the iD editor you can try adding the URL as a "Custom" background.
 
 We previously required contributors to run local checks with `make check`, and run `make` to rebuild the combined files. This is now handled automatically for every pull request, and should not be done anymore.
 


### PR DESCRIPTION
https://rapideditor.github.io/imagery-index seems to be broken and it hasn't been updated since 2023.

I get a mapbox token error in the console. I would think that I could put in a different geojson and click "View it!" but nothing seems to happen when I do.

I figured we could just suggest people test it in iD, but I'm new to this corner of OSM so maybe that's misguided.