### PR TITLE
make GitHub recognise that this repo contains mostly GeoJson, not JS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.geojson linguist-detectable
+
+site/libs/** linguist-vendored


### PR DESCRIPTION
In GitHub's UI, it looks like this repository is "66%" javascript, which isn't really accurate:

<img width="321" height="130" alt="image" src="https://github.com/user-attachments/assets/6eb95b8d-1e00-4184-b93d-cab2413041ca" />

We can add a `.gitattributes` file, to [instruct the 'linguist' library](https://github.com/github-linguist/linguist/blob/main/docs/overrides.md) to count `*.geojson` files and ignore `site/libs/**`. The result is a bit more accurate:

<img width="307" height="125" alt="image" src="https://github.com/user-attachments/assets/f70f8833-0654-4219-a44e-fea8f792979d" />


the same change was recently implemented [in id-tagging-schema](https://github.com/openstreetmap/id-tagging-schema/blame/832dfbcdd64de266a2563a7d64b8ff649ee30fa2/.gitattributes#L1), [name-suggestion-index](https://github.com/osmlab/name-suggestion-index/blame/main/.gitattributes#L7-L13), and [osm-community-index](https://github.com/osmlab/osm-community-index/blame/8c7f940b337fb47d4e046d4402c13e79e8b66bdf/.gitattributes#L3-L13).