### PR TITLE
Add Maple Ridge imagery for 1978, 2016, 2018, 2020, and 2023

### DIFF
--- a/sources/north-america/ca/bc/MapleRidge_1978.geojson
+++ b/sources/north-america/ca/bc/MapleRidge_1978.geojson
@@ -13,7 +13,7 @@
         "license_url": "https://osmfoundation.org/wiki/OGL_Canada_and_local_variants",
         "permission_osm": "implicit",
         "country_code": "CA",
-        "end_date": 1978,
+        "end_date": "1978",
         "type": "wms",
         "available_projections": [
             "EPSG:3857",

--- a/sources/north-america/ca/bc/MapleRidge_1978.geojson
+++ b/sources/north-america/ca/bc/MapleRidge_1978.geojson
@@ -1,0 +1,78 @@
+{
+    "type": "Feature",
+    "properties": {
+        "id": "Maple-Ridge-1978",
+        "attribution": {
+            "url": "https://www.mapleridge.ca/terms-use#OpenGovernmentLicenceMapleRidge",
+            "text": "Contains information licensed under the Open Government Licence – Maple Ridge",
+            "required": true
+        },
+        "name": "City of Maple Ridge Orthoimagery (1978)",
+        "url": "https://geoservices.mapleridge.ca/image/rest/services/Orthoimagery/1978_Mosaic/ImageServer/exportImage?f=image&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&format=jpgpng",
+        "max_zoom": 24,
+        "license_url": "https://osmfoundation.org/wiki/OGL_Canada_and_local_variants",
+        "permission_osm": "implicit",
+        "country_code": "CA",
+        "end_date": 1978,
+        "type": "wms",
+        "available_projections": [
+            "EPSG:3857",
+            "EPSG:4326"
+        ],
+        "description": "Historic aerial imagery of the City of Maple Ridge from 1978",
+        "category": "historicphoto",
+        "valid-georeference": true,
+        "privacy_policy_url": "https://www.mapleridge.ca/terms-use"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -122.68717031438804,
+                    49.19402548989717
+                ],
+                [
+                    -122.6162334391505,
+                    49.19402960992406
+                ],
+                [
+                    -122.61597957076191,
+                    49.181846273675575
+                ],
+                [
+                    -122.56764467445929,
+                    49.181834438611986
+                ],
+                [
+                    -122.56788502049591,
+                    49.19291335067635
+                ],
+                [
+                    -122.5121764084497,
+                    49.19255583680123
+                ],
+                [
+                    -122.51365558588593,
+                    49.28022512507707
+                ],
+                [
+                    -122.6417608988129,
+                    49.27943742312368
+                ],
+                [
+                    -122.64274151222718,
+                    49.24980886613099
+                ],
+                [
+                    -122.68961639009618,
+                    49.24980886613099
+                ],
+                [
+                    -122.68717031438804,
+                    49.19402548989717
+                ]
+            ]
+        ]
+    }
+}

--- a/sources/north-america/ca/bc/MapleRidge_2016_RGB.geojson
+++ b/sources/north-america/ca/bc/MapleRidge_2016_RGB.geojson
@@ -13,8 +13,8 @@
         "license_url": "https://osmfoundation.org/wiki/OGL_Canada_and_local_variants",
         "permission_osm": "implicit",
         "country_code": "CA",
