### PR TITLE
Updating New Hampshire LiDAR imagery to current URL

### DIFF
--- a/sources/north-america/us/nh/LiDAR_Bare_Earth_NE_HS_NH_2022.geojson
+++ b/sources/north-america/us/nh/LiDAR_Bare_Earth_NE_HS_NH_2022.geojson
@@ -9,7 +9,7 @@
         },
         "name": "NH GRANIT LiDAR Hillshade 2022 (Northeast)",
         "icon": "https://www.arcgis.com/sharing/rest/content/items/9077b6cdf1d94589b79cc66d8f919da2/resources/GRANITLogoTransparent1.png",
-        "url": "https://nhgeodata.unh.edu/nhgeodata/services/ImageServices/LiDAR_Bare_Earth_NE_HS_NH_2022/ImageServer/WMSServer?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://nhgeodata.unh.edu/image/services/ImageServices/LiDAR_Bare_Earth_NE_HS_NH_2022_img/ImageServer/WMSServer?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=LiDAR_Bare_Earth_NE_HS_NH_2022_img&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "max_zoom": 20,
         "license_url": "https://wiki.openstreetmap.org/wiki/New_Hampshire#Usage_grant_for_NH_GRANIT_imagery",
         "country_code": "US",

--- a/sources/north-america/us/nh/LiDAR_Bare_Earth_NW_HS_NH_2022.geojson
+++ b/sources/north-america/us/nh/LiDAR_Bare_Earth_NW_HS_NH_2022.geojson
@@ -9,7 +9,7 @@
         },
         "name": "NH GRANIT LiDAR Hillshade 2022 (Northwest)",
         "icon": "https://www.arcgis.com/sharing/rest/content/items/9077b6cdf1d94589b79cc66d8f919da2/resources/GRANITLogoTransparent1.png",
-        "url": "https://nhgeodata.unh.edu/nhgeodata/services/ImageServices/LiDAR_Bare_Earth_NW_HS_NH_2022/ImageServer/WMSServer?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=0&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://nhgeodata.unh.edu/image/services/ImageServices/LiDAR_Bare_Earth_NW_HS_NH_2022_img/ImageServer/WMSServer?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=LiDAR_Bare_Earth_NW_HS_NH_2022_img&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "max_zoom": 20,
         "license_url": "https://wiki.openstreetmap.org/wiki/New_Hampshire#Usage_grant_for_NH_GRANIT_imagery",
         "country_code": "US",


### PR DESCRIPTION
Trying to do the same update for the LiDAR hillshades as was done for the aerial imagery, moving the URL to the current location. I believe it's the same imagery and licensing, just in a new location. The existing layers have been broken for some time now.

#2738 