### PR TITLE
fix(no): replace dead icon URLs for Fiskeridirektoratet and Kystverket

### DIFF
--- a/sources/europe/no/FiskeridirektoratetAquacultureoverlay.geojson
+++ b/sources/europe/no/FiskeridirektoratetAquacultureoverlay.geojson
@@ -7,7 +7,7 @@
         "description": "Aquaculture/marine farms (licensed sites, may not yet have any installations)",
         "overlay": true,
         "type": "wms",
-        "icon": "https://www.fiskeridir.no/_/asset/no.seeds.fiskeridir:0000019be524d150/images/icons/favicon-96x96.png",
+        "icon": "https://www.fiskeridir.no/_/image/434a88f5-6b85-43b4-b520-75010b48a8d6:2c71df53a881af3ee11e7b6b31ab98f8c3d45bdd/width-180/favicon-96x96.png",
         "url": "https://gis.fiskeridir.no/server/services/fiskeridirWMS_akva/MapServer/WMSServer?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=flate_ihht_akvakulturregisteret,akvakultur_lokaliteter&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "max_zoom": 22,
         "min_zoom": 3,

--- a/sources/europe/no/KystverketNavigationalAidoverlay.geojson
+++ b/sources/europe/no/KystverketNavigationalAidoverlay.geojson
@@ -7,7 +7,7 @@
         "description": "Beacons, buoys, lights and fairways maintained by the Norwegian Coastal Administration",
         "overlay": true,
         "type": "wms",
-        "icon": "https://www.kystverket.no/UI/favicon/safari-pinned-tab.svg",
+        "icon": "https://www.kystverket.no/UI/favicon/favicon.svg",
         "url": "https://nfs.kystverket.no/arcgis/services/nfs/NFSSistOperativ/MapServer/WMSServer?FORMAT=image/png&TRANSPARENT=TRUE&VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=13,12,10,8,6,5,4,3&STYLES=&CRS={proj}&WIDTH={width}&HEIGHT={height}&BBOX={bbox}",
         "max_zoom": 19,
         "min_zoom": 12,


### PR DESCRIPTION
Two icon URLs in `sources/europe/no/` return 404. Both are pre-existing — the old and
new `strict_check.py` report them identically, so this is unrelated to #3042.

**Fiskeridirektoratet Aquaculture overlay**
`.../_/asset/no.seeds.fiskeridir:0000019be524d150/images/icons/favicon-96x96.png` → 404.
The Enonic CMS changed its asset path format and the content hash no longer resolves.
Replaced with the current `rel="icon"` from the site head, same basename, same domain as
`attribution.url`. Note it serves 180×180 despite the filename: `/width-180/` in the path
is a CMS transform.

**Kystverket Navigational Aid overlay**
`/UI/favicon/safari-pinned-tab.svg` → 404. The directory still serves everything else;
this one file is gone, and `safari-pinned-tab` no longer appears in the page head at all —
retired rather than moved. Replaced with `/UI/favicon/favicon.svg`, the same directory and
the same format, which is the vector icon the site now declares.

Both replacements verified individually: HTTP 200, correct content type confirmed on the
downloaded bytes with `file`, non-zero size. Both stay on the agency's own domain, matching
`attribution.url`.

Only the `icon` field is touched. No other fields, no other files.
