### PR TITLE
Update OpenStreetMap-GermanStyle.geojson - Use preferred tile.openstreetmap.de URL

### DIFF
--- a/sources/world/OpenStreetMap-GermanStyle.geojson
+++ b/sources/world/OpenStreetMap-GermanStyle.geojson
@@ -13,7 +13,7 @@
         "name": "OpenStreetMap (German Style)",
         "type": "tms",
         "category": "osmbasedmap",
-        "url": "https://{switch:a,b,c,d}.tile.openstreetmap.de/tiles/osmde/{zoom}/{x}/{y}.png"
+        "url": "https://tile.openstreetmap.de/tiles/osmde/{zoom}/{x}/{y}.png"
     },
     "type": "Feature"
 }


### PR DESCRIPTION
tile.openstreetmap.de [has retired their a., b. and c. aliases as of 1 August 2023](https://community.openstreetmap.org/t/a-b-c-tile-openstreetmap-de-subdomains-von-tile-openstreetmap-de-werden-aufgehoben/100830).

It is mentioned there is buffer time, though it might have ended already.

(but [this thread](https://community.openstreetmap.org/t/i-wonder-if-it-is-possible-to-request-tiles-tile-openstreetmap-de-over-http-2/108481) says HTTP/2 is not supported on this server eventhough it is mentioned in the announcement. )

---

as in https://github.com/fossgis/openstreetmap.de/pull/51