-        "start_date": 2016,
-        "end_date": 2016,
+        "start_date": "2016",
+        "end_date": "2016",
         "type": "wms",
         "available_projections": [
             "EPSG:3857",

--- a/sources/north-america/ca/bc/MapleRidge_2016_RGB.geojson
+++ b/sources/north-america/ca/bc/MapleRidge_2016_RGB.geojson
@@ -1,0 +1,67 @@
+{
+  "type": "Feature",
+  "properties": {
+    "id": "Maple-Ridge-RGB-2016",
+    "attribution": {
+      "url": "https://www.mapleridge.ca/terms-use#OpenGovernmentLicenceMapleRidge",
+      "text": "Contains information licensed under the Open Government Licence – Maple Ridge",
+      "required": true
+    },
+    "name": "City of Maple Ridge Orthoimagery (2016)",
+    "url": "https://geoservices.mapleridge.ca/image/rest/services/Orthoimagery/2016_8cm/ImageServer/exportImage?f=image&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&format=jpgpng",
+    "max_zoom": 24,
+    "license_url": "https://osmfoundation.org/wiki/OGL_Canada_and_local_variants",
+    "permission_osm": "implicit",
+    "country_code": "CA",
+    "start_date": 2016,
+    "end_date": 2016,
+    "type": "wms",
+    "available_projections": [
+      "EPSG:3857",
+      "EPSG:4326"
+    ],
+    "description": "Aerial imagery acquired by the City of Maple Ridge in 2016",
+    "category": "photo",
+    "valid-georeference": true,
+    "privacy_policy_url": "https://www.mapleridge.ca/terms-use"
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -122.40265654546003,
+          49.15511449972402
+        ],
+        [
+          -122.40293259264621,
+          49.359223023724894
+        ],
+        [
+          -122.65698474483321,
+          49.35749539494594
+        ],
+        [
+          -122.78689638210375,
+          49.22385458102434
+        ],
+        [
+          -122.71382453840138,
+          49.183444896717674
+        ],
+        [
+          -122.60248959213604,
+          49.18323647970729
+        ],
+        [
+          -122.57155288243067,
+          49.16302086684544
+        ],
+        [
+          -122.40265654546003,
+          49.15511449972402
+        ]
+      ]
+    ]
+  }
+}

--- a/sources/north-america/ca/bc/MapleRidge_2016_RGB.geojson
+++ b/sources/north-america/ca/bc/MapleRidge_2016_RGB.geojson
@@ -1,67 +1,67 @@
 {
-  "type": "Feature",
-  "properties": {
-    "id": "Maple-Ridge-RGB-2016",
-    "attribution": {
-      "url": "https://www.mapleridge.ca/terms-use#OpenGovernmentLicenceMapleRidge",
-      "text": "Contains information licensed under the Open Government Licence – Maple Ridge",
-      "required": true
+    "type": "Feature",
+    "properties": {
+        "id": "Maple-Ridge-RGB-2016",
+        "attribution": {
+            "url": "https://www.mapleridge.ca/terms-use#OpenGovernmentLicenceMapleRidge",
+            "text": "Contains information licensed under the Open Government Licence – Maple Ridge",
+            "required": true
+        },
+        "name": "City of Maple Ridge Orthoimagery (2016)",
+        "url": "https://geoservices.mapleridge.ca/image/rest/services/Orthoimagery/2016_8cm/ImageServer/exportImage?f=image&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&format=jpgpng",
+        "max_zoom": 24,
+        "license_url": "https://osmfoundation.org/wiki/OGL_Canada_and_local_variants",
+        "permission_osm": "implicit",
+        "country_code": "CA",
+        "start_date": 2016,
+        "end_date": 2016,
+        "type": "wms",
+        "available_projections": [
+            "EPSG:3857",
+            "EPSG:4326"
+        ],
+        "description": "Aerial imagery acquired by the City of Maple Ridge in 2016",
+        "category": "photo",
+        "valid-georeference": true,
+        "privacy_policy_url": "https://www.mapleridge.ca/terms-use"
     },
-    "name": "City of Maple Ridge Orthoimagery (2016)",
-    "url": "https://geoservices.mapleridge.ca/image/rest/services/Orthoimagery/2016_8cm/ImageServer/exportImage?f=image&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&format=jpgpng",
-    "max_zoom": 24,
-    "license_url": "https://osmfoundation.org/wiki/OGL_Canada_and_local_variants",
-    "permission_osm": "implicit",
-    "country_code": "CA",
-    "start_date": 2016,
-    "end_date": 2016,
-    "type": "wms",
-    "available_projections": [
-      "EPSG:3857",
-      "EPSG:4326"
-    ],
-    "description": "Aerial imagery acquired by the City of Maple Ridge in 2016",
-    "category": "photo",
-    "valid-georeference": true,
-    "privacy_policy_url": "https://www.mapleridge.ca/terms-use"
-  },
-  "geometry": {
-    "type": "Polygon",
-    "coordinates": [
-      [
-        [
-          -122.40265654546003,
-          49.15511449972402
-        ],
-        [
-          -122.40293259264621,
-          49.359223023724894
-        ],
-        [
-          -122.65698474483321,
-          49.35749539494594
-        ],
-        [
-          -122.78689638210375,
-          49.22385458102434
-        ],
-        [
-          -122.71382453840138,
-          49.183444896717674
-        ],
-        [
-          -122.60248959213604,
-          49.18323647970729
-        ],
-        [
-          -122.57155288243067,
-          49.16302086684544
-        ],
-        [
-          -122.40265654546003,
-          49.15511449972402
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -122.40265654546003,
+                    49.15511449972402
+                ],
+                [
+                    -122.40293259264621,
+                    49.359223023724894
+                ],
+                [
+                    -122.65698474483321,
+                    49.35749539494594
+                ],
+                [
+                    -122.78689638210375,
+                    49.22385458102434
+                ],
+                [
+                    -122.71382453840138,
+                    49.183444896717674
+                ],
+                [
+                    -122.60248959213604,
+                    49.18323647970729
+                ],
+                [
+                    -122.57155288243067,
+                    49.16302086684544
+                ],
+                [
+                    -122.40265654546003,
+                    49.15511449972402
+                ]
+            ]
         ]
-      ]
-    ]
-  }
+    }
 }

