### PR TITLE
Update Brussels UrbIS WMS endpoints to new servers

### DIFF
--- a/sources/europe/be/UrbISFR.geojson
+++ b/sources/europe/be/UrbISFR.geojson
@@ -339,7 +339,7 @@
         "privacy_policy_url": "https://bric.brussels/en/disclaimer-conditions-of-use-of-the-bric-website",
         "name": "UrbisAdm FR",
         "type": "wms",
-        "url": "https://geoservices-urbis.irisnet.be/geoserver/BaseMaps/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=UrbISFrenchLabeledColor&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
+        "url": "https://geoservices-basemap.irisnet.be/geoserver/BaseMaps/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=UrbISFrenchLabeledColor&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
     },
     "type": "Feature"
 }

--- a/sources/europe/be/UrbISFRNL.geojson
+++ b/sources/europe/be/UrbISFRNL.geojson
@@ -339,7 +339,7 @@
         "privacy_policy_url": "https://bric.brussels/en/disclaimer-conditions-of-use-of-the-bric-website",
         "name": "UrbisAdm FR/NL",
         "type": "wms",
-        "url": "https://geoservices-urbis.irisnet.be/geoserver/BaseMaps/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=UrbISNotLabeledColor&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
+        "url": "https://geoservices-basemap.irisnet.be/geoserver/BaseMaps/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=UrbISNotLabeledColor&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
     },
     "type": "Feature"
 }

--- a/sources/europe/be/UrbISNL.geojson
+++ b/sources/europe/be/UrbISNL.geojson
@@ -339,7 +339,7 @@
         "privacy_policy_url": "https://bric.brussels/en/disclaimer-conditions-of-use-of-the-bric-website",
         "name": "UrbisAdm NL",
         "type": "wms",
-        "url": "https://geoservices-urbis.irisnet.be/geoserver/BaseMaps/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=UrbISDutchLabeledColor&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
+        "url": "https://geoservices-basemap.irisnet.be/geoserver/BaseMaps/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=UrbISDutchLabeledColor&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
     },
     "type": "Feature"
 }

--- a/sources/europe/be/UrbIS_OrthoPhoto.geojson
+++ b/sources/europe/be/UrbIS_OrthoPhoto.geojson
@@ -283,7 +283,7 @@
         "privacy_policy_url": "https://bric.brussels/en/disclaimer-conditions-of-use-of-the-bric-website",
         "name": "CIRB/CIBG most recent aerial imagery",
         "type": "wms",
-        "url": "https://geoservices-urbis.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
+        "url": "https://geoservices-grid.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
     },
     "type": "Feature"
 }

--- a/sources/europe/be/UrbIS_OrthoPhoto2009.geojson
+++ b/sources/europe/be/UrbIS_OrthoPhoto2009.geojson
@@ -283,7 +283,7 @@
         "privacy_policy_url": "https://bric.brussels/en/disclaimer-conditions-of-use-of-the-bric-website",
         "start_date": "2009",
         "type": "wms",
-        "url": "https://geoservices-urbis.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2009&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
+        "url": "https://geoservices-grid.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2009&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
     },
     "type": "Feature"
 }

--- a/sources/europe/be/UrbIS_OrthoPhoto2012.geojson
+++ b/sources/europe/be/UrbIS_OrthoPhoto2012.geojson
@@ -283,7 +283,7 @@
         "privacy_policy_url": "https://bric.brussels/en/disclaimer-conditions-of-use-of-the-bric-website",
         "start_date": "2012",
         "type": "wms",
-        "url": "https://geoservices-urbis.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2012&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
+        "url": "https://geoservices-grid.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2012&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
     },
     "type": "Feature"
 }

--- a/sources/europe/be/UrbIS_OrthoPhoto2014.geojson
+++ b/sources/europe/be/UrbIS_OrthoPhoto2014.geojson
@@ -283,7 +283,7 @@
         "privacy_policy_url": "https://bric.brussels/en/disclaimer-conditions-of-use-of-the-bric-website",
         "start_date": "2014",
         "type": "wms",
-        "url": "https://geoservices-urbis.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2014&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
+        "url": "https://geoservices-grid.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2014&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
     },
     "type": "Feature"
 }

--- a/sources/europe/be/UrbIS_OrthoPhoto2015.geojson
+++ b/sources/europe/be/UrbIS_OrthoPhoto2015.geojson
@@ -283,7 +283,7 @@
         "privacy_policy_url": "https://bric.brussels/en/disclaimer-conditions-of-use-of-the-bric-website",
         "start_date": "2015",
         "type": "wms",
-        "url": "https://geoservices-urbis.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2015&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
+        "url": "https://geoservices-grid.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2015&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
     },
     "type": "Feature"
 }

--- a/sources/europe/be/UrbIS_OrthoPhoto2016.geojson
+++ b/sources/europe/be/UrbIS_OrthoPhoto2016.geojson
@@ -285,7 +285,7 @@
         "name": "UrbIS-Ortho 2016",
         "start_date": "2016",
         "type": "wms",
-        "url": "https://geoservices-urbis.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2016&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
+        "url": "https://geoservices-grid.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2016&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
     },
     "type": "Feature"
 }

--- a/sources/europe/be/UrbIS_OrthoPhoto2017.geojson
+++ b/sources/europe/be/UrbIS_OrthoPhoto2017.geojson
@@ -284,7 +284,7 @@
         "name": "UrbIS-Ortho 2017",
         "start_date": "2017",
         "type": "wms",
-        "url": "https://geoservices-urbis.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2017&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
+        "url": "https://geoservices-grid.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2017&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
     },
     "type": "Feature"
 }

--- a/sources/europe/be/UrbIS_OrthoPhoto2018.geojson
+++ b/sources/europe/be/UrbIS_OrthoPhoto2018.geojson
@@ -284,7 +284,7 @@
         "name": "UrbIS-Ortho 2018",
         "start_date": "2018",
         "type": "wms",
-        "url": "https://geoservices-urbis.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2018&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
+        "url": "https://geoservices-grid.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2018&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
     },
     "type": "Feature"
 }

--- a/sources/europe/be/UrbIS_OrthoPhoto2019.geojson
+++ b/sources/europe/be/UrbIS_OrthoPhoto2019.geojson
@@ -284,7 +284,7 @@
         "name": "UrbIS-Ortho 2019",
         "start_date": "2019",
         "type": "wms",
-        "url": "https://geoservices-urbis.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2019&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
+        "url": "https://geoservices-grid.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2019&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
     },
     "type": "Feature"
 }

--- a/sources/europe/be/UrbIS_OrthoPhoto2020.geojson
+++ b/sources/europe/be/UrbIS_OrthoPhoto2020.geojson
@@ -284,7 +284,7 @@
         "name": "UrbIS-Ortho 2020",
         "start_date": "2020",
         "type": "wms",
-        "url": "https://geoservices-urbis.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2020&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
+        "url": "https://geoservices-grid.irisnet.be/geoserver/urbisgrid/ows?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=Ortho2020&WIDTH={width}&HEIGHT={height}&CRS={proj}&STYLES=&BBOX={bbox}"
     },
     "type": "Feature"
 }


### PR DESCRIPTION
The old geoservices-urbis.irisnet.be domain is being decommissioned at end of June 2026. New endpoints per Paradigm (service owner):
- Orthophotos (urbisgrid): geoservices-grid.irisnet.be
- BaseMaps (vector): geoservices-basemap.irisnet.be

Fixes: #2979