### PR TITLE
Updating source URLs for north-america/us/nh

### DIFF
--- a/sources/north-america/us/nh/NH_2021_2022_6in_CIR.geojson
+++ b/sources/north-america/us/nh/NH_2021_2022_6in_CIR.geojson
@@ -9,7 +9,7 @@
         },
         "name": "NH GRANIT 2021/2022 6-inch Orthophotos (Infrared)",
         "icon": "https://www.arcgis.com/sharing/rest/content/items/9077b6cdf1d94589b79cc66d8f919da2/resources/GRANITLogoTransparent1.png",
-        "url": "https://nhgeodata.unh.edu/nhgeodata/services/ImageServices/NH_2021_2022_6in_CIR/ImageServer/WMSServer?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=NH_2021_2022_6in_CIR:2122CIR&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://nhgeodata.unh.edu/image/services/ImageServices/NH_2021_2022_6in_CIR/ImageServer/WMSServer?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=NH_2021_2022_6in_CIR&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "max_zoom": 20,
         "license_url": "https://wiki.openstreetmap.org/wiki/New_Hampshire#Usage_grant_for_NH_GRANIT_imagery",
         "country_code": "US",


### PR DESCRIPTION
Updating the following to reflect a change in the service:

* NH_2021_2022_6in_CIR.geojson

`NH_2021_2022_6in_RGB.geojson` was updated in a previous commit. The other two still need to be updated.

NOTE:

Strangely, there is one difference between `NH_2021_2022_6in_CIR.geojson` and `NH_2021_2022_6in_RGB.geojson`, which is that the latter has a `:None` in the URL (Same place that the old URL scheme had a `:2122CIR` which turns out needed to be removed). If I remove the `:None` from the RGB, it seems to behave the same, so maybe we should just do that. But if I add `:None` to the CIR, it becomes RGB.

BTW credit goes to someone in the OSMUS Slack, I didn't find this URL myself.