### PR TITLE
Add Lyon orthophoto 2023 and latest

### DIFF
--- a/sources/europe/fr/Lyon-Orthophoto-2022.geojson
+++ b/sources/europe/fr/Lyon-Orthophoto-2022.geojson
@@ -5,7 +5,7 @@
         "name": "Lyon Orthophoto 2022 (5cm)",
         "type": "wms",
         "url": "https://imagerie.data.grandlyon.com/geoserver/grandlyon/ows?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=ortho_2022&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
-        "best": true,
+        "best": false,
         "end_date": "2022-02-15",
         "start_date": "2022-03-31",
         "country_code": "FR",

--- a/sources/europe/fr/Lyon-Orthophoto-2023.geojson
+++ b/sources/europe/fr/Lyon-Orthophoto-2023.geojson
@@ -4,7 +4,7 @@
         "id": "orthophoto_lyon_2023",
         "name": "Lyon Orthophoto 2023 (5cm)",
         "type": "wms",
-        "url": "https://data.grandlyon.com/geoserver/grandlyon/ows?layers=grandlyon:ortho_2023&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&transparent=true&STYLES=&WIDTH={width}&HEIGHT={height}&FORMAT=image/png&crs={proj}&BBOX={bbox}",
+        "url": "https://data.grandlyon.com/geoserver/grandlyon/ows?layers=ortho_2023&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&transparent=true&STYLES=&WIDTH={width}&HEIGHT={height}&FORMAT=image/png&crs={proj}&BBOX={bbox}",
         "best": false,
         "start_date": "2023-07-01",
         "end_date": "2024-09-30",

--- a/sources/europe/fr/Lyon-Orthophoto-2023.geojson
+++ b/sources/europe/fr/Lyon-Orthophoto-2023.geojson
@@ -1,0 +1,46 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "orthophoto_lyon_2023",
+        "name": "Lyon Orthophoto 2023 (5cm)",
+        "type": "wms",
+        "url": "https://data.grandlyon.com/geoserver/grandlyon/ows?layers=grandlyon:ortho_2023&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&transparent=true&WIDTH={width}&HEIGHT={height}&FORMAT=image/png&crs={proj}&BBOX={bbox}",
+        "best": false,
+        "start_date": "2023-07-01",
+        "end_date": "2024-09-30",
+        "country_code": "FR",
+        "max_zoom": 22,
+        "min_zoom": 10,
+        "description": "Orthophotographie 2023 de la Métropole de Lyon",
+        "attribution": {
+            "url": "https://data.grandlyon.com/portail/fr/jeux-de-donnees/orthophotographie-2023-de-la-metropole-de-lyon/info",
+            "text": "CRAIG - Métropole du Grand Lyon 2023",
+            "required": true
+        },
+        "available_projections": [
+            "EPSG:2154",
+            "EPSG:3857",
+            "EPSG:3946",
+            "EPSG:4171",
+            "EPSG:4258",
+            "EPSG:4326",
+            "EPSG:27562",
+            "EPSG:27572"
+        ],
+        "license_url": "https://data.grandlyon.com/portail/fr/assets/licences/ETALAB-Licence-Ouverte-v2.0.pdf",
+        "privacy_policy_url": "https://data.grandlyon.com/portail/en/donnees-personnelles",
+        "category": "photo"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [4.6928, 45.9393],
+                [5.062, 45.9393],
+                [5.062, 45.5571],
+                [4.6928, 45.5571],
+                [4.6928, 45.9393]
+            ]
+        ]
+    }
+}

--- a/sources/europe/fr/Lyon-Orthophoto-2023.geojson
+++ b/sources/europe/fr/Lyon-Orthophoto-2023.geojson
@@ -4,7 +4,7 @@
         "id": "orthophoto_lyon_2023",
         "name": "Lyon Orthophoto 2023 (5cm)",
         "type": "wms",
-        "url": "https://data.grandlyon.com/geoserver/grandlyon/ows?layers=grandlyon:ortho_2023&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&transparent=true&WIDTH={width}&HEIGHT={height}&FORMAT=image/png&crs={proj}&BBOX={bbox}",
+        "url": "https://data.grandlyon.com/geoserver/grandlyon/ows?layers=grandlyon:ortho_2023&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&transparent=true&STYLES=&WIDTH={width}&HEIGHT={height}&FORMAT=image/png&crs={proj}&BBOX={bbox}",
         "best": false,
         "start_date": "2023-07-01",
         "end_date": "2024-09-30",
@@ -36,9 +36,9 @@
         "coordinates": [
             [
                 [4.6928, 45.9393],
-                [5.062, 45.9393],
-                [5.062, 45.5571],
                 [4.6928, 45.5571],
+                [5.062, 45.5571],
+                [5.062, 45.9393],
                 [4.6928, 45.9393]
             ]
         ]

