### PR TITLE
Update LINZ Hawkes Bay Imagery (NZ)

### DIFF
--- a/sources/oceania/nz/LINZ-Hawkes-Bay-Cyclone-Gabrielle.geojson
+++ b/sources/oceania/nz/LINZ-Hawkes-Bay-Cyclone-Gabrielle.geojson
@@ -10,7 +10,6 @@
         "name": "LINZ Cyclone Gabrielle – Hawke's Bay",
         "privacy_policy_url": "https://www.linz.govt.nz/privacy",
         "category": "photo",
-        "best": true,
         "url": "https://basemaps.linz.govt.nz/v1/tiles/hawkes-bay-cyclone-gabrielle-2023-0.1m/WebMercatorQuad/{zoom}/{x}/{y}.webp?api=d01egend5f8dv4zcbfj6z2t7rs3",
         "max_zoom": 21,
         "country_code": "NZ",

--- a/sources/oceania/nz/LINZ-NZ-Aerial-Imagery.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Aerial-Imagery.geojson
@@ -16,6 +16,7 @@
         "type": "tms",
         "id": "LINZ_NZ_Aerial_Imagery",
         "icon": "https://basemaps.linz.govt.nz/assets/logo-linz.svg",
+        "best": true
     },
     "geometry": {
         "type": "MultiPolygon",

--- a/sources/oceania/nz/LINZ-NZ-Aerial-Imagery.geojson
+++ b/sources/oceania/nz/LINZ-NZ-Aerial-Imagery.geojson
@@ -16,7 +16,6 @@
         "type": "tms",
         "id": "LINZ_NZ_Aerial_Imagery",
         "icon": "https://basemaps.linz.govt.nz/assets/logo-linz.svg",
-        "best": true
     },
     "geometry": {
         "type": "MultiPolygon",


### PR DESCRIPTION
Remove best imagery tag from LINZ cyclone Gabrielle imagery for Hawkes Bay as the standard LINZ layer now contains further updated imagery. After discussion with oceanic community we've decided to leave the cyclone imagery as an alternate source as it is still fairly up to date.

Attached screenshots of Discord discussion in OSM World Discord.
<img width="1273" height="822" alt="image" src="https://github.com/user-attachments/assets/0d00d543-14f0-4462-b242-e41ac3b15a5d" />
