### PR TITLE
Improve quality of Henrico County, VA 2024 aerial layer

### DIFF
--- a/sources/north-america/us/va/Henrico_VA_2024.geojson
+++ b/sources/north-america/us/va/Henrico_VA_2024.geojson
@@ -1,7 +1,7 @@
 {
   "type": "Feature",
   "properties": {
-    "url": "https://portal.henrico.gov/mapping/rest/services/Imagery/AerialPhotosAll/MapServer/export?bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&dpi=96&format=png32&transparent=true&layers=show:96,100&f=image",
+    "url": "https://portal.henrico.gov/mapping/rest/services/Imagery/AerialPhotosAll/MapServer/export?bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&dpi=96&format=jpg&transparent=true&layers=show:96,100&f=image",
     "name": "Henrico County Aerial Imagery (2024)",
     "type": "wms",
     "id": "Henrico_VA_2024",

--- a/sources/north-america/us/va/Henrico_VA_2024.geojson
+++ b/sources/north-america/us/va/Henrico_VA_2024.geojson
@@ -1,7 +1,7 @@
 {
   "type": "Feature",
   "properties": {
-    "url": "https://portal.henrico.us/mapping/rest/services/Imagery/AerialPhotos2024/ImageServer/exportImage?bbox={bbox}&bboxSR={wkid}&size={width},{height}&imageSR={wkid}&format=jpg&f=image",
+    "url": "https://portal.henrico.gov/mapping/rest/services/Imagery/AerialPhotosAll/MapServer/export?bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&dpi=96&format=png32&transparent=true&layers=show:96,100&f=image",
     "name": "Henrico County Aerial Imagery (2024)",
     "type": "wms",
     "id": "Henrico_VA_2024",
@@ -9,7 +9,7 @@
     "start_date": "2024",
     "end_date": "2024",
     "min_zoom": 1,
-    "max_zoom": 20,
+    "max_zoom": 21,
     "country_code": "US",
     "attribution": {
       "url": "https://henrico.gov/it/gis/",


### PR DESCRIPTION
- Adjust URL to query an endpoint with better processing at high zooms
- Request up to zoom 21 to fully exhaust source image quality

This new URL has two layer GET parameters, which refer to the same layer from the source. The first is a caching layer which speeds up response times in my experience.

Below are before and after screenshots for these changes in iD. The change in colors is from the source, when requesting imagery equivalent to zoom 21. At lower zooms (z<=20), the colors are identical because it is the same source imagery.

<img width="1478" height="941" alt="Screenshot From 2025-07-31 22-56-50" src="https://github.com/user-attachments/assets/da7d9a1a-36e1-46e2-a891-93e7c2042781" />
<img width="1478" height="941" alt="Screenshot From 2025-07-31 22-56-40" src="https://github.com/user-attachments/assets/970498fa-f744-48c7-ba5f-d80ed81f59d2" />
