### PR TITLE
Slopes for Culebra, Puerto Rico

### DIFF
--- a/sources/north-america/us/pr/usgs-culebra-slope.geojson
+++ b/sources/north-america/us/pr/usgs-culebra-slope.geojson
@@ -1,0 +1,48 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "us-pr-slope",
+        "name": "USGS slope",
+        "description": "Slopes of Culebra, Puerto Rico. The yellower the flatter.",
+        "type": "tms",
+        "url": "https://ps738.user.srcf.net/slope/us-pr/{zoom}/{x}/{y}.webp",
+        "category": "elevation",
+        "min_zoom": 11,
+        "max_zoom": 16,
+        "country_code": "US",
+        "attribution": {
+            "text": "USGS",
+            "url": "https://data.usgs.gov/datacatalog/data/USGS:77ae0551-c61e-4979-aedd-d797abdcde0e"
+        },
+        "icon": "https://www.usgs.gov/themes/custom/usgs_tantalum/usgs_logo.png",
+        "license_url": "https://data.usgs.gov/datacatalog/data/USGS:77ae0551-c61e-4979-aedd-d797abdcde0e",
+        "privacy_policy_url": "https://help.uis.cam.ac.uk/cudn-rules"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [-65.3415, 18.3098],
+                [-65.3396, 18.3003],
+                [-65.3286, 18.2926],
+                [-65.2866, 18.2756],
+                [-65.2553, 18.2913],
+                [-65.2534, 18.2979],
+                [-65.2512, 18.2985],
+                [-65.2512, 18.3004],
+                [-65.2541, 18.3005],
+                [-65.2552, 18.3025],
+                [-65.2337, 18.302],
+                [-65.22, 18.3097],
+                [-65.22, 18.3219],
+                [-65.2494, 18.3433],
+                [-65.2659, 18.3433],
+                [-65.2904, 18.3355],
+                [-65.3383, 18.3515],
+                [-65.3419, 18.3497],
+                [-65.3463, 18.3503],
+                [-65.3415, 18.3098]
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
Similar to https://github.com/osmlab/editor-layer-index/pull/2769, bot now for a US island. A slope colour map, the yellower an area, the flatter it is. See examples below.

---

# Data source

Data source for this tileset: USGS. More precisely: these [1](https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/1m/Projects/PR_PRVI_C_2018/TIFF/USGS_1m_x25y204_PR_PRVI_C_2018.tif) [2](https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/1m/Projects/PR_PRVI_C_2018/TIFF/USGS_1m_x25y203_PR_PRVI_C_2018.tif) [3](https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/1m/Projects/PR_PRVI_C_2018/TIFF/USGS_1m_x26y203_PR_PRVI_C_2018.tif) files.

[Their website](https://data.usgs.gov/datacatalog/data/USGS:77ae0551-c61e-4979-aedd-d797abdcde0e) says this about the source:
> All 3DEP products are public domain.

Other sources suggesting the data is in public domain:
- https://wiki.openstreetmap.org/wiki/United_States_Geological_Survey
> Most products available from the USGS are in the public domain.

- https://portal.opentopography.org/raster?opentopoID=OTNED.012021.4269.3
> All 3DEP products are public domain.

I created a slope raster from the elevation rasters provided by USGS and tiled it. Tileset is served from a university server (more info about them [here](https://www.srcf.net/)).

---

# Purpose

1) **Adjusting paths or roads**

We can use this tileset to improve the location of existing paths, supporting imagery sources. Example for such an improvement opportunity:

<img width="1840" height="1105" alt="image" src="https://github.com/user-attachments/assets/01a1e3e0-b2af-4ded-b716-0fd1732e372c" />

Same location with Bing Maps Aerial basemap (exact location of path much less clear):

<img width="1840" height="1105" alt="image" src="https://github.com/user-attachments/assets/46661827-bd33-4100-aaa9-fd9d58b0e106" />

2) **Discovering new suspected paths**

Example:

<img width="1840" height="1105" alt="image" src="https://github.com/user-attachments/assets/bdd1ec2a-31cd-4fa9-9c43-9696ec1dfb74" />

Of course, I would recommend having additional supporting evidence before marking the features visible on the above screenshot paths/roads (such as: imagery, Strava heatmap, local survey). 