--- a/sources/north-america/ca/bc/MapleRidge_2018_RGB.geojson
+++ b/sources/north-america/ca/bc/MapleRidge_2018_RGB.geojson
@@ -13,8 +13,8 @@
         "license_url": "https://osmfoundation.org/wiki/OGL_Canada_and_local_variants",
         "permission_osm": "implicit",
         "country_code": "CA",
-        "start_date": 2018,
-        "end_date": 2018,
+        "start_date": "2018",
+        "end_date": "2018",
         "type": "wms",
         "available_projections": [
             "EPSG:3857",

--- a/sources/north-america/ca/bc/MapleRidge_2018_RGB.geojson
+++ b/sources/north-america/ca/bc/MapleRidge_2018_RGB.geojson
@@ -1,67 +1,67 @@
 {
-  "type": "Feature",
-  "properties": {
-    "id": "Maple-Ridge-RGB-2018",
-    "attribution": {
-      "url": "https://www.mapleridge.ca/terms-use#OpenGovernmentLicenceMapleRidge",
-      "text": "Contains information licensed under the Open Government Licence – Maple Ridge",
-      "required": true
+    "type": "Feature",
+    "properties": {
+        "id": "Maple-Ridge-RGB-2018",
+        "attribution": {
+            "url": "https://www.mapleridge.ca/terms-use#OpenGovernmentLicenceMapleRidge",
+            "text": "Contains information licensed under the Open Government Licence – Maple Ridge",
+            "required": true
+        },
+        "name": "City of Maple Ridge Orthoimagery (2018)",
+        "url": "https://geoservices.mapleridge.ca/image/rest/services/Orthoimagery/2018_8cm/ImageServer/exportImage?f=image&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&format=jpgpng",
+        "max_zoom": 24,
+        "license_url": "https://osmfoundation.org/wiki/OGL_Canada_and_local_variants",
+        "permission_osm": "implicit",
+        "country_code": "CA",
+        "start_date": 2018,
+        "end_date": 2018,
+        "type": "wms",
+        "available_projections": [
+            "EPSG:3857",
+            "EPSG:4326"
+        ],
+        "description": "Aerial imagery acquired by the City of Maple Ridge in 2018",
+        "category": "photo",
+        "valid-georeference": true,
+        "privacy_policy_url": "https://www.mapleridge.ca/terms-use"
     },
-    "name": "City of Maple Ridge Orthoimagery (2018)",
-    "url": "https://geoservices.mapleridge.ca/image/rest/services/Orthoimagery/2018_8cm/ImageServer/exportImage?f=image&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&format=jpgpng",
-    "max_zoom": 24,
-    "license_url": "https://osmfoundation.org/wiki/OGL_Canada_and_local_variants",
-    "permission_osm": "implicit",
-    "country_code": "CA",
-    "start_date": 2018,
-    "end_date": 2018,
-    "type": "wms",
-    "available_projections": [
-      "EPSG:3857",
-      "EPSG:4326"
-    ],
-    "description": "Aerial imagery acquired by the City of Maple Ridge in 2018",
-    "category": "photo",
-    "valid-georeference": true,
-    "privacy_policy_url": "https://www.mapleridge.ca/terms-use"
-  },
-  "geometry": {
-    "type": "Polygon",
-    "coordinates": [
-      [
-        [
-          -122.40265654546003,
-          49.15511449972402
-        ],
-        [
-          -122.40293259264621,
-          49.359223023724894
-        ],
-        [
-          -122.65698474483321,
-          49.35749539494594
-        ],
-        [
-          -122.78689638210375,
-          49.22385458102434
-        ],
-        [
-          -122.71382453840138,
-          49.183444896717674
-        ],
-        [
-          -122.60248959213604,
-          49.18323647970729
-        ],
-        [
-          -122.57155288243067,
-          49.16302086684544
-        ],
-        [
-          -122.40265654546003,
-          49.15511449972402
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -122.40265654546003,
+                    49.15511449972402
+                ],
+                [
+                    -122.40293259264621,
+                    49.359223023724894
+                ],
+                [
+                    -122.65698474483321,
+                    49.35749539494594
+                ],
+                [
+                    -122.78689638210375,
+                    49.22385458102434
+                ],
+                [
+                    -122.71382453840138,
+                    49.183444896717674
+                ],
+                [
+                    -122.60248959213604,
+                    49.18323647970729
+                ],
+                [
+                    -122.57155288243067,
+                    49.16302086684544
+                ],
+                [
+                    -122.40265654546003,
+                    49.15511449972402
+                ]
+            ]
         ]
-      ]
-    ]
-  }
+    }
 }

