### PR TITLE
Update Trafikverket NVDB url

### DIFF
--- a/sources/europe/se/trafikverket-nvdb-extra.geojson
+++ b/sources/europe/se/trafikverket-nvdb-extra.geojson
@@ -16,7 +16,7 @@
             "text": "© Trafikverket, CC0",
             "url": "https://www.trafikverket.se"
         },
-        "license_url": "https://api.trafikinfo.trafikverket.se/DynamicContent/ContentDetails/58e384810bb22118e8041667",
+        "license_url": "https://www.trafikverket.se/e-tjanster/hamta-data-fran-trafikverket/",
         "privacy_policy_url": "https://bransch.trafikverket.se/en/startpage/about-us/Trafikverket/About-the-website/Legal-information/this-is-how-trafikverket-works-with-the-general-data-protection-ordinance-gdpr/",
         "overlay": true,
         "available_projections": [

--- a/sources/europe/se/trafikverket-nvdb-extra.geojson
+++ b/sources/europe/se/trafikverket-nvdb-extra.geojson
@@ -7,7 +7,7 @@
         "id": "trafikverket-vagnat-extra",
         "country_code": "SE",
         "description": "Swedish NVDB extra details: Highway reference, traffic calming, rest area, bus stop, bridge, tunnel, speed camera",
-        "url": "https://geo-netinfo.trafikverket.se/mapservice/wms.axd/NetInfo?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=Vagnummer,Vaghinder,Rastplats,Hallplats,Farthinder,BroTunnel,ATK_Matplats&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://geo-netinfo.trafikverket.se/mapservice/wms.axd/NetInfo?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&  =Vagnummer,Vaghinder,Hallplats,Farthinder,BroTunnel,ATK_Matplats&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "icon": "https://data.trafikverket.se/assets/img/favicon/apple-touch-icon-144x144.png",
         "min_zoom": 3,
         "max_zoom": 20,

--- a/sources/europe/se/trafikverket-nvdb-extra.geojson
+++ b/sources/europe/se/trafikverket-nvdb-extra.geojson
@@ -7,8 +7,8 @@
         "id": "trafikverket-vagnat-extra",
         "country_code": "SE",
         "description": "Swedish NVDB extra details: Highway reference, traffic calming, rest area, bus stop, bridge, tunnel, speed camera",
-        "url": "https://geo-netinfo.trafikverket.se/mapservice/wms.axd/NetInfo_1_5?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=Vagnummer,Vaghinder,Rastplats,Hallplats,Farthinder,BroTunnel,ATK_Matplats&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
-        "icon": "https://api.trafikinfo.trafikverket.se/img/apple-touch-icon-144-precomposed.png",
+        "url": "https://geo-netinfo.trafikverket.se/mapservice/wms.axd/NetInfo?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=Vagnummer,Vaghinder,Rastplats,Hallplats,Farthinder,BroTunnel,ATK_Matplats&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "icon": "https://data.trafikverket.se/assets/img/favicon/apple-touch-icon-144x144.png",
         "min_zoom": 3,
         "max_zoom": 20,
         "attribution": {

--- a/sources/europe/se/trafikverket-nvdb-extra.geojson
+++ b/sources/europe/se/trafikverket-nvdb-extra.geojson
@@ -7,7 +7,7 @@
         "id": "trafikverket-vagnat-extra",
         "country_code": "SE",
         "description": "Swedish NVDB extra details: Highway reference, traffic calming, rest area, bus stop, bridge, tunnel, speed camera",
-        "url": "https://geo-netinfo.trafikverket.se/mapservice/wms.axd/NetInfo?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&  =Vagnummer,Vaghinder,Hallplats,Farthinder,BroTunnel,ATK_Matplats&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
+        "url": "https://geo-netinfo.trafikverket.se/mapservice/wms.axd/NetInfo_1_8?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=Vagnummer,Vaghinder,Rastplats,Hallplats,Farthinder,BroTunnel,ATK_Matplats&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "icon": "https://data.trafikverket.se/assets/img/favicon/apple-touch-icon-144x144.png",
         "min_zoom": 3,
         "max_zoom": 20,

--- a/sources/europe/se/trafikverket-nvdb-main.geojson
+++ b/sources/europe/se/trafikverket-nvdb-main.geojson
@@ -16,7 +16,7 @@
             "text": "© Trafikverket, CC0",
             "url": "https://www.trafikverket.se"
         },
-        "license_url": "https://api.trafikinfo.trafikverket.se/DynamicContent/ContentDetails/58e384810bb22118e8041667",
+        "license_url": "https://www.trafikverket.se/e-tjanster/hamta-data-fran-trafikverket/",
         "privacy_policy_url": "https://bransch.trafikverket.se/en/startpage/about-us/Trafikverket/About-the-website/Legal-information/this-is-how-trafikverket-works-with-the-general-data-protection-ordinance-gdpr/",
         "overlay": true,
         "available_projections": [

--- a/sources/europe/se/trafikverket-nvdb-main.geojson
+++ b/sources/europe/se/trafikverket-nvdb-main.geojson
@@ -7,7 +7,7 @@
         "id": "trafikverket-vagnat",
         "country_code": "SE",
         "description": "Swedish NVDB road network",
-        "url": "https://geo-netinfo.trafikverket.se/mapservice/wms.axd/NetInfo?LAYERS=Vagtrafiknat,Funkvagklass,Farjeled&STYLES=&FORMAT=image/png&TRANSPARENT=TRUE&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "url": "https://geo-netinfo.trafikverket.se/mapservice/wms.axd/NetInfo_1_8?LAYERS=Vagtrafiknat,Funkvagklass,Farjeled&STYLES=&FORMAT=image/png&TRANSPARENT=TRUE&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
         "icon": "https://data.trafikverket.se/assets/img/favicon/apple-touch-icon-144x144.png",
         "min_zoom": 13,
         "max_zoom": 20,

--- a/sources/europe/se/trafikverket-nvdb-main.geojson
+++ b/sources/europe/se/trafikverket-nvdb-main.geojson
@@ -7,8 +7,8 @@
         "id": "trafikverket-vagnat",
         "country_code": "SE",
         "description": "Swedish NVDB road network",
-        "url": "https://geo-netinfo.trafikverket.se/mapservice/wms.axd/NetInfo_1_5?LAYERS=Vagtrafiknat,Funkvagklass,Farjeled&STYLES=&FORMAT=image/png&TRANSPARENT=TRUE&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
-        "icon": "https://api.trafikinfo.trafikverket.se/img/apple-touch-icon-144-precomposed.png",
+        "url": "https://geo-netinfo.trafikverket.se/mapservice/wms.axd/NetInfo?LAYERS=Vagtrafiknat,Funkvagklass,Farjeled&STYLES=&FORMAT=image/png&TRANSPARENT=TRUE&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap",
+        "icon": "https://data.trafikverket.se/assets/img/favicon/apple-touch-icon-144x144.png",
         "min_zoom": 13,
         "max_zoom": 20,
         "attribution": {

--- a/sources/europe/se/trafikverket-nvdb-options.geojson
+++ b/sources/europe/se/trafikverket-nvdb-options.geojson
@@ -7,7 +7,7 @@
         "id": "trafikverket-vagnat-option",
         "country_code": "SE",
         "description": "Swedish NVDB road network with several options for map layers",
-        "url": "https://geo-netinfo.trafikverket.se/mapservice/wms.axd/NetInfo?service=wms&request=getCapabilities",
+        "url": "https://geo-netinfo.trafikverket.se/mapservice/wms.axd/NetInfo_1_8?service=wms&request=getCapabilities",
         "icon": "https://data.trafikverket.se/assets/img/favicon/apple-touch-icon-144x144.png",
         "min_zoom": 3,
         "max_zoom": 20,

--- a/sources/europe/se/trafikverket-nvdb-options.geojson
+++ b/sources/europe/se/trafikverket-nvdb-options.geojson
@@ -7,8 +7,8 @@
         "id": "trafikverket-vagnat-option",
         "country_code": "SE",
         "description": "Swedish NVDB road network with several options for map layers",
-        "url": "https://geo-netinfo.trafikverket.se/mapservice/wms.axd/NetInfo_1_5?service=wms&request=getCapabilities",
-        "icon": "https://api.trafikinfo.trafikverket.se/img/apple-touch-icon-144-precomposed.png",
+        "url": "https://geo-netinfo.trafikverket.se/mapservice/wms.axd/NetInfo?service=wms&request=getCapabilities",
+        "icon": "https://data.trafikverket.se/assets/img/favicon/apple-touch-icon-144x144.png",
         "min_zoom": 3,
         "max_zoom": 20,
         "attribution": {

--- a/sources/europe/se/trafikverket-nvdb-options.geojson
+++ b/sources/europe/se/trafikverket-nvdb-options.geojson
@@ -16,7 +16,7 @@
             "text": "© Trafikverket, CC0",
             "url": "https://www.trafikverket.se"
         },
-        "license_url": "https://api.trafikinfo.trafikverket.se/DynamicContent/ContentDetails/58e384810bb22118e8041667",
+        "license_url": "https://www.trafikverket.se/e-tjanster/hamta-data-fran-trafikverket/",
         "privacy_policy_url": "https://bransch.trafikverket.se/en/startpage/about-us/Trafikverket/About-the-website/Legal-information/this-is-how-trafikverket-works-with-the-general-data-protection-ordinance-gdpr/",
         "overlay": true,
         "category": "other"


### PR DESCRIPTION
Removed `_1_5` from the url.
Syncs with JOSM.
Tested as custom layer in ID editor and confirmed it worked.

Also updated the URL for the icon.