### PR TITLE
New route to slope tiles

### DIFF
--- a/sources/europe/fr/ign-bl-slope.geojson
+++ b/sources/europe/fr/ign-bl-slope.geojson
@@ -5,7 +5,7 @@
         "name": "IGN slope",
         "description": "Slopes of Saint Barthélemy. The yellower the flatter.",
         "type": "tms",
-        "url": "https://cbb5c1ce-proxy.slopes4osm.workers.dev/fr-bl/{zoom}/{x}/{y}",
+        "url": "https://proxy.slopes4osm.workers.dev/fr-bl/{zoom}/{x}/{y}",
         "category": "elevation",
         "min_zoom": 11,
         "max_zoom": 16,

--- a/sources/europe/fr/ign-bl-slope.geojson
+++ b/sources/europe/fr/ign-bl-slope.geojson
@@ -5,7 +5,7 @@
         "name": "IGN slope",
         "description": "Slopes of Saint Barthélemy. The yellower the flatter.",
         "type": "tms",
-        "url": "https://ps738.user.srcf.net/slope/fr-bl/{zoom}/{x}/{y}.webp",
+        "url": "https://cbb5c1ce-proxy.slopes4osm.workers.dev/fr-bl/{zoom}/{x}/{y}",
         "category": "elevation",
         "min_zoom": 11,
         "max_zoom": 16,

--- a/sources/north-america/us/pr/usgs-culebra-slope.geojson
+++ b/sources/north-america/us/pr/usgs-culebra-slope.geojson
@@ -5,7 +5,7 @@
         "name": "USGS slope",
         "description": "Slopes of Culebra, Puerto Rico. The yellower the flatter.",
         "type": "tms",
-        "url": "https://cbb5c1ce-proxy.slopes4osm.workers.dev/us-pr/{zoom}/{x}/{y}",
+        "url": "https://proxy.slopes4osm.workers.dev/us-pr/{zoom}/{x}/{y}",
         "category": "elevation",
         "min_zoom": 11,
         "max_zoom": 16,

--- a/sources/north-america/us/pr/usgs-culebra-slope.geojson
+++ b/sources/north-america/us/pr/usgs-culebra-slope.geojson
@@ -5,7 +5,7 @@
         "name": "USGS slope",
         "description": "Slopes of Culebra, Puerto Rico. The yellower the flatter.",
         "type": "tms",
-        "url": "https://ps738.user.srcf.net/slope/us-pr/{zoom}/{x}/{y}.webp",
+        "url": "https://cbb5c1ce-proxy.slopes4osm.workers.dev/us-pr/{zoom}/{x}/{y}",
         "category": "elevation",
         "min_zoom": 11,
         "max_zoom": 16,


### PR DESCRIPTION
Set up [a proxy](https://github.com/zabop/slopes4osm/tree/master) to route to the slope tiles I recently created (https://github.com/osmlab/editor-layer-index/pull/2769, https://github.com/osmlab/editor-layer-index/pull/2771).

I would like to increase the coverage of these tilesets to large fractions of US & France. The university server I currently use does not provide enough storage to do that. Routing through a proxy will enable me to point to the new, larger storage solution, once it is set up (without again having to make an ELI PR to the new location + wait until new iD is released).