### PR TITLE
Increase max_zoom from 14 to 15 in MTBmapno.geojson

### DIFF
--- a/sources/europe/no/MTBmapno.geojson
+++ b/sources/europe/no/MTBmapno.geojson
@@ -119,7 +119,7 @@
         "description": "Norwegian mountain biking map from OSM (max zoom 14-16, varies per region)",
         "icon": "https://osmlab.github.io/editor-layer-index/sources/europe/no/MTBmapno.png",
         "id": "mtbmap-no",
-        "max_zoom": 14,
+        "max_zoom": 15,
         "min_zoom": 3,
         "name": "MTBmap.no",
         "type": "tms",


### PR DESCRIPTION
By request of the map author / owner @Reitstoen.

No tiles exist at z14