### PR TITLE
Unmark Budapest district XI 2023 ortophoto as best

### DIFF
--- a/sources/europe/hu/Budapest-XI-district-ortophoto-2023.geojson
+++ b/sources/europe/hu/Budapest-XI-district-ortophoto-2023.geojson
@@ -19,7 +19,6 @@
         "privacy_policy_url": "https://kozigazgatas.ujbuda.hu/adatvedelem",
         "start_date": "2023",
         "end_date": "2023",
-        "best": true,
         "country_code": "HU",
         "type": "wms",
         "id": "Budapest_XI_2023",


### PR DESCRIPTION
The Budapest district XI 2025 ortophoto (that covers the same area) is already marked as best.