### PR TITLE
give proper error message if `properties` is missing

### DIFF
--- a/scripts/check.py
+++ b/scripts/check.py
@@ -99,6 +99,11 @@ for filename in arguments.path:
 
         ## jsonschema validate
         validator.validate(source, schema)
+
+        if "properties" not in source:
+            logger.exception(f"{filename} missing properties")
+            raise ValidationError(f"{filename} missing properties")
+
         sourceid = source["properties"]["id"]
         if sourceid in seen_ids:
             raise ValidationError("Id %s used multiple times" % sourceid)


### PR DESCRIPTION
`properties` is required within sources, if it's missing check will fail, but it won't give a useful message. This change ensures a useful message is given when `properties` is absent.