### PR TITLE
Add 2025 3in Philadelphia imagery

### DIFF
--- a/sources/north-america/us/pa/Philadelphia_Ortho_2025_3in.geojson
+++ b/sources/north-america/us/pa/Philadelphia_Ortho_2025_3in.geojson
@@ -1,21 +1,22 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "Philadelphia_Ortho_2024_1in",
+        "id": "Philadelphia_Ortho_2025_3in",
         "attribution": {
             "url": "https://www.opendataphilly.org/dataset/aerial-photography",
             "text": "City of Philadelphia",
             "required": false
         },
-        "name": "Philadelphia Orthoimagery 2024 (1in)",
-        "url": "https://tiles.arcgis.com/tiles/fLeGjb7u4uXqeF9q/arcgis/rest/services/CityImagery_2024_1in/MapServer/tile/{zoom}/{y}/{x}",
+        "name": "Philadelphia Orthoimagery 2025 (3in)",
+        "url": "https://tiles.arcgis.com/tiles/fLeGjb7u4uXqeF9q/arcgis/rest/services/CityImagery_2025_3in/MapServer/tile/{zoom}/{y}/{x}",
         "max_zoom": 22,
         "license_url": "https://opendataphilly.org/organizations/city-of-philadelphia/",
+        "best": true,
         "country_code": "US",
         "type": "tms",
-        "start_date": "2024",
-        "end_date": "2024",
-        "description": "Digital orthophotography with a ground resolution of 1-inch per pixel, georeferenced to the Pennsylvania State Plane Coordinate System, and delivered as mosaicked raster images for the city of Philadelphia",
+        "start_date": "2025",
+        "end_date": "2025",
+        "description": "Digital orthophotography with a ground resolution of 3-inch per pixel, georeferenced to the Pennsylvania State Plane Coordinate System, and delivered as mosaicked raster images for the city of Philadelphia",
         "category": "photo",
         "valid-georeference": true,
         "privacy_policy_url": "https://www.esri.com/en-us/privacy/overview"


### PR DESCRIPTION
This PR adds the 2025 Philadelphia imagery. 

There should be no changes needed other than the URL, and I have updated this 2025 imagery to "best" despite there being 1in imagery available from 2024, as 3in is still very good.

Closes #2915