--- a/sources/north-america/ca/bc/MapleRidge_2018_RGB.geojson
+++ b/sources/north-america/ca/bc/MapleRidge_2018_RGB.geojson
@@ -1,0 +1,67 @@
+{
+  "type": "Feature",
+  "properties": {
+    "id": "Maple-Ridge-RGB-2018",
+    "attribution": {
+      "url": "https://www.mapleridge.ca/terms-use#OpenGovernmentLicenceMapleRidge",
+      "text": "Contains information licensed under the Open Government Licence – Maple Ridge",
+      "required": true
+    },
+    "name": "City of Maple Ridge Orthoimagery (2018)",
+    "url": "https://geoservices.mapleridge.ca/image/rest/services/Orthoimagery/2018_8cm/ImageServer/exportImage?f=image&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&format=jpgpng",
+    "max_zoom": 24,
+    "license_url": "https://osmfoundation.org/wiki/OGL_Canada_and_local_variants",
+    "permission_osm": "implicit",
+    "country_code": "CA",
+    "start_date": 2018,
+    "end_date": 2018,
+    "type": "wms",
+    "available_projections": [
+      "EPSG:3857",
+      "EPSG:4326"
+    ],
+    "description": "Aerial imagery acquired by the City of Maple Ridge in 2018",
+    "category": "photo",
+    "valid-georeference": true,
+    "privacy_policy_url": "https://www.mapleridge.ca/terms-use"
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -122.40265654546003,
+          49.15511449972402
+        ],
+        [
+          -122.40293259264621,
+          49.359223023724894
+        ],
+        [
+          -122.65698474483321,
+          49.35749539494594
+        ],
+        [
+          -122.78689638210375,
+          49.22385458102434
+        ],
+        [
+          -122.71382453840138,
+          49.183444896717674
+        ],
+        [
+          -122.60248959213604,
+          49.18323647970729
+        ],
+        [
+          -122.57155288243067,
+          49.16302086684544
+        ],
+        [
+          -122.40265654546003,
+          49.15511449972402
+        ]
+      ]
+    ]
+  }
+}

--- a/sources/north-america/ca/bc/MapleRidge_2020_RGB.geojson
+++ b/sources/north-america/ca/bc/MapleRidge_2020_RGB.geojson
@@ -13,8 +13,8 @@
         "license_url": "https://osmfoundation.org/wiki/OGL_Canada_and_local_variants",
         "permission_osm": "implicit",
         "country_code": "CA",
