### PR TITLE
Update Fairfax imagery URL

### DIFF
--- a/sources/north-america/us/va/Fairfax_VA_Most_Recent.geojson
+++ b/sources/north-america/us/va/Fairfax_VA_Most_Recent.geojson
@@ -1,23 +1,23 @@
 {
     "type": "Feature",
     "properties": {
-        "id": "Fairfax_VA_2025",
+        "id": "Fairfax_VA_Most_Recent",
         "attribution": {
             "url": "https://www.fairfaxcounty.gov/maps/aerial-photography",
             "text": "Government of Fairfax County, Virginia",
             "required": true
         },
-        "name": "Fairfax County Orthoimagery (2025)",
-        "url": "https://www.fairfaxcounty.gov/gisimagery/rest/services/AerialPhotography/2025AerialPhotographyCached/ImageServer/tile/{zoom}/{y}/{x}",
-        "min_zoom": 9,
-        "max_zoom": 23,
+        "name": "Fairfax County Orthoimagery (Current)",
+        "url": "https://www.fairfaxcounty.gov/gisimagery/rest/services/AerialPhotography/MostRecentAerialPhotographyCached/ImageServer/tile/{zoom}/{y}/{x}",
+        "min_zoom": 10,
+        "max_zoom": 20,
         "license_url": "https://www.fairfaxcounty.gov/maps/disclaimer",
         "country_code": "US",
         "type": "tms",
-        "start_date": "2025",
-        "end_date": "2025",
+        "start_date": "2026",
+        "end_date": "2026",
         "best": true,
-        "description": "The 2025 orthoimagery for Fairfax County of the Commonwealth of Virginia",
+        "description": "The most recent orthoimagery for Fairfax County of the Commonwealth of Virginia",
         "category": "photo",
         "privacy_policy_url": "https://www.fairfaxcounty.gov/topics/copyright-privacy"
     },

--- a/sources/north-america/us/va/Fairfax_VA_Most_Recent.geojson
+++ b/sources/north-america/us/va/Fairfax_VA_Most_Recent.geojson
@@ -7,7 +7,7 @@
             "text": "Government of Fairfax County, Virginia",
             "required": true
         },
-        "name": "Fairfax County Orthoimagery (Current)",
+        "name": "Fairfax County Orthoimagery (Latest)",
         "url": "https://www.fairfaxcounty.gov/gisimagery/rest/services/AerialPhotography/MostRecentAerialPhotographyCached/ImageServer/tile/{zoom}/{y}/{x}",
         "min_zoom": 10,
         "max_zoom": 20,


### PR DESCRIPTION
It looks like rather than providing the current year at a non-stable
URL, it is now provided at a stable URL; however, with only the current
year available. It also seems that only zoom levels 10 through 20 are
actually available (though, I am not sure whether I verified that
correctly).
