### PR TITLE
Mark Eureka, CA 2023 orthoimagery as "best"

### DIFF
--- a/sources/north-america/us/ca/Eureka_CA_2023.geojson
+++ b/sources/north-america/us/ca/Eureka_CA_2023.geojson
@@ -7,6 +7,7 @@
             "text": "City of Eureka",
             "required": false
         },
+        "best": true,
         "name": "City of Eureka Orthoimagery (2023)",
         "icon": "https://www.eurekaca.gov/ImageRepository/Document?documentID=66",
         "url": "https://arcgis-svr.ci.eureka.ca.gov/arcgis/rest/services/2023_mosaic/ImageServer/exportImage?f=image&format=jpg&bbox={bbox}&bboxSR={wkid}&imageSR={wkid}&size={width},{height}",


### PR DESCRIPTION
The imagery for Eureka, California is one year newer and significantly higher resolution than any base imagery (Bing, Esri, Esri Clarity, or Mapbox) and so is a good candidate for marking as best.