### PR TITLE
Update date range for Munich aerials

### DIFF
--- a/sources/europe/de/AktuelleLuftbilderDerLandeshauptstadtMuenchen20cm.geojson
+++ b/sources/europe/de/AktuelleLuftbilderDerLandeshauptstadtMuenchen20cm.geojson
@@ -7,8 +7,8 @@
         "type": "wms",
         "category": "photo",
         "url": "https://geoportal.muenchen.de/geoserver/gsm/luftbild/ows?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=luftbild&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
-        "start_date": "2018-05-02",
-        "end_date": "2018-05-02",
+        "start_date": "2025-02",
+        "end_date": "2025-04",
         "country_code": "DE",
         "available_projections": [
             "EPSG:4326",


### PR DESCRIPTION
Closes #2933 

This is a simple PR that updates the imagery vintage. The imagery has been updated but uses the same URL, so no other changes should be needed.