### PR TITLE
Fix broken source URLs: Solano .gov migration, dead icons, Poland Geoportal privacy/terms

### DIFF
--- a/sources/europe/pl/Geoportal2-PL-squares-and-housing-estates_WMS.geojson
+++ b/sources/europe/pl/Geoportal2-PL-squares-and-housing-estates_WMS.geojson
@@ -23,14 +23,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "other",
         "overlay": true,
         "transparent": true

--- a/sources/europe/pl/Geoportal2ArchivalOrthophotomap(aerialimage)_WMS.geojson
+++ b/sources/europe/pl/Geoportal2ArchivalOrthophotomap(aerialimage)_WMS.geojson
@@ -24,14 +24,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "historicphoto"
     },
     "geometry": {

--- a/sources/europe/pl/Geoportal2ArchivalOrthophotomapHighQuality(aerialimage)_WMS.geojson
+++ b/sources/europe/pl/Geoportal2ArchivalOrthophotomapHighQuality(aerialimage)_WMS.geojson
@@ -19,14 +19,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "historicphoto"
     },
     "geometry": {

--- a/sources/europe/pl/Geoportal2EwidencjabudynkówWMS.geojson
+++ b/sources/europe/pl/Geoportal2EwidencjabudynkówWMS.geojson
@@ -23,14 +23,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "other",
         "overlay": true,
         "transparent": true

--- a/sources/europe/pl/Geoportal2Ewidencjagruntów.geojson
+++ b/sources/europe/pl/Geoportal2Ewidencjagruntów.geojson
@@ -23,14 +23,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "other",
         "overlay": true,
         "transparent": true

--- a/sources/europe/pl/Geoportal2Nazwyulic.geojson
+++ b/sources/europe/pl/Geoportal2Nazwyulic.geojson
@@ -23,14 +23,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "other",
         "overlay": true,
         "transparent": true

--- a/sources/europe/pl/Geoportal2Orthophotomap(aerialimage)_WMS.geojson
+++ b/sources/europe/pl/Geoportal2Orthophotomap(aerialimage)_WMS.geojson
@@ -24,14 +24,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "photo"
     },
     "geometry": {

--- a/sources/europe/pl/Geoportal2Orthophotomap(aerialimage)_WMTS.geojson
+++ b/sources/europe/pl/Geoportal2Orthophotomap(aerialimage)_WMTS.geojson
@@ -15,10 +15,10 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "photo"
     },
     "geometry": {

--- a/sources/europe/pl/Geoportal2OrthophotomapHighQuality(aerialimage)_WMS.geojson
+++ b/sources/europe/pl/Geoportal2OrthophotomapHighQuality(aerialimage)_WMS.geojson
@@ -19,14 +19,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "photo"
     },
     "geometry": {

--- a/sources/europe/pl/Geoportal2PRNG(geonames).geojson
+++ b/sources/europe/pl/Geoportal2PRNG(geonames).geojson
@@ -28,7 +28,7 @@
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "other"
     },
     "geometry": {

--- a/sources/europe/pl/Geoportal2Punktyadresowe.geojson
+++ b/sources/europe/pl/Geoportal2Punktyadresowe.geojson
@@ -23,14 +23,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "other",
         "overlay": true,
         "transparent": true

--- a/sources/europe/pl/Geoportal2_Granice_gmin_WMS.geojson
+++ b/sources/europe/pl/Geoportal2_Granice_gmin_WMS.geojson
@@ -23,14 +23,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "other",
         "overlay": true,
         "transparent": true

--- a/sources/europe/pl/Geoportal2_Granice_miast_WMS.geojson
+++ b/sources/europe/pl/Geoportal2_Granice_miast_WMS.geojson
@@ -19,14 +19,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "other",
         "overlay": true,
         "transparent": true

--- a/sources/europe/pl/Geoportal2_Granice_panstwa_WMS.geojson
+++ b/sources/europe/pl/Geoportal2_Granice_panstwa_WMS.geojson
@@ -23,14 +23,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "other",
         "overlay": true,
         "transparent": true

--- a/sources/europe/pl/Geoportal2_Granice_powiatow_WMS.geojson
+++ b/sources/europe/pl/Geoportal2_Granice_powiatow_WMS.geojson
@@ -23,14 +23,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "other",
         "overlay": true,
         "transparent": true

--- a/sources/europe/pl/Geoportal2_Granice_wojewodztw_WMS.geojson
+++ b/sources/europe/pl/Geoportal2_Granice_wojewodztw_WMS.geojson
@@ -23,14 +23,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "other",
         "overlay": true,
         "transparent": true

--- a/sources/europe/pl/Geoportal2_ShadedRelief_WMS.geojson
+++ b/sources/europe/pl/Geoportal2_ShadedRelief_WMS.geojson
@@ -23,14 +23,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "elevation"
     },
     "geometry": {

--- a/sources/europe/pl/Geoportal2_przewod_cieplowniczy_WMS.geojson
+++ b/sources/europe/pl/Geoportal2_przewod_cieplowniczy_WMS.geojson
@@ -23,14 +23,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "other",
         "overlay": true,
         "transparent": true

--- a/sources/europe/pl/Geoportal2_przewod_elektroenergetyczny_WMS.geojson
+++ b/sources/europe/pl/Geoportal2_przewod_elektroenergetyczny_WMS.geojson
@@ -23,14 +23,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "other",
         "overlay": true,
         "transparent": true

--- a/sources/europe/pl/Geoportal2_przewod_gazowy_WMS.geojson
+++ b/sources/europe/pl/Geoportal2_przewod_gazowy_WMS.geojson
@@ -23,14 +23,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "other",
         "overlay": true,
         "transparent": true

--- a/sources/europe/pl/Geoportal2_przewod_kanalizacyjny_WMS.geojson
+++ b/sources/europe/pl/Geoportal2_przewod_kanalizacyjny_WMS.geojson
@@ -23,14 +23,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "other",
         "overlay": true,
         "transparent": true

--- a/sources/europe/pl/Geoportal2_przewod_telekomunikacyjny_WMS.geojson
+++ b/sources/europe/pl/Geoportal2_przewod_telekomunikacyjny_WMS.geojson
@@ -23,14 +23,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "other",
         "overlay": true,
         "transparent": true

--- a/sources/europe/pl/Geoportal2_przewod_wodociagowy_WMS.geojson
+++ b/sources/europe/pl/Geoportal2_przewod_wodociagowy_WMS.geojson
@@ -23,14 +23,14 @@
             "required": true
         },
         "icon": "https://wiki.openstreetmap.org/w/images/f/fd/Geoportal2.png",