-        "start_date": 2020,
-        "end_date": 2020,
+        "start_date": "2020",
+        "end_date": "2020",
         "type": "wms",
         "available_projections": [
             "EPSG:3857",

--- a/sources/north-america/ca/bc/MapleRidge_2020_RGB.geojson
+++ b/sources/north-america/ca/bc/MapleRidge_2020_RGB.geojson
@@ -1,0 +1,67 @@
+{
+  "type": "Feature",
+  "properties": {
+    "id": "Maple-Ridge-RGB-2020",
+    "attribution": {
+      "url": "https://www.mapleridge.ca/terms-use#OpenGovernmentLicenceMapleRidge",
+      "text": "Contains information licensed under the Open Government Licence – Maple Ridge",
+      "required": true
+    },
+    "name": "City of Maple Ridge Orthoimagery (2020)",
+    "url": "https://geoservices.mapleridge.ca/image/rest/services/Orthoimagery/2020_8cm/ImageServer/exportImage?f=image&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&format=jpgpng",
+    "max_zoom": 24,
+    "license_url": "https://osmfoundation.org/wiki/OGL_Canada_and_local_variants",
+    "permission_osm": "implicit",
+    "country_code": "CA",
+    "start_date": 2020,
+    "end_date": 2020,
+    "type": "wms",
+    "available_projections": [
+      "EPSG:3857",
+      "EPSG:4326"
+    ],
+    "description": "Aerial imagery acquired by the City of Maple Ridge in 2020",
+    "category": "photo",
+    "valid-georeference": true,
+    "privacy_policy_url": "https://www.mapleridge.ca/terms-use"
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -122.40265654546003,
+          49.15511449972402
+        ],
+        [
+          -122.40293259264621,
+          49.359223023724894
+        ],
+        [
+          -122.65698474483321,
+          49.35749539494594
+        ],
+        [
+          -122.78689638210375,
+          49.22385458102434
+        ],
+        [
+          -122.71382453840138,
+          49.183444896717674
+        ],
+        [
+          -122.60248959213604,
+          49.18323647970729
+        ],
+        [
+          -122.57155288243067,
+          49.16302086684544
+        ],
+        [
+          -122.40265654546003,
+          49.15511449972402
+        ]
+      ]
+    ]
+  }
+}

--- a/sources/north-america/ca/bc/MapleRidge_2020_RGB.geojson
+++ b/sources/north-america/ca/bc/MapleRidge_2020_RGB.geojson
@@ -1,67 +1,67 @@
 {
-  "type": "Feature",
-  "properties": {
-    "id": "Maple-Ridge-RGB-2020",
-    "attribution": {
-      "url": "https://www.mapleridge.ca/terms-use#OpenGovernmentLicenceMapleRidge",
-      "text": "Contains information licensed under the Open Government Licence – Maple Ridge",
-      "required": true
+    "type": "Feature",
+    "properties": {
+        "id": "Maple-Ridge-RGB-2020",
+        "attribution": {
+            "url": "https://www.mapleridge.ca/terms-use#OpenGovernmentLicenceMapleRidge",
+            "text": "Contains information licensed under the Open Government Licence – Maple Ridge",
+            "required": true
+        },
+        "name": "City of Maple Ridge Orthoimagery (2020)",
+        "url": "https://geoservices.mapleridge.ca/image/rest/services/Orthoimagery/2020_8cm/ImageServer/exportImage?f=image&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&format=jpgpng",
+        "max_zoom": 24,
+        "license_url": "https://osmfoundation.org/wiki/OGL_Canada_and_local_variants",
+        "permission_osm": "implicit",
+        "country_code": "CA",
+        "start_date": 2020,
+        "end_date": 2020,
+        "type": "wms",
+        "available_projections": [
+            "EPSG:3857",
+            "EPSG:4326"
+        ],
+        "description": "Aerial imagery acquired by the City of Maple Ridge in 2020",
+        "category": "photo",
+        "valid-georeference": true,
+        "privacy_policy_url": "https://www.mapleridge.ca/terms-use"
     },
-    "name": "City of Maple Ridge Orthoimagery (2020)",
-    "url": "https://geoservices.mapleridge.ca/image/rest/services/Orthoimagery/2020_8cm/ImageServer/exportImage?f=image&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&format=jpgpng",
-    "max_zoom": 24,
-    "license_url": "https://osmfoundation.org/wiki/OGL_Canada_and_local_variants",
-    "permission_osm": "implicit",
-    "country_code": "CA",
-    "start_date": 2020,
-    "end_date": 2020,
-    "type": "wms",
-    "available_projections": [
-      "EPSG:3857",
-      "EPSG:4326"
-    ],
-    "description": "Aerial imagery acquired by the City of Maple Ridge in 2020",
-    "category": "photo",
-    "valid-georeference": true,
-    "privacy_policy_url": "https://www.mapleridge.ca/terms-use"
-  },
-  "geometry": {
-    "type": "Polygon",
-    "coordinates": [
-      [
-        [
-          -122.40265654546003,
-          49.15511449972402
-        ],
-        [
-          -122.40293259264621,
-          49.359223023724894
-        ],
-        [
-          -122.65698474483321,
-          49.35749539494594
-        ],
-        [
-          -122.78689638210375,
-          49.22385458102434
-        ],
-        [
-          -122.71382453840138,
-          49.183444896717674
-        ],
-        [
-          -122.60248959213604,
-          49.18323647970729
-        ],
-        [
-          -122.57155288243067,
-          49.16302086684544
-        ],
-        [
-          -122.40265654546003,
-          49.15511449972402
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -122.40265654546003,
+                    49.15511449972402
+                ],
+                [
+                    -122.40293259264621,
+                    49.359223023724894
+                ],
+                [
+                    -122.65698474483321,
+                    49.35749539494594
+                ],
+                [
+                    -122.78689638210375,
+                    49.22385458102434
+                ],
+                [
+                    -122.71382453840138,
+                    49.183444896717674
+                ],
+                [
+                    -122.60248959213604,
+                    49.18323647970729
+                ],
+                [
+                    -122.57155288243067,
+                    49.16302086684544
+                ],
+                [
+                    -122.40265654546003,
+                    49.15511449972402
+                ]
+            ]
         ]
-      ]
-    ]
-  }
+    }
 }

