### PR TITLE
Update Aachen Liegenschaftskataster URL

### DIFF
--- a/sources/europe/de/aachen_alkis.geojson
+++ b/sources/europe/de/aachen_alkis.geojson
@@ -4,7 +4,7 @@
         "name": "Aachen Liegenschaftskataster",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/de/aachen_alkis.png",
         "type": "wms",
-        "url": "https://geodienste.staedteregion-aachen.de/cgi-bin/qgis_mapserv.fcgi?MAP=/home/geonet/inkasserver/QMAPS/ALKIS/ALKIS_LK_Inkas.qgs&LAYERS=alkis_lk_inkas&FORMAT=image/png&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "url": "https://geodienste.staedteregion-aachen.de/?MAP=ALKIS_LK_Inkas.qgs&LAYERS=alkis_lk_inkas&FORMAT=image/png&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
         "license_url": "https://www.staedteregion-aachen.de/de/navigation/staedteregion/geoportal/administration-impressum-datenschutz-nutzung/nutzungsbedingungen",
         "privacy_policy_url": "https://www.staedteregion-aachen.de/de/navigation/staedteregion/geoportal/administration-impressum-datenschutz-nutzung/datenschutz",
         "id": "aachen_alkis_wms",
@@ -14,7 +14,9 @@
         "category": "other",
         "available_projections": [
             "CRS:84",
-            "EPSG:25832"
+            "EPSG:25832",
+            "EPSG:3857",
+            "EPSG:4326"
         ]
     },
     "geometry": {


### PR DESCRIPTION
The old URL is no longer working. Otherwise there don't seem to be any changes.