-        "terms-of-use-text": "https://geoportal.gov.pl/web/guest/regulamin",
+        "terms-of-use-text": "https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/Geoportal.gov.pl",
         "custom-http-headers": {
             "header-name": "User-Agent",
             "header-value": "Mozilla/5.0 (JOSM)"
         },
-        "privacy_policy_url": "https://www.geoportal.gov.pl/ciasteczka-cookies-",
+        "privacy_policy_url": "https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/",
         "category": "other",
         "overlay": true,
         "transparent": true

--- a/sources/north-america/us/ca/Sacramento_CA_2022.geojson
+++ b/sources/north-america/us/ca/Sacramento_CA_2022.geojson
@@ -8,7 +8,7 @@
             "required": false
         },
         "name": "Sacramento County Orthoimagery (2022)",
-        "icon": "https://www.saccounty.gov/SiteAssets/responsive/img/logo.png",
+        "icon": "https://www.saccounty.gov/content/dam/saccounty/us/en/images/logo-standard.png",
         "url": "https://mapservices.gis.saccounty.gov/ArcGIS/rest/services/Cache/IMAGERY_2022_WEB_MERCATOR/MapServer/tile/{zoom}/{y}/{x}",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/California#Publicly_Available_Data",

--- a/sources/north-america/us/ca/Solano_CA_2022.geojson
+++ b/sources/north-america/us/ca/Solano_CA_2022.geojson
@@ -3,12 +3,12 @@
     "properties": {
         "id": "Solano_CA_2022",
         "attribution": {
-            "url": "https://www.solanocounty.com/",
+            "url": "https://www.solanocounty.gov/",
             "text": "Solano County",
             "required": false
         },
         "name": "Solano County Orthoimagery (2022)",
-        "icon": "https://www.solanocounty.com/images/depts/CountyAdministrator/TransparentGIF(400x400).gif",
+        "icon": "https://www.solanocounty.gov/static/CF_Main_Color_logo_3x.png",
         "url": "https://tiles.arcgis.com/tiles/SCn6czzcqKAFwdGU/arcgis/rest/services/Aerial2022_WGS84_ESRI_Aux/MapServer/tile/{zoom}/{y}/{x}",
         "max_zoom": 23,
         "license_url": "https://wiki.openstreetmap.org/wiki/California#Publicly_Available_Data",

--- a/sources/north-america/us/ca/Solano_CA_2023.geojson
+++ b/sources/north-america/us/ca/Solano_CA_2023.geojson
@@ -3,12 +3,12 @@
     "properties": {
         "id": "Solano_CA_2023",
         "attribution": {
-            "url": "https://www.solanocounty.com/",
+            "url": "https://www.solanocounty.gov/",
             "text": "Solano County",
             "required": false
         },
         "name": "Solano County Orthoimagery (2023)",
-        "icon": "https://www.solanocounty.com/images/depts/CountyAdministrator/TransparentGIF(400x400).gif",
+        "icon": "https://www.solanocounty.gov/static/CF_Main_Color_logo_3x.png",
         "url": "https://tiles.arcgis.com/tiles/SCn6czzcqKAFwdGU/arcgis/rest/services/Aerial2023_WGS84_ESRI_Aux/MapServer/tile/{zoom}/{y}/{x}",
         "max_zoom": 21,
         "license_url": "https://wiki.openstreetmap.org/wiki/California#Publicly_Available_Data",

--- a/sources/north-america/us/ca/Solano_CA_2024.geojson
+++ b/sources/north-america/us/ca/Solano_CA_2024.geojson
@@ -3,12 +3,12 @@
     "properties": {
         "id": "Solano_CA_2024",
         "attribution": {
-            "url": "https://www.solanocounty.com/",
+            "url": "https://www.solanocounty.gov/",
             "text": "Solano County",
             "required": false
         },
         "name": "Solano County Orthoimagery (2024)",
-        "icon": "https://www.solanocounty.com/images/depts/CountyAdministrator/TransparentGIF(400x400).gif",
+        "icon": "https://www.solanocounty.gov/static/CF_Main_Color_logo_3x.png",
         "url": "https://tiles.arcgis.com/tiles/SCn6czzcqKAFwdGU/arcgis/rest/services/Aerial2024_WGS84/MapServer/tile/{zoom}/{y}/{x}",
         "max_zoom": 21,
         "license_url": "https://wiki.openstreetmap.org/wiki/California#Publicly_Available_Data",

--- a/sources/north-america/us/ca/Solano_CA_2025.geojson
+++ b/sources/north-america/us/ca/Solano_CA_2025.geojson
@@ -3,12 +3,12 @@
     "properties": {
         "id": "Solano_CA_2025",
         "attribution": {
-            "url": "https://www.solanocounty.com/",
+            "url": "https://www.solanocounty.gov/",
             "text": "Solano County",
             "required": false
         },
         "name": "Solano County Orthoimagery (2025)",
-        "icon": "https://www.solanocounty.com/images/depts/CountyAdministrator/TransparentGIF(400x400).gif",
+        "icon": "https://www.solanocounty.gov/static/CF_Main_Color_logo_3x.png",
         "url": "https://tiles.arcgis.com/tiles/SCn6czzcqKAFwdGU/arcgis/rest/services/Aerial2025_WGS84/MapServer/tile/{zoom}/{y}/{x}",
         "max_zoom": 21,
         "license_url": "https://wiki.openstreetmap.org/wiki/California#Publicly_Available_Data",


### PR DESCRIPTION
## Summary

Updates broken URLs across 28 source files in three groups. Each change is a mechanical find-and-replace to a working endpoint.

### Solano County domain migration (4 files)

Solano County moved from `solanocounty.com` to `solanocounty.gov`. Updated both the attribution URL and the icon URL for all yearly variants (`2022`–`2025`).

- **Old icon:** `https://www.solanocounty.com/images/depts/CountyAdministrator/TransparentGIF(400x400).gif` → **New icon:** `https://www.solanocounty.gov/static/CF_Main_Color_logo_3x.png`
- **Old attribution:** `https://www.solanocounty.com/` → **New attribution:** `https://www.solanocounty.gov/`

### Sacramento County dead icon (1 file)

- **Old icon:** `https://www.saccounty.gov/SiteAssets/responsive/img/logo.png` (404) → **New icon:** `https://www.saccounty.gov/content/dam/saccounty/us/en/images/logo-standard.png`

### Poland Geoportal metadata URLs (23 files: 22 WMS + 1 WMTS)

Updated stale privacy policy and terms-of-use URLs across all Geoportal sources.

- **Old privacy:** `https://www.geoportal.gov.pl/ciasteczka-cookies-` → **New privacy:** `https://www.geoportal.gov.pl/pl/o-geoportalu/polityka-prywatnosci/`
- **Old terms:** `https://geoportal.gov.pl/web/guest/regulamin` → **New terms:** `https://www.geoportal.gov.pl/pl/o-geoportalu/regulamin/`

## Changed files

28 files, 54 insertions(+), 54 deletions(-) — no structural or metadata changes beyond URL replacements.

## Validation

`scripts/strict_check.py` passes for all changed files. Poland Geoportal sources depend on the geoportal.gov.pl server which is known to be occasionally flaky and may cause transient CI failures unrelated to the URL changes.

## Disclosure

This PR was prepared by Kimi K2.6 with human oversight. The URL changes were verified against live endpoints and repository validation scripts.