### PR TITLE
fix(scripts): unpack test_url() result so attribution and privacy-policy URL checks actually fire

### DIFF
--- a/scripts/strict_check.py
+++ b/scripts/strict_check.py
@@ -941,11 +941,12 @@ for filename in arguments.path:
             if "url" in source["properties"]["attribution"]:
                 url = source["properties"]["attribution"]["url"]
 
-                if not test_url(url, headers):
+                reachable, status_code = test_url(url, headers)
+                if not reachable:
                     messages.append(
                         Message(
                             level=MessageLevel.ERROR,
-                            message=f"{filename}: could not retrieve attribution url {url}.",
+                            message=f"{filename}: could not retrieve attribution url {url}: HTTP code: {status_code}",
                         )
                     )
 
@@ -983,11 +984,12 @@ for filename in arguments.path:
 
             if isinstance(source["properties"]["privacy_policy_url"], str):
                 # Check if privacy url exists
-                if not test_url(source["properties"]["privacy_policy_url"], headers):
+                reachable, status_code = test_url(source["properties"]["privacy_policy_url"], headers)
+                if not reachable:
                     messages.append(
                         Message(
                             level=MessageLevel.ERROR,
-                            message=f"{filename}: could not retrieve privacy policy url {source['properties']['privacy_policy_url']}.",
+                            message=f"{filename}: could not retrieve privacy policy url {source['properties']['privacy_policy_url']}: HTTP code: {status_code}",
                         )
                     )
             elif not isinstance(source["properties"]["privacy_policy_url"], str) and not (


### PR DESCRIPTION
`test_url()` returns a `(bool, int)` tuple, but both of its call sites test the return value directly:

```python
if not test_url(url, headers):
```

A non-empty tuple is always truthy, so `not test_url(...)` is always `False` and neither branch can be reached. The attribution-URL check (line 944) and the privacy-policy-URL check (line 986) have therefore never reported anything.

This unpacks both call sites explicitly and includes the status code in the message, matching the wording the `license_url` check just above already uses.

### Demonstration

Run against `sources/europe/de/Saxony-DOP20-latest.geojson`, whose attribution URL returns HTTP 404, on current `gh-pages`:

**Before**

```
INFO:root:Finished processing sources/europe/de/Saxony-DOP20-latest.geojson
```

**After**

```
ERROR:root:sources/europe/de/Saxony-DOP20-latest.geojson: could not retrieve attribution url https://geoportal.sachsen.de/cps/metadaten_seite.html?id=26df8686-08cd-4dc2-b459-4d51b9badfe8: HTTP code: 404
```

The full output is otherwise identical — one line differs. A source with a working attribution URL (`Saxony-DOP20-historic-2018-2020.geojson`, on GeoMIS) produces no new message, so this does not introduce false positives.

### Context

#3006 reported four Saxony sources with dead attribution URLs. The same dead pattern turned out to be on twelve, all returning 404, and none of them were ever flagged. That is what prompted this. The source-side migration is in #3041; this PR is only the tooling fix.