--- a/sources/europe/fr/Lyon-Orthophoto-plus-recente.geojson
+++ b/sources/europe/fr/Lyon-Orthophoto-plus-recente.geojson
@@ -4,7 +4,7 @@
         "id": "orthophoto_lyon_plus_recente",
         "name": "Lyon Orthophoto plus récente",
         "type": "wms",
-        "url": "https://data.grandlyon.com/geoserver/grandlyon/ows?layers=grandlyon:ortho_latest&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&transparent=true&WIDTH={width}&HEIGHT={height}&FORMAT=image/png&crs={proj}&BBOX={bbox}",
+        "url": "https://data.grandlyon.com/geoserver/grandlyon/ows?layers=grandlyon:ortho_latest&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&transparent=true&STYLES=&WIDTH={width}&HEIGHT={height}&FORMAT=image/png&crs={proj}&BBOX={bbox}",
         "best": true,
         "start_date": "2023-07-01",
         "end_date": "2024-09-30",
@@ -36,9 +36,9 @@
         "coordinates": [
             [
                 [4.6928, 45.9393],
-                [5.062, 45.9393],
-                [5.062, 45.5571],
                 [4.6928, 45.5571],
+                [5.062, 45.5571],
+                [5.062, 45.9393],
                 [4.6928, 45.9393]
             ]
         ]

--- a/sources/europe/fr/Lyon-Orthophoto-plus-recente.geojson
+++ b/sources/europe/fr/Lyon-Orthophoto-plus-recente.geojson
@@ -1,0 +1,46 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "orthophoto_lyon_plus_recente",
+        "name": "Lyon Orthophoto plus récente",
+        "type": "wms",
+        "url": "https://data.grandlyon.com/geoserver/grandlyon/ows?layers=grandlyon:ortho_latest&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&transparent=true&WIDTH={width}&HEIGHT={height}&FORMAT=image/png&crs={proj}&BBOX={bbox}",
+        "best": true,
+        "start_date": "2023-07-01",
+        "end_date": "2024-09-30",
+        "country_code": "FR",
+        "max_zoom": 22,
+        "min_zoom": 10,
+        "description": "Orthophotographie la plus récente de la Métropole de Lyon",
+        "attribution": {
+            "url": "https://data.grandlyon.com/portail/fr/jeux-de-donnees/orthophotographie-la-plus-recente-de-la-metropole-de-lyon/info",
+            "text": "CRAIG - Métropole du Grand Lyon 2023",
+            "required": true
+        },
+        "available_projections": [
+            "EPSG:2154",
+            "EPSG:3857",
+            "EPSG:3946",
+            "EPSG:4171",
+            "EPSG:4258",
+            "EPSG:4326",
+            "EPSG:27562",
+            "EPSG:27572"
+        ],
+        "license_url": "https://data.grandlyon.com/portail/fr/assets/licences/ETALAB-Licence-Ouverte-v2.0.pdf",
+        "privacy_policy_url": "https://data.grandlyon.com/portail/en/donnees-personnelles",
+        "category": "photo"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [4.6928, 45.9393],
+                [5.062, 45.9393],
+                [5.062, 45.5571],
+                [4.6928, 45.5571],
+                [4.6928, 45.9393]
+            ]
+        ]
+    }
+}

--- a/sources/europe/fr/Lyon-Orthophoto-plus-recente.geojson
+++ b/sources/europe/fr/Lyon-Orthophoto-plus-recente.geojson
@@ -4,7 +4,7 @@
         "id": "orthophoto_lyon_plus_recente",
         "name": "Lyon Orthophoto plus récente",
         "type": "wms",
-        "url": "https://data.grandlyon.com/geoserver/grandlyon/ows?layers=grandlyon:ortho_latest&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&transparent=true&STYLES=&WIDTH={width}&HEIGHT={height}&FORMAT=image/png&crs={proj}&BBOX={bbox}",
+        "url": "https://data.grandlyon.com/geoserver/grandlyon/ows?layers=ortho_latest&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&transparent=true&STYLES=&WIDTH={width}&HEIGHT={height}&FORMAT=image/png&crs={proj}&BBOX={bbox}",
         "best": true,
         "start_date": "2023-07-01",
         "end_date": "2024-09-30",


### PR DESCRIPTION
Copied from https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/fr/Lyon-Orthophoto-2022.geojson

They now offer a "latest" URL so I think it's a good idea to use it so we always get the freshest layer, even though it means that the metadata will become stale if they update what's the latest one. WDYT?