### PR TITLE
Mark Munich imagery as preferred

### DIFF
--- a/sources/europe/de/AktuelleLuftbilderDerLandeshauptstadtMuenchen20cm.geojson
+++ b/sources/europe/de/AktuelleLuftbilderDerLandeshauptstadtMuenchen20cm.geojson
@@ -24,6 +24,7 @@
             "text": "Datenquelle: dl-de/by-2-0: Landeshauptstadt München – Kommunalreferat – GeodatenService – www.geodatenservice-muenchen.de",
             "required": true
         },
+        "best": true,
         "min_zoom": 11,
         "license_url": "https://lists.openstreetmap.de/pipermail/bayern/2017-March/001345.html",
         "privacy_policy_url": "https://stadt.muenchen.de/dam/jcr:ddf96b3b-a390-42dd-a716-15b025c1ef2b/Hinweis_DSGVO_GSM_2021_01.pdf"


### PR DESCRIPTION
Marked the _LandeshauptstadtMuenchen20cm_ imagery as "best" as it's the best imagery available in Munich. It has the highest resolution and it's an orthophoto.