### PR TITLE
fix(de): migrate dead Saxony attribution URLs to GeoMIS

### DIFF
--- a/sources/europe/de/Saxony-DOP20-historic-2005.geojson
+++ b/sources/europe/de/Saxony-DOP20-historic-2005.geojson
@@ -4,7 +4,7 @@
         "attribution": {
             "required": true,
             "text": "Staatsbetrieb Geobasisinformation und Vermessung Sachsen",
-            "url": "https://geoportal.sachsen.de/cps/metadaten_seite.html?id=3f38c3f3-03db-4a2a-b6da-2704b9a1d5f0"
+            "url": "https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/3f38c3f3-03db-4a2a-b6da-2704b9a1d5f0"
         },
         "available_projections": [
             "CRS:84",

--- a/sources/europe/de/Saxony-DOP20-historic-2006-2008.geojson
+++ b/sources/europe/de/Saxony-DOP20-historic-2006-2008.geojson
@@ -4,7 +4,7 @@
         "attribution": {
             "required": true,
             "text": "Staatsbetrieb Geobasisinformation und Vermessung Sachsen",
-            "url": "https://geoportal.sachsen.de/cps/metadaten_seite.html?id=64943fad-2794-49a3-806b-64b4247a847e"
+            "url": "https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/64943fad-2794-49a3-806b-64b4247a847e"
         },
         "available_projections": [
             "EPSG:2180",

--- a/sources/europe/de/Saxony-DOP20-historic-2009-2011.geojson
+++ b/sources/europe/de/Saxony-DOP20-historic-2009-2011.geojson
@@ -4,7 +4,7 @@
         "attribution": {
             "required": true,
             "text": "Staatsbetrieb Geobasisinformation und Vermessung Sachsen",
-            "url": "https://geoportal.sachsen.de/cps/metadaten_seite.html?id=13c6d72f-af11-48c6-b3bb-c669f4a4d1c1"
+            "url": "https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/13c6d72f-af11-48c6-b3bb-c669f4a4d1c1"
         },
         "available_projections": [
             "EPSG:2180",

--- a/sources/europe/de/Saxony-DOP20-historic-2012-2014.geojson
+++ b/sources/europe/de/Saxony-DOP20-historic-2012-2014.geojson
@@ -4,7 +4,7 @@
         "attribution": {
             "required": true,
             "text": "Staatsbetrieb Geobasisinformation und Vermessung Sachsen",
-            "url": "https://geoportal.sachsen.de/cps/metadaten_seite.html?id=8c276e3c-88af-462f-8128-6900bc7dd4f8"
+            "url": "https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/8c276e3c-88af-462f-8128-6900bc7dd4f8"
         },
         "available_projections": [
             "EPSG:2180",

--- a/sources/europe/de/Saxony-DOP20-historic-2015-2017.geojson
+++ b/sources/europe/de/Saxony-DOP20-historic-2015-2017.geojson
@@ -4,7 +4,7 @@
         "attribution": {
             "required": true,
             "text": "Staatsbetrieb Geobasisinformation und Vermessung Sachsen",
-            "url": "https://geoportal.sachsen.de/cps/metadaten_seite.html?id=8dbabd0c-b357-49e5-9b10-b792620159e5"
+            "url": "https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/8dbabd0c-b357-49e5-9b10-b792620159e5"
         },
         "available_projections": [
             "EPSG:2180",

--- a/sources/europe/de/Saxony-DOP20-historic-2023-2024.geojson
+++ b/sources/europe/de/Saxony-DOP20-historic-2023-2024.geojson
@@ -4,7 +4,7 @@
         "attribution": {
             "required": true,
             "text": "Staatsbetrieb Geobasisinformation und Vermessung Sachsen",
-            "url": "https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/8fe04e3b-e444-407f-bf4a-531751132899"
+            "url": "https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/d21e8bbb-5ff5-4c9c-b6dd-da18122edbf8"
         },
         "available_projections": [
             "EPSG:2180",

--- a/sources/europe/de/Saxony-DOP20-latest-infrared.geojson
+++ b/sources/europe/de/Saxony-DOP20-latest-infrared.geojson
@@ -4,7 +4,7 @@
         "attribution": {
             "required": true,
             "text": "Staatsbetrieb Geobasisinformation und Vermessung Sachsen",
-            "url": "https://geoportal.sachsen.de/cps/metadaten_portal.html?id=ba87bbed-4cb5-4539-a9f5-f863de752f52"
+            "url": "https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/ba87bbed-4cb5-4539-a9f5-f863de752f52"
         },
         "available_projections": [
             "CRS:84",

--- a/sources/europe/de/Saxony-DOP20-latest.geojson
+++ b/sources/europe/de/Saxony-DOP20-latest.geojson
@@ -4,7 +4,7 @@
         "attribution": {
             "required": true,
             "text": "Staatsbetrieb Geobasisinformation und Vermessung Sachsen",
-            "url": "https://geoportal.sachsen.de/cps/metadaten_seite.html?id=26df8686-08cd-4dc2-b459-4d51b9badfe8"
+            "url": "https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/26df8686-08cd-4dc2-b459-4d51b9badfe8"
         },
         "available_projections": [
             "CRS:84",

--- a/sources/europe/de/Saxony-DOP20-raw.geojson
+++ b/sources/europe/de/Saxony-DOP20-raw.geojson
@@ -4,7 +4,7 @@
         "attribution": {
             "required": true,
             "text": "Staatsbetrieb Geobasisinformation und Vermessung Sachsen",
-            "url": "https://geoportal.sachsen.de/cps/metadaten_seite.html?id=0fe7859e-a5e0-4e8d-a48a-ce29db7b5717"
+            "url": "https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/0fe7859e-a5e0-4e8d-a48a-ce29db7b5717"
         },
         "available_projections": [
             "EPSG:2180",

--- a/sources/europe/de/Saxony-WebAtlasSN.geojson
+++ b/sources/europe/de/Saxony-WebAtlasSN.geojson
@@ -4,7 +4,7 @@
         "attribution": {
             "required": true,
             "text": "Staatsbetrieb Geobasisinformation und Vermessung Sachsen",
-            "url": "https://geoportal.sachsen.de/cps/metadaten_portal.html?id=475a9197-620f-4dcb-b8aa-7f71b626443f"
+            "url": "https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/475a9197-620f-4dcb-b8aa-7f71b626443f"
         },
         "available_projections": [
             "EPSG:3034",

--- a/sources/europe/de/Saxony-borders-and-parcels.geojson
+++ b/sources/europe/de/Saxony-borders-and-parcels.geojson
@@ -4,7 +4,7 @@
         "attribution": {
             "required": true,
             "text": "Staatsbetrieb Geobasisinformation und Vermessung Sachsen",
-            "url": "https://geoportal.sachsen.de/cps/metadaten_seite.html?id=a55d5e28-998a-4d8f-916d-33f922381d1a"
+            "url": "https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/a55d5e28-998a-4d8f-916d-33f922381d1a"
         },
         "available_projections": [
             "CRS:84",

--- a/sources/europe/de/Saxony-digitalterrainmodel-contour-lines.geojson
+++ b/sources/europe/de/Saxony-digitalterrainmodel-contour-lines.geojson
@@ -4,7 +4,7 @@
         "attribution": {
             "required": true,
             "text": "Staatsbetrieb Geobasisinformation und Vermessung Sachsen",
-            "url": "https://geoportal.sachsen.de/cps/metadaten_seite.html?id=5e0f6071-008e-4d57-810e-48a8362acf04"
+            "url": "https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/5e0f6071-008e-4d57-810e-48a8362acf04"
         },
         "available_projections": [
             "EPSG:2180",

--- a/sources/europe/de/Saxony-digitalterrainmodel-ground.geojson
+++ b/sources/europe/de/Saxony-digitalterrainmodel-ground.geojson
@@ -4,7 +4,7 @@
         "attribution": {
             "required": true,
             "text": "Staatsbetrieb Geobasisinformation und Vermessung Sachsen",
-            "url": "https://geoportal.sachsen.de/cps/metadaten_seite.html?id=5e0f6071-008e-4d57-810e-48a8362acf04"
+            "url": "https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/5e0f6071-008e-4d57-810e-48a8362acf04"
         },
         "available_projections": [
             "EPSG:2180",


### PR DESCRIPTION
Fixes #3006.

GeoSN has moved its metadata catalogue from `geoportal.sachsen.de` to GeoMIS Sachsen. The old `metadaten_seite.html` / `metadaten_portal.html` pages now return HTTP 404, so the attribution links on the Saxony sources lead nowhere.

The three most recently added Saxony sources already use the new `geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/<uuid>` form, and GeoMIS keeps the same record UUIDs — so this is a host/path migration with the UUID left untouched in every case.

### Scope

The issue lists four files; the same dead pattern is on **12**. This PR changes **13 files** in total (the 12 below, plus one further correction noted at the end).

| pattern | files |
|---|---|
| `metadaten_seite.html` | `historic-2005`, `historic-2006-2008`, `historic-2009-2011`, `historic-2012-2014`, `historic-2015-2017`, `latest`, `raw`, `borders-and-parcels`, `digitalterrainmodel-ground`, `digitalterrainmodel-contour-lines` |
| `metadaten_portal.html` | `latest-infrared`, `WebAtlasSN` |

All four files named in the issue are included.

### Verification

Before rewriting anything, **each UUID was looked up individually** in the GeoMIS catalogue index (`geomis-iso/iso/select?q=id:<uuid>`) to confirm it resolves to the dataset the layer actually describes. All 12 resolved, and every returned title matched its layer — for example:

| UUID | GeoMIS title | source |
|---|---|---|
| `26df8686…` | WMS SN DOP-RGB | `Saxony-DOP20-latest` |
| `ba87bbed…` | WMS SN DOP-CIR | `Saxony-DOP20-latest-infrared` |
| `0fe7859e…` | WMS SN QUICK-DOP-RGB | `Saxony-DOP20-raw` |
| `a55d5e28…` | Flurstücke und Gemarkungen | `Saxony-borders-and-parcels` |
| `5e0f6071…` | Höheninformationen Sachsen | `Saxony-digitalterrainmodel-ground` |

Fetching every attribution URL with the CI's own User-Agent (`Mozilla/5.0 (compatible; MSIE 6.0; OpenStreetMap Editor Layer Index CI check)`), before and after the change: **12 of 13 returned 404 before, and 13 of 13 return 200 after.**

`scripts/check.py` passes over all 1666 sources.

### One further correction — separable

`Saxony-DOP20-historic-2023-2024.geojson` was already on a working GeoMIS URL, but pointed at `8fe04e3b-e444-407f-bf4a-531751132899` — the *Historische DOP 2021-2022* record, the same one the 2021-2022 source uses. The catalogue has a distinct `d21e8bbb-5ff5-4c9c-b6dd-da18122edbf8` → *Historische DOP 2023-2024*, so that one line is corrected here too.

It is a wrong link rather than a dead one, so it falls outside the literal scope of #3006. Happy to split it into its own PR if you'd prefer to keep this one to the migration.

### Why these could go stale unnoticed

`strict_check.py` never flags a broken attribution URL. `test_url()` returns a `(bool, int)` tuple, but line 943 tests it as `if not test_url(url, headers):` — a non-empty tuple is always truthy, so the branch is unreachable. The `privacy_policy_url` check on line 986 has the same shape.

That is a tooling change rather than a source fix, so it is **not** part of this PR — I am opening it separately.
