### PR TITLE
move npm package name to the @openstreetmap namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "editor-layer-index",
+  "name": "@openstreetmap/editor-layer-index",
   "version": "0.0.0",
   "description": "available imagery for osm editors",
   "main": "index.js",


### PR DESCRIPTION
This unblocks https://github.com/openstreetmap/iD/pull/11966/, preventing us to avoid an annoying false positive "malware" detection when using ELI as a npm dependency. As a secondary effect, this would also allow us to publish ELI data as an actual npm package at some point in the future, if we would like to do so eventually.

Given that following https://github.com/openstreetmap/iD/issues/10772#issuecomment-3297426336, my attempt to fix this issue via npm's support were (still as of today) not successful, and that it seems like there is no interest/progress in fixing the underlying [upstream](https://github.com/npm/cli/issues/5110) issue, the only way to prevent the mentioned false positive in `npm audit` is to rename the package in `package.json`. I propose to use `@openstreetmap/editor-layer-index` in order to be in line with similarly named packages like `@openstreetmap/id-tagging-schema`.

For the time being, I have already parked a dummy [package](https://www.npmjs.com/package/@openstreetmap/editor-layer-index) on npm with the proposed name/namespace with only a readme with instructions about how to use ELI.