### PR TITLE
Update geoimage.at WMS layer

### DIFF
--- a/sources/europe/at/GeoimageatMaxRes.geojson
+++ b/sources/europe/at/GeoimageatMaxRes.geojson
@@ -808,7 +808,7 @@
         "permission_osm": "explicit",
         "type": "wms",
         "category": "photo",
-        "url": "https://gis.lfrz.gv.at/wmsgw/?LAYERS=Luftbild&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&KEY=4d80de696cd562a63ce463a58a61488d"
+        "url": "https://gis.lfrz.gv.at/wmsgw/?LAYERS=orthophoto&STYLES=&FORMAT=image/jpeg&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&KEY=4d80de696cd562a63ce463a58a61488d"
     },
     "type": "Feature"
 }


### PR DESCRIPTION
The `Luftbild` layer alias has been dropped, so the URL has to be updated to work again.