### PR TITLE
add CI script to publish to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish to npm
+
+on:
+    workflow_dispatch:
+
+permissions:
+    contents: read
+    id-token: write
+
+jobs:
+    deploy:
+        name: Publish to npm
+        runs-on: ubuntu-latest
+        environment:
+            name: npm
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+              with:
+                  persist-credentials: false
+
+            - name: Publish to npm
+              run: npm publish --provenance --access public

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,3 +139,11 @@ use the following commands:
 
 For convenience you can also run these commands as `make txpush` or `make txpull`.
 
+
+### Releases
+
+Releases are manually created by a maintainer. To create a release, a maintainer needs to:
+
+1. Confirm that the main branch is in a valid state and that the CI is passing.
+1. Update the version number in [package.json](./package.json), and push this change to the main branch (`gh-pages`)
+1. Go to [this GitHub page](https://github.com/osmlab/editor-layer-index/actions/workflows/publish.yml), and then click <kbd>Run workflow</kbd>.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for info on how to contribute new sources
 
 ## Using this index
 
-If you are using iD or Potlatch 2 you are already using this index! iD only updates imagery layers upon release, so recently added or modified layers may not yet appear in iD, [this may be improved in the future](https://github.com/openstreetmap/iD/issues/9730), but for now to check iD using the latest imagery layers you can view the preview site [https://ideditor.netlify.app](https://ideditor.netlify.app).
+If you are using iD or Potlatch 2 you are already using this index!
 
 For JOSM you can add `https://osmlab.github.io/editor-layer-index/imagery.xml` to the preference key `imagery.layers.sites` in advanced preferences. You probably want to remove the `https://josm.openstreetmap.de/maps` entry or you'll get the same layers listed twice.
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@openstreetmap/editor-layer-index",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "available imagery for osm editors",
-  "main": "index.js",
+  "main": "imagery.geojson",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -10,10 +10,16 @@
     "type": "git",
     "url": "git://github.com/osmlab/editor-layer-index.git"
   },
+  "homepage": "https://osmlab.github.io/editor-layer-index",
   "keywords": [
     "openstreetmap",
     "editor",
     "imagery"
+  ],
+  "files": [
+    "imagery.geojson",
+    "imagery.xml",
+    "schema.json"
   ],
   "author": "Ian Dees",
   "license": "BSD"


### PR DESCRIPTION
Based on the recent discussions, it sounds like everyone supports the idea of publishing releases.

So, now that #2917 is merged, this PR adds a button to the GitHub UI, which a maintainer can click to publish a new version to npm:

<img width="938" height="493" alt="image" src="https://github.com/user-attachments/assets/9d24e84c-e526-4841-99a8-30edf90bd1a0" />

There's no authentication tokens required, and this runs completely in the CI, maintainers don't need to run any commands locally.

---

<details>
<summary>Before this can be merged, there are a few extra steps that a maintainer needs to take (click to expand)</summary>


1. Go to [/settings/environments/new](https://github.com/osmlab/editor-layer-index/settings/environments/new), and create   new environment called `npm`. Setup whatever restrictions you want, like only allowing deployments from the `gh-pages` branch.
2. Open [the existing npm package on the npm website](https://npm.im/@openstreetmap/editor-layer-index), click on [Settings](https://www.npmjs.com/package/@openstreetmap/editor-layer-index/access), and configure the following options:

<img width="1036" height="714" alt="Untitled" src="https://github.com/user-attachments/assets/dda3144e-b9e2-46b8-bc6c-cbf805826f84" />

Once these two steps are done, publishing will work from the GitHub CI without needing to setup any other authentication or permissions. (thanks to the ['trusted publishing' feature](https://docs.npmjs.com/trusted-publishers))

</details>