--- a/sources/north-america/ca/bc/MapleRidge_2023_RGB.geojson
+++ b/sources/north-america/ca/bc/MapleRidge_2023_RGB.geojson
@@ -1,0 +1,124 @@
+{
+  "type": "Feature",
+  "properties": {
+    "id": "Maple-Ridge-RGB-2023",
+    "attribution": {
+      "url": "https://www.mapleridge.ca/terms-use#OpenGovernmentLicenceMapleRidge",
+      "text": "Contains information licensed under the Open Government Licence – Maple Ridge",
+      "required": true
+    },
+    "name": "City of Maple Ridge Orthoimagery (2023)",
+    "url": "https://geoservices.mapleridge.ca/image/rest/services/Orthoimagery/2023_7_5cm/ImageServer/exportImage?f=image&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&format=jpgpng",
+    "max_zoom": 24,
+    "license_url": "https://osmfoundation.org/wiki/OGL_Canada_and_local_variants",
+    "permission_osm": "implicit",
+    "country_code": "CA",
+    "best": true,
+    "start_date": 2023,
+    "end_date": 2023,
+    "type": "wms",
+    "available_projections": [
+      "EPSG:3857",
+      "EPSG:4326"
+    ],
+    "description": "Aerial imagery acquired by the City of Maple Ridge in Spring 2023",
+    "category": "photo",
+    "valid-georeference": true,
+    "privacy_policy_url": "https://www.mapleridge.ca/terms-use"
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -122.64794407988816,
+          49.202591334144074
+        ],
+        [
+          -122.63865446846927,
+          49.20619664622018
+        ],
+        [
+          -122.62012325830901,
+          49.210263814187726
+        ],
+        [
+          -122.60347418908682,
+          49.208750020867626
+        ],
+        [
+          -122.59311326206793,
+          49.201035561494734
+        ],
+        [
+          -122.58521493628665,
+          49.187202315566935
+        ],
+        [
+          -122.51880257972772,
+          49.166111417810754
+        ],
+        [
+          -122.46697874917099,
+          49.170216164644785
+        ],
+        [
+          -122.446978793639,
+          49.17059724681724
+        ],
+        [
+          -122.43281878827875,
+          49.16849769867301
+        ],
+        [
+          -122.41355474235314,
+          49.163536809724405
+        ],
+        [
+          -122.41359062462766,
+          49.24344782535633
+        ],
+        [
+          -122.47933958675097,
+          49.2482061698548
+        ],
+        [
+          -122.47965667828947,
+          49.27266420498154
+        ],
+        [
+          -122.51708005666615,
+          49.272724966572866
+        ],
+        [
+          -122.5488583330423,
+          49.25651917834071
+        ],
+        [
+          -122.62304081258158,
+          49.28683454144897
+        ],
+        [
+          -122.67819555611854,
+          49.2266402908202
+        ],
+        [
+          -122.67757586992391,
+          49.19961720871237
+        ],
+        [
+          -122.66368248682801,
+          49.19774325762447
+        ],
+        [
+          -122.65400397748644,
+          49.1999903138657
+        ],
+        [
+          -122.64794407988816,
+          49.202591334144074
+        ]
+      ]
+    ]
+  }
+}

