### PR TITLE
Switch from TMS to WMS for MML background maps

### DIFF
--- a/sources/europe/fi/mml-orto.geojson
+++ b/sources/europe/fi/mml-orto.geojson
@@ -6,7 +6,7 @@
         "id": "mml-orto",
         "country_code": "FI",
         "description": "Ortophotos from the National Land Survey of Finland",
-        "url": " https://tiles.kartat.kapsi.fi/ortokuva?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://tiles.kartat.kapsi.fi/ortokuva?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "icon": "https://www.maanmittauslaitos.fi/apple-touch-icon.png",
         "min_zoom": 2,
         "max_zoom": 19,

--- a/sources/europe/fi/mml-orto.geojson
+++ b/sources/europe/fi/mml-orto.geojson
@@ -17,7 +17,13 @@
             "url": "https://www.maanmittauslaitos.fi/en"
         },
         "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=356296#p356296",
-        "category": "photo"
+        "category": "photo",
+        "available_projections": [
+            "EPSG:4326",
+            "EPSG:900913",
+            "EPSG:3857",
+            "EPSG:3067"
+        ]
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/fi/mml-orto.geojson
+++ b/sources/europe/fi/mml-orto.geojson
@@ -1,7 +1,7 @@
 {
     "type": "Feature",
     "properties": {
-        "type": "tms",
+        "type": "wms",
         "name": "MML Orthophoto",
         "id": "mml-orto",
         "country_code": "FI",

--- a/sources/europe/fi/mml-orto.geojson
+++ b/sources/europe/fi/mml-orto.geojson
@@ -6,7 +6,7 @@
         "id": "mml-orto",
         "country_code": "FI",
         "description": "Ortophotos from the National Land Survey of Finland",
-        "url": "https://tiles.kartat.kapsi.fi/ortokuva/{zoom}/{x}/{y}.png",
+        "url": " https://tiles.kartat.kapsi.fi/ortokuva?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "icon": "https://www.maanmittauslaitos.fi/apple-touch-icon.png",
         "min_zoom": 2,
         "max_zoom": 19,

--- a/sources/europe/fi/mml-orto.geojson
+++ b/sources/europe/fi/mml-orto.geojson
@@ -5,7 +5,7 @@
         "name": "MML Orthophoto",
         "id": "mml-orto",
         "country_code": "FI",
-        "description": "Ortophotos from the National Land Survey of Finland",
+        "description": "Orthophotos from the National Land Survey of Finland",
         "url": "https://tiles.kartat.kapsi.fi/ortokuva?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "icon": "https://www.maanmittauslaitos.fi/apple-touch-icon.png",
         "min_zoom": 2,

--- a/sources/europe/fi/mml-tausta.geojson
+++ b/sources/europe/fi/mml-tausta.geojson
@@ -16,7 +16,13 @@
             "url": "https://www.maanmittauslaitos.fi/en"
         },
         "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=356296#p356296",
-        "category": "map"
+        "category": "map",
+        "available_projections": [
+            "EPSG:4326",
+            "EPSG:900913",
+            "EPSG:3857",
+            "EPSG:3067"
+        ]
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/fi/mml-tausta.geojson
+++ b/sources/europe/fi/mml-tausta.geojson
@@ -1,7 +1,7 @@
 {
     "type": "Feature",
     "properties": {
-        "type": "tms",
+        "type": "wms",
         "name": "MML Background Map",
         "id": "mml-tausta",
         "country_code": "FI",

--- a/sources/europe/fi/mml-tausta.geojson
+++ b/sources/europe/fi/mml-tausta.geojson
@@ -6,7 +6,7 @@
         "id": "mml-tausta",
         "country_code": "FI",
         "description": "Background map from the National Land Survey of Finland",
-        "url": "https://tiles.kartat.kapsi.fi/taustakartta/{zoom}/{x}/{y}.png",
+        "url": "https://tiles.kartat.kapsi.fi/taustakartta?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "icon": "https://www.maanmittauslaitos.fi/apple-touch-icon.png",
         "min_zoom": 2,
         "max_zoom": 19,

--- a/sources/europe/fi/mml-topo.geojson
+++ b/sources/europe/fi/mml-topo.geojson
@@ -6,7 +6,7 @@
         "id": "mml-topo",
         "country_code": "FI",
         "description": "Topographic map from the National Land Survey of Finland",
-        "url": "https://tiles.kartat.kapsi.fi/peruskartta/{zoom}/{x}/{y}.png",
+        "url": "https://tiles.kartat.kapsi.fi/peruskartta?FORMAT=image/jpeg&VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&STYLES=&SRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "icon": "https://www.maanmittauslaitos.fi/apple-touch-icon.png",
         "min_zoom": 2,
         "max_zoom": 19,

--- a/sources/europe/fi/mml-topo.geojson
+++ b/sources/europe/fi/mml-topo.geojson
@@ -16,7 +16,13 @@
             "url": "https://www.maanmittauslaitos.fi/en"
         },
         "license_url": "https://forum.openstreetmap.org/viewtopic.php?pid=356296#p356296",
-        "category": "map"
+        "category": "map",
+        "available_projections": [
+            "EPSG:4326",
+            "EPSG:900913",
+            "EPSG:3857",
+            "EPSG:3067"
+        ]
     },
     "geometry": {
         "type": "Polygon",

--- a/sources/europe/fi/mml-topo.geojson
+++ b/sources/europe/fi/mml-topo.geojson
@@ -1,7 +1,7 @@
 {
     "type": "Feature",
     "properties": {
-        "type": "tms",
+        "type": "wms",
         "name": "MML Topographic Map",
         "id": "mml-topo",
         "country_code": "FI",


### PR DESCRIPTION
Kapsi tile map service has ceased to operate couple of months ago. WMS is still working, so switch finnish NLS background maps to use that instead.

Tested with iD editor using each URL as custom background.