--- a/sources/north-america/ca/bc/MapleRidge_2023_RGB.geojson
+++ b/sources/north-america/ca/bc/MapleRidge_2023_RGB.geojson
@@ -1,124 +1,124 @@
 {
-  "type": "Feature",
-  "properties": {
-    "id": "Maple-Ridge-RGB-2023",
-    "attribution": {
-      "url": "https://www.mapleridge.ca/terms-use#OpenGovernmentLicenceMapleRidge",
-      "text": "Contains information licensed under the Open Government Licence – Maple Ridge",
-      "required": true
+    "type": "Feature",
+    "properties": {
+        "id": "Maple-Ridge-RGB-2023",
+        "attribution": {
+            "url": "https://www.mapleridge.ca/terms-use#OpenGovernmentLicenceMapleRidge",
+            "text": "Contains information licensed under the Open Government Licence – Maple Ridge",
+            "required": true
+        },
+        "name": "City of Maple Ridge Orthoimagery (2023)",
+        "url": "https://geoservices.mapleridge.ca/image/rest/services/Orthoimagery/2023_7_5cm/ImageServer/exportImage?f=image&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&format=jpgpng",
+        "max_zoom": 24,
+        "license_url": "https://osmfoundation.org/wiki/OGL_Canada_and_local_variants",
+        "permission_osm": "implicit",
+        "country_code": "CA",
+        "best": true,
+        "start_date": 2023,
+        "end_date": 2023,
+        "type": "wms",
+        "available_projections": [
+            "EPSG:3857",
+            "EPSG:4326"
+        ],
+        "description": "Aerial imagery acquired by the City of Maple Ridge in Spring 2023",
+        "category": "photo",
+        "valid-georeference": true,
+        "privacy_policy_url": "https://www.mapleridge.ca/terms-use"
     },
-    "name": "City of Maple Ridge Orthoimagery (2023)",
-    "url": "https://geoservices.mapleridge.ca/image/rest/services/Orthoimagery/2023_7_5cm/ImageServer/exportImage?f=image&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}&format=jpgpng",
-    "max_zoom": 24,
-    "license_url": "https://osmfoundation.org/wiki/OGL_Canada_and_local_variants",
-    "permission_osm": "implicit",
-    "country_code": "CA",
-    "best": true,
-    "start_date": 2023,
-    "end_date": 2023,
-    "type": "wms",
-    "available_projections": [
-      "EPSG:3857",
-      "EPSG:4326"
-    ],
-    "description": "Aerial imagery acquired by the City of Maple Ridge in Spring 2023",
-    "category": "photo",
-    "valid-georeference": true,
-    "privacy_policy_url": "https://www.mapleridge.ca/terms-use"
-  },
-  "geometry": {
-    "type": "Polygon",
-    "coordinates": [
-      [
-        [
-          -122.64794407988816,
-          49.202591334144074
-        ],
-        [
-          -122.63865446846927,
-          49.20619664622018
-        ],
-        [
-          -122.62012325830901,
-          49.210263814187726
-        ],
-        [
-          -122.60347418908682,
-          49.208750020867626
-        ],
-        [
-          -122.59311326206793,
-          49.201035561494734
-        ],
-        [
-          -122.58521493628665,
-          49.187202315566935
-        ],
-        [
-          -122.51880257972772,
-          49.166111417810754
-        ],
-        [
-          -122.46697874917099,
-          49.170216164644785
-        ],
-        [
-          -122.446978793639,
-          49.17059724681724
-        ],
-        [
-          -122.43281878827875,
-          49.16849769867301
-        ],
-        [
-          -122.41355474235314,
-          49.163536809724405
-        ],
-        [
-          -122.41359062462766,
-          49.24344782535633
-        ],
-        [
-          -122.47933958675097,
-          49.2482061698548
-        ],
-        [
-          -122.47965667828947,
-          49.27266420498154
-        ],
-        [
-          -122.51708005666615,
-          49.272724966572866
-        ],
-        [
-          -122.5488583330423,
-          49.25651917834071
-        ],
-        [
-          -122.62304081258158,
-          49.28683454144897
-        ],
-        [
-          -122.67819555611854,
-          49.2266402908202
-        ],
-        [
-          -122.67757586992391,
-          49.19961720871237
-        ],
-        [
-          -122.66368248682801,
-          49.19774325762447
-        ],
-        [
-          -122.65400397748644,
-          49.1999903138657
-        ],
-        [
-          -122.64794407988816,
-          49.202591334144074
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -122.64794407988816,
+                    49.202591334144074
+                ],
+                [
+                    -122.63865446846927,
+                    49.20619664622018
+                ],
+                [
+                    -122.62012325830901,
+                    49.210263814187726
+                ],
+                [
+                    -122.60347418908682,
+                    49.208750020867626
+                ],
+                [
+                    -122.59311326206793,
+                    49.201035561494734
+                ],
+                [
+                    -122.58521493628665,
+                    49.187202315566935
+                ],
+                [
+                    -122.51880257972772,
+                    49.166111417810754
+                ],
+                [
+                    -122.46697874917099,
+                    49.170216164644785
+                ],
+                [
+                    -122.446978793639,
+                    49.17059724681724
+                ],
+                [
+                    -122.43281878827875,
+                    49.16849769867301
+                ],
+                [
+                    -122.41355474235314,
+                    49.163536809724405
+                ],
+                [
+                    -122.41359062462766,
+                    49.24344782535633
+                ],
+                [
+                    -122.47933958675097,
+                    49.2482061698548
+                ],
+                [
+                    -122.47965667828947,
+                    49.27266420498154
+                ],
+                [
+                    -122.51708005666615,
+                    49.272724966572866
+                ],
+                [
+                    -122.5488583330423,
+                    49.25651917834071
+                ],
+                [
+                    -122.62304081258158,
+                    49.28683454144897
+                ],
+                [
+                    -122.67819555611854,
+                    49.2266402908202
+                ],
+                [
+                    -122.67757586992391,
+                    49.19961720871237
+                ],
+                [
+                    -122.66368248682801,
+                    49.19774325762447
+                ],
+                [
+                    -122.65400397748644,
+                    49.1999903138657
+                ],
+                [
+                    -122.64794407988816,
+                    49.202591334144074
+                ]
+            ]
         ]
-      ]
-    ]
-  }
+    }
 }

--- a/sources/north-america/ca/bc/MapleRidge_2023_RGB.geojson
+++ b/sources/north-america/ca/bc/MapleRidge_2023_RGB.geojson
@@ -14,8 +14,8 @@
         "permission_osm": "implicit",
         "country_code": "CA",
         "best": true,
-        "start_date": 2023,
-        "end_date": 2023,
+        "start_date": "2023",
+        "end_date": "2023",
         "type": "wms",
         "available_projections": [
             "EPSG:3857",


### PR DESCRIPTION
Hello! This PR adds the imagery available from the City of Maple Ridge for 2016, 2018, 2020, and 2023, along with a historical entry from 1978.

I have marked the 2023 imagery as "best" (it is also better than Esri/Bing). I wasn't too sure if I should mark the older pre-2023 imagery as historic, as the docs say I should "when there exists a more recent photo source", but some other examples I looked at (such as Toronto) still mark the older "modern" imagery as "photo".

2016, 2018, and 2020 share a coordinate boundary, while 2023 and 1978 have their own unique coordinates as their coverage is smaller. 

I have tested all of these sources as custom layers in the iD editor.

Please let me know if I've done anything wrong or can improve